### PR TITLE
Reduce CI/deploy memory pressure with sequential image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+env:
+  NODE_OPTIONS: --max-old-space-size=4096
+
 jobs:
   frontend:
     runs-on: ubuntu-latest
@@ -39,6 +42,7 @@ jobs:
         run: npm run build
 
   backend:
+    needs: frontend
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -90,6 +94,7 @@ jobs:
         run: npm run build
 
   ai-service:
+    needs: backend
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,21 +20,13 @@ env:
   ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
 
 jobs:
-  # ── 1. Build & push all three images to ECR ───────────────────────────────
+  # ── 1. Build & push images to ECR (sequential to reduce peak memory) ─────
   build-and-push:
-    name: Build & push — ${{ matrix.service }}
+    name: Build & push images
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - service: backend
-            context: ./backend
-          - service: frontend
-            context: ./frontend
-          - service: ai-service
-            context: ./ai-service
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
 
     steps:
       - name: Checkout
@@ -62,21 +54,45 @@ jobs:
           WS_URL="${WS_URL/http:\/\//ws://}"
           echo "url=$WS_URL" >> "$GITHUB_OUTPUT"
 
-      # Build args only apply to the frontend image; ignored by backend/ai-service
-      - name: Build and push ${{ matrix.service }}
+      - name: Build and push backend
         uses: docker/build-push-action@v6
         with:
-          context: ${{ matrix.context }}
+          context: ./backend
           push: true
           tags: |
-            ${{ env.ECR_REGISTRY }}/oncosaas-${{ matrix.service }}:${{ github.sha }}
-            ${{ env.ECR_REGISTRY }}/oncosaas-${{ matrix.service }}:latest
+            ${{ env.ECR_REGISTRY }}/oncosaas-backend:${{ github.sha }}
+            ${{ env.ECR_REGISTRY }}/oncosaas-backend:latest
+          build-args: |
+            NODE_OPTIONS=${{ env.NODE_OPTIONS }}
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,mode=max,scope=backend
+
+      # Build args only apply to the frontend image
+      - name: Build and push frontend
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          push: true
+          tags: |
+            ${{ env.ECR_REGISTRY }}/oncosaas-frontend:${{ github.sha }}
+            ${{ env.ECR_REGISTRY }}/oncosaas-frontend:latest
           build-args: |
             NEXT_PUBLIC_API_URL=${{ secrets.APP_URL }}
             NEXT_PUBLIC_WS_URL=${{ steps.ws.outputs.url }}
-          # Layer cache scoped per service — dramatically speeds up subsequent builds
-          cache-from: type=gha,scope=${{ matrix.service }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.service }}
+            NODE_OPTIONS=${{ env.NODE_OPTIONS }}
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,mode=max,scope=frontend
+
+      - name: Build and push ai-service
+        uses: docker/build-push-action@v6
+        with:
+          context: ./ai-service
+          push: true
+          tags: |
+            ${{ env.ECR_REGISTRY }}/oncosaas-ai-service:${{ github.sha }}
+            ${{ env.ECR_REGISTRY }}/oncosaas-ai-service:latest
+          cache-from: type=gha,scope=ai-service
+          cache-to: type=gha,mode=max,scope=ai-service
 
   # ── 2. Deploy to EC2 ──────────────────────────────────────────────────────
   deploy:


### PR DESCRIPTION
### Motivation
- CI builds were exhausting runner memory when building multiple service images in parallel and running jobs concurrently. 
- Deploy step should not build on the EC2 host and must only `docker pull` + `docker compose up -d --no-build` to avoid extra memory/CPU pressure on the instance.

### Description
- Replace the parallel matrix in `.github/workflows/deploy.yml` with sequential build steps that build and push `backend`, then `frontend`, then `ai-service` in a single job to lower peak memory usage. 
- Add `env: NODE_OPTIONS: --max-old-space-size=4096` to both `.github/workflows/deploy.yml` and `.github/workflows/ci.yml` and forward `NODE_OPTIONS` as a build-arg for Node-based images to cap V8 heap. 
- Enable BuildKit layer caching per service using `cache-from` / `cache-to` scope entries in the deploy workflow so rebuilds reuse layers and do less work. 
- Change CI job ordering in `.github/workflows/ci.yml` to run `frontend` → `backend` → `ai-service` (using `needs`) to avoid running those heavy jobs in parallel, and keep the deploy job as SSH-only `docker pull` + `docker compose up -d --no-build` (no builds on EC2). 

### Testing
- Parsed both workflow files with Python using `yaml.safe_load` to validate YAML syntax, which succeeded. 
- Committed the changes (`git commit`) and inspected diffs with `git show` to verify the edits were applied, which succeeded. 
- Verified the updated workflows by printing the modified files (`sed`/`nl`) to confirm the expected sections and steps were present, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1fa549dac832bbcc7a9b43f73260d)