### PR TITLE
feat(navigation): RTU terapêutica, DnD entre fases, overlay e ajustes locais

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ docker compose -f compose.infra.yml up -d
 ```bash
 cd frontend && npm install
 cd ../backend && npm install
-cd ../ai-service && python3 -m pip install -r requirements.txt
+cd ../ai-service && python -m pip install -r requirements.txt
 cd ..
 ```
 
@@ -108,7 +108,7 @@ cd backend && npm run start:dev
 cd frontend && npm run dev
 
 # terminal 3
-cd ai-service && python3 -m uvicorn main:app --reload --host 0.0.0.0 --port 8001
+cd ai-service && python -m uvicorn main:app --reload --host 0.0.0.0 --port 8001
 ```
 
 ## Banco de dados (Prisma)
@@ -134,11 +134,11 @@ Após o seed inicial:
 
 ## URLs locais
 
-- Frontend: <http://localhost:3000>
-- Backend API: <http://localhost:3002/api/v1>
-- Backend health: <http://localhost:3002/api/v1/health>
-- AI service health: <http://localhost:8001/health>
-- RabbitMQ UI: <http://localhost:15672>
+- Frontend: [http://localhost:3000](http://localhost:3000)
+- Backend API: [http://localhost:3002/api/v1](http://localhost:3002/api/v1)
+- Backend health: [http://localhost:3002/api/v1/health](http://localhost:3002/api/v1/health)
+- AI service health: [http://localhost:8001/health](http://localhost:8001/health)
+- RabbitMQ UI: [http://localhost:15672](http://localhost:15672)
 
 ## HTTPS local (Embedded Signup / Meta)
 

--- a/ai-service/main.py
+++ b/ai-service/main.py
@@ -2,7 +2,7 @@ import json
 import logging
 from pathlib import Path
 from fastapi import FastAPI
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 from dotenv import load_dotenv
@@ -52,14 +52,21 @@ except Exception as e:
 
 
 class Settings(BaseSettings):
+    """Carrega `.env` local; campos espelham `ai-service/.env.example`."""
+
+    model_config = SettingsConfigDict(env_file=str(LOCAL_ENV_PATH), env_file_encoding="utf-8")
+
     openai_api_key: str = ""
     anthropic_api_key: str = ""
     google_cloud_project_id: str = ""
     backend_url: str = "http://localhost:3002"
+    backend_service_token: str = ""
     cors_origins: str = "http://localhost:3000,http://localhost:3002"
-
-    class Config:
-        env_file = str(LOCAL_ENV_PATH)
+    rag_embedding_model: str = (
+        "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+    )
+    rag_top_k: int = 4
+    rag_score_threshold: float = 0.30
 
 
 settings = Settings()

--- a/ai-service/requirements.txt
+++ b/ai-service/requirements.txt
@@ -4,7 +4,7 @@ pydantic==2.12.5
 pydantic-settings==2.9.1
 python-dotenv==1.0.0
 openai==1.66.3
-anthropic==0.75.0
+anthropic==0.93.0
 numpy==2.2.3
 pandas==2.2.3
 scikit-learn==1.8.0

--- a/backend/src/clinical-protocols/templates/bladder.protocol.ts
+++ b/backend/src/clinical-protocols/templates/bladder.protocol.ts
@@ -78,6 +78,12 @@ export const BLADDER_PROTOCOL = {
           name: 'Imunoterapia',
           conditional: 'if indicated (PD-L1+)',
         },
+        {
+          key: 'transurethral_resection_therapeutic',
+          name: 'RTU de Bexiga (terapêutica / re-ressecção)',
+          daysToComplete: 42,
+          conditional: 'NMIBC — recidiva/resgate (distinta da RTU diagnóstica)',
+        },
       ],
     },
     FOLLOW_UP: {

--- a/backend/src/oncology-navigation/dto/update-navigation-step.dto.ts
+++ b/backend/src/oncology-navigation/dto/update-navigation-step.dto.ts
@@ -7,7 +7,7 @@ import {
   IsObject,
   IsArray,
 } from 'class-validator';
-import { NavigationStepStatus } from '@generated/prisma/client';
+import { JourneyStage, NavigationStepStatus } from '@generated/prisma/client';
 
 export class UpdateNavigationStepDto {
   @IsEnum(NavigationStepStatus)
@@ -57,4 +57,9 @@ export class UpdateNavigationStepDto {
   @IsString()
   @IsOptional()
   notes?: string;
+
+  /** Alterar fase da jornada (ex.: arrastar etapa para outra coluna). Limpa dependências e prazos relativos. */
+  @IsEnum(JourneyStage)
+  @IsOptional()
+  journeyStage?: JourneyStage;
 }

--- a/backend/src/oncology-navigation/oncology-navigation.service.spec.ts
+++ b/backend/src/oncology-navigation/oncology-navigation.service.spec.ts
@@ -19,6 +19,8 @@ type MockPrisma = {
     findMany: jest.Mock;
     findFirst: jest.Mock;
     create: jest.Mock;
+    update: jest.Mock;
+    aggregate: jest.Mock;
   };
   alert: {
     findFirst: jest.Mock;
@@ -55,6 +57,8 @@ describe('OncologyNavigationService', () => {
         findMany: jest.fn(),
         findFirst: jest.fn(),
         create: jest.fn(),
+        update: jest.fn(),
+        aggregate: jest.fn(),
       },
       alert: {
         findFirst: jest.fn(),
@@ -428,13 +432,18 @@ describe('OncologyNavigationService', () => {
     it('should return { created: 0, skipped: N } when all steps already exist', async () => {
       mockPrisma.patient.findFirst.mockResolvedValue(basePatient);
 
-      // Bladder cancer TREATMENT has exactly 4 steps
-      mockPrisma.navigationStep.findMany.mockResolvedValue([
-        { stepKey: 'intravesical_bcg' },
-        { stepKey: 'radical_cystectomy' },
-        { stepKey: 'neobladder_or_urostomy' },
-        { stepKey: 'chemotherapy' },
-      ]);
+      const allTreatmentKeys = [
+        'intravesical_bcg',
+        'radical_cystectomy',
+        'neobladder_or_urostomy',
+        'chemotherapy',
+        'transurethral_resection_therapeutic',
+        'specialist_consultation',
+        'navigation_consultation',
+      ];
+      mockPrisma.navigationStep.findMany.mockResolvedValue(
+        allTreatmentKeys.map((stepKey) => ({ stepKey }))
+      );
 
       const result = await service.createMissingStepsForStage(
         PATIENT_ID,
@@ -443,7 +452,7 @@ describe('OncologyNavigationService', () => {
       );
 
       expect(result.created).toBe(0);
-      expect(result.skipped).toBe(4);
+      expect(result.skipped).toBe(allTreatmentKeys.length);
       expect(mockPrisma.navigationStep.create).not.toHaveBeenCalled();
     });
 
@@ -780,6 +789,67 @@ describe('OncologyNavigationService', () => {
         'breast',
         JourneyStage.SCREENING
       );
+    });
+  });
+
+  describe('updateStep — journeyStage (mover etapa)', () => {
+    it('should update stage, clear dependencies and assign next stepOrder', async () => {
+      const existing = {
+        id: 'step-move-1',
+        tenantId: TENANT,
+        patientId: PATIENT_ID,
+        journeyStage: JourneyStage.DIAGNOSIS,
+        isCompleted: false,
+        dependsOnStepKey: 'cystoscopy',
+        relativeDaysMin: 1,
+        relativeDaysMax: 7,
+        expectedDate: null,
+        dueDate: null,
+        status: NavigationStepStatus.PENDING,
+        actualDate: null,
+        completedAt: null,
+      };
+      mockPrisma.navigationStep.findFirst.mockResolvedValue(existing);
+      mockPrisma.navigationStep.aggregate.mockResolvedValue({
+        _max: { stepOrder: 5 },
+      });
+      mockPrisma.navigationStep.update.mockResolvedValue({
+        ...existing,
+        journeyStage: JourneyStage.TREATMENT,
+        stepOrder: 6,
+        dependsOnStepKey: null,
+        relativeDaysMin: null,
+        relativeDaysMax: null,
+        expectedDate: null,
+        dueDate: null,
+      });
+
+      await service.updateStep(
+        'step-move-1',
+        { journeyStage: JourneyStage.TREATMENT },
+        TENANT
+      );
+
+      expect(mockPrisma.navigationStep.aggregate).toHaveBeenCalledWith({
+        where: {
+          patientId: PATIENT_ID,
+          tenantId: TENANT,
+          journeyStage: JourneyStage.TREATMENT,
+        },
+        _max: { stepOrder: true },
+      });
+      expect(mockPrisma.navigationStep.update).toHaveBeenCalledWith({
+        where: { id: 'step-move-1', tenantId: TENANT },
+        data: expect.objectContaining({
+          journeyStage: JourneyStage.TREATMENT,
+          stepOrder: 6,
+          dependsOnStepKey: null,
+          relativeDaysMin: null,
+          relativeDaysMax: null,
+          expectedDate: null,
+          dueDate: null,
+        }),
+      });
     });
   });
 });

--- a/backend/src/oncology-navigation/oncology-navigation.service.ts
+++ b/backend/src/oncology-navigation/oncology-navigation.service.ts
@@ -242,6 +242,25 @@ export class OncologyNavigationService {
       updateData.status = NavigationStepStatus.OVERDUE;
     }
 
+    if (updateDto.journeyStage !== undefined) {
+      if (updateDto.journeyStage === existingStep.journeyStage) {
+        delete (updateData as { journeyStage?: JourneyStage }).journeyStage;
+      } else {
+        const nextOrder = await this.getNextStepOrderForStage(
+          existingStep.patientId,
+          tenantId,
+          updateDto.journeyStage
+        );
+        updateData.journeyStage = updateDto.journeyStage;
+        updateData.stepOrder = nextOrder;
+        updateData.dependsOnStepKey = null;
+        updateData.relativeDaysMin = null;
+        updateData.relativeDaysMax = null;
+        updateData.expectedDate = null;
+        updateData.dueDate = null;
+      }
+    }
+
     const updatedStep = await this.prisma.navigationStep.update({
       where: { id: stepId, tenantId },
       data: updateData,
@@ -1121,6 +1140,73 @@ export class OncologyNavigationService {
   }
 
   /**
+   * Etapas transversais a todas as fases da jornada (consultas de coordenação / especialista).
+   * Injetadas após os protocolos por tipo de câncer.
+   */
+  private mergeUniversalStepConfigs(configs: StepConfig[]): StepConfig[] {
+    const present = new Set(configs.map((c) => `${c.journeyStage}:${c.stepKey}`));
+    const stagesInConfigs = [...new Set(configs.map((c) => c.journeyStage))];
+    const universalDefs: Omit<StepConfig, 'journeyStage' | 'stepOrder'>[] = [
+      {
+        stepKey: 'specialist_consultation',
+        stepName: 'Consulta especializada',
+        stepDescription:
+          'Consulta com especialista da linha de cuidado (não substitui a navegação oncológica).',
+        isRequired: false,
+        dependsOnStepKey: null,
+        relativeDaysMin: null,
+        relativeDaysMax: null,
+      },
+      {
+        stepKey: 'navigation_consultation',
+        stepName: 'Consulta de navegação oncológica',
+        stepDescription:
+          'Atendimento com o navegador oncológico para coordenação de acesso, barreiras e continuidade do cuidado.',
+        isRequired: false,
+        dependsOnStepKey: null,
+        relativeDaysMin: null,
+        relativeDaysMax: null,
+      },
+    ];
+
+    const merged = [...configs];
+    for (const stage of stagesInConfigs) {
+      const maxOrder = Math.max(
+        0,
+        ...configs
+          .filter((c) => c.journeyStage === stage)
+          .map((c) => c.stepOrder)
+      );
+      let nextOrder = maxOrder + 1;
+      for (const def of universalDefs) {
+        const key = `${stage}:${def.stepKey}`;
+        if (!present.has(key)) {
+          merged.push({
+            ...def,
+            journeyStage: stage,
+            stepOrder: nextOrder++,
+          });
+          present.add(key);
+        }
+      }
+    }
+    return merged;
+  }
+
+  /** Próximo stepOrder ao mover etapa para uma fase (append ao fim da coluna). */
+  private async getNextStepOrderForStage(
+    patientId: string,
+    tenantId: string,
+    journeyStage: JourneyStage
+  ): Promise<number> {
+    const agg = await this.prisma.navigationStep.aggregate({
+      where: { patientId, tenantId, journeyStage },
+      _max: { stepOrder: true },
+    });
+    return (agg._max.stepOrder ?? 0) + 1;
+  }
+
+  /**
    * Retorna as configurações de etapas para um tipo de câncer.
    * Cada etapa define dependência relativa (stepKey da predecessora + dias).
    * Datas são calculadas em runtime quando a dependência é concluída.
@@ -1130,33 +1216,42 @@ export class OncologyNavigationService {
     patientStatus?: PatientStatus,
     currentStage?: JourneyStage,
   ): StepConfig[] {
+    let base: StepConfig[];
     // New JourneyStage PALLIATIVE must provision palliative templates
     // even when patient.status is not yet synchronized to PALLIATIVE_CARE.
     if (
       currentStage === JourneyStage.PALLIATIVE ||
       patientStatus === PatientStatus.PALLIATIVE_CARE
     ) {
-      return this.getPalliativeStepConfigs();
+      base = this.getPalliativeStepConfigs();
+    } else {
+      switch (cancerType.toLowerCase()) {
+        case 'colorectal':
+          base = this.getColorectalStepConfigs();
+          break;
+        case 'breast':
+          base = this.getBreastStepConfigs();
+          break;
+        case 'lung':
+          base = this.getLungStepConfigs();
+          break;
+        case 'prostate':
+          base = this.getProstateStepConfigs();
+          break;
+        case 'kidney':
+          base = this.getKidneyStepConfigs();
+          break;
+        case 'bladder':
+          base = this.getBladderStepConfigs();
+          break;
+        case 'testicular':
+          base = this.getTesticularStepConfigs();
+          break;
+        default:
+          base = this.getGenericStepConfigs();
+      }
     }
-
-    switch (cancerType.toLowerCase()) {
-      case 'colorectal':
-        return this.getColorectalStepConfigs();
-      case 'breast':
-        return this.getBreastStepConfigs();
-      case 'lung':
-        return this.getLungStepConfigs();
-      case 'prostate':
-        return this.getProstateStepConfigs();
-      case 'kidney':
-        return this.getKidneyStepConfigs();
-      case 'bladder':
-        return this.getBladderStepConfigs();
-      case 'testicular':
-        return this.getTesticularStepConfigs();
-      default:
-        return this.getGenericStepConfigs();
-    }
+    return this.mergeUniversalStepConfigs(base);
   }
 
 
@@ -1523,6 +1618,18 @@ export class OncologyNavigationService {
         stepOrder: 11,
       },
       {
+        journeyStage: JourneyStage.TREATMENT,
+        stepKey: 'transurethral_resection_therapeutic',
+        stepName: 'RTU de Bexiga (terapêutica / re-ressecção)',
+        stepDescription:
+          'Ressecção transuretral com finalidade terapêutica (ex.: doença residual, recidiva intravesical, resgate após BCG). Distinta da RTU diagnóstica inicial.',
+        isRequired: false,
+        dependsOnStepKey: 'pathology_report',
+        relativeDaysMin: 14,
+        relativeDaysMax: 42,
+        stepOrder: 12,
+      },
+      {
         journeyStage: JourneyStage.FOLLOW_UP,
         stepKey: 'cystoscopy_3months',
         stepName: 'Cistoscopia 3 Meses',
@@ -1531,7 +1638,7 @@ export class OncologyNavigationService {
         dependsOnStepKey: 'intravesical_bcg',
         relativeDaysMin: 90,
         relativeDaysMax: 90,
-        stepOrder: 12,
+        stepOrder: 13,
       },
       {
         journeyStage: JourneyStage.FOLLOW_UP,
@@ -1542,7 +1649,7 @@ export class OncologyNavigationService {
         dependsOnStepKey: 'intravesical_bcg',
         relativeDaysMin: 180,
         relativeDaysMax: 180,
-        stepOrder: 13,
+        stepOrder: 14,
       },
       {
         journeyStage: JourneyStage.FOLLOW_UP,
@@ -1553,7 +1660,7 @@ export class OncologyNavigationService {
         dependsOnStepKey: 'intravesical_bcg',
         relativeDaysMin: 365,
         relativeDaysMax: 365,
-        stepOrder: 14,
+        stepOrder: 15,
       },
     ];
   }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "oncosaas-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^3.3.4",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -609,6 +611,45 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
       "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.0",
@@ -8459,7 +8500,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,8 @@
     "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^3.3.4",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/frontend/src/app/oncology-navigation/page.tsx
+++ b/frontend/src/app/oncology-navigation/page.tsx
@@ -892,6 +892,7 @@ function StepCard({ step, apiUrl }: StepCardProps) {
           <div className="flex items-center gap-1">
             {/* Botão de atalho para marcar como concluída */}
             <button
+              type="button"
               onClick={handleQuickComplete}
               disabled={updateStep.isPending}
               className={`p-1.5 rounded transition-colors ${
@@ -911,6 +912,36 @@ function StepCard({ step, apiUrl }: StepCardProps) {
                 }`}
               />
             </button>
+            <label htmlFor={`onc-nav-move-${step.id}`} className="sr-only">
+              Mover etapa para outra fase
+            </label>
+            <select
+              id={`onc-nav-move-${step.id}`}
+              className="h-8 max-w-[10rem] rounded border border-input bg-background px-1.5 text-xs"
+              defaultValue=""
+              onChange={async (e) => {
+                const v = e.currentTarget.value as JourneyStage;
+                e.currentTarget.value = '';
+                if (!v || v === step.journeyStage) return;
+                try {
+                  await updateStep.mutateAsync({
+                    stepId: step.id,
+                    data: { journeyStage: v },
+                  });
+                  toast.success('Etapa movida para outra fase');
+                } catch {
+                  /* toast no hook */
+                }
+              }}
+              disabled={updateStep.isPending}
+            >
+              <option value="">Mover para fase…</option>
+              {JOURNEY_STAGES.filter((s) => s !== step.journeyStage).map((s) => (
+                <option key={s} value={s}>
+                  {JOURNEY_STAGE_LABELS[s]}
+                </option>
+              ))}
+            </select>
             {/* Botão de editar */}
             <button
               onClick={() => setIsEditing(!isEditing)}

--- a/frontend/src/app/oncology-navigation/page.tsx
+++ b/frontend/src/app/oncology-navigation/page.tsx
@@ -49,6 +49,22 @@ import {
   JOURNEY_STAGES,
   type JourneyStage,
 } from '@/lib/utils/journey-stage';
+import {
+  DndContext,
+  DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  buildNavDropId,
+  DraggableNavigationStep,
+  NavigationStepDragPreview,
+  parseNavDropId,
+  StageDroppableColumn,
+} from '@/components/patients/navigation-step-dnd';
 
 interface FileMetadata {
   filename: string;
@@ -404,6 +420,7 @@ function PatientNavigationCard({
   >([]);
   const [loadingTemplates, setLoadingTemplates] = useState(false);
   const [createStage, setCreateStage] = useState<string | null>(null);
+  const [activeDragStepId, setActiveDragStepId] = useState<string | null>(null);
 
   const createFromTemplateMutation = useMutation({
     mutationFn: ({ journeyStage, stepKey }: { journeyStage: string; stepKey: string }) =>
@@ -432,6 +449,51 @@ function PatientNavigationCard({
       toast.error(`Erro ao criar etapas: ${error.message}`);
     },
   });
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
+  );
+
+  const moveStepMutation = useMutation({
+    mutationFn: ({
+      stepId,
+      journeyStage,
+    }: {
+      stepId: string;
+      journeyStage: JourneyStage;
+    }) => navigationApi.updateStep(stepId, { journeyStage }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['navigation-steps', patient.id] });
+      queryClient.invalidateQueries({ queryKey: ['patients'] });
+      toast.success('Etapa movida para outra fase');
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Erro ao mover etapa');
+    },
+  });
+
+  const handlePatientNavDragStart = (event: DragStartEvent): void => {
+    setActiveDragStepId(String(event.active.id));
+  };
+
+  const handlePatientNavDragEnd = (event: DragEndEvent): void => {
+    setActiveDragStepId(null);
+    const { active, over } = event;
+    if (!over) return;
+    const parsed = parseNavDropId(String(over.id));
+    if (!parsed) return;
+    const stepId = String(active.id);
+    const step = navigationSteps?.find((s) => s.id === stepId);
+    if (!step) return;
+    if (step.cancerType.toLowerCase() !== cancerType.toLowerCase()) return;
+    if (parsed.typeKey.toLowerCase() !== cancerType.toLowerCase()) return;
+    if (step.journeyStage === parsed.stage) return;
+    moveStepMutation.mutate({ stepId, journeyStage: parsed.stage });
+  };
+
+  const handlePatientNavDragCancel = (): void => {
+    setActiveDragStepId(null);
+  };
 
   const handleSelectPhase = async (stage: JourneyStage): Promise<void> => {
     setWizardPhase(stage);
@@ -507,6 +569,11 @@ function PatientNavigationCard({
 
   const currentStage = patient.currentStage || 'SCREENING';
   const isPalliativeCare = patient.status === 'PALLIATIVE_CARE';
+
+  const activeDragStep = useMemo(() => {
+    if (!activeDragStepId || !navigationSteps) return undefined;
+    return navigationSteps.find((s) => s.id === activeDragStepId);
+  }, [activeDragStepId, navigationSteps]);
 
   return (
     <div
@@ -679,52 +746,93 @@ function PatientNavigationCard({
               Nenhuma etapa de navegação definida para este paciente.
             </div>
           ) : (
-            Object.entries(stepsByStage).map(([stage, steps]) => {
-              if (steps.length === 0) return null;
+            <DndContext
+              sensors={sensors}
+              onDragStart={handlePatientNavDragStart}
+              onDragEnd={handlePatientNavDragEnd}
+              onDragCancel={handlePatientNavDragCancel}
+            >
+              <div className="space-y-4">
+                {JOURNEY_STAGES.map((stage) => {
+                  const steps = stepsByStage[stage] ?? [];
+                  const stageCompleted = steps.filter(
+                    (s) => s.status === 'COMPLETED'
+                  ).length;
+                  const stageOverdue = steps.filter(
+                    (s) => s.status === 'OVERDUE'
+                  ).length;
+                  const isCurrentStage = stage === currentStage;
+                  const stageLabel = JOURNEY_STAGE_LABELS[stage] || stage;
 
-              const stageCompleted = steps.filter(
-                (s) => s.status === 'COMPLETED'
-              ).length;
-              const stageOverdue = steps.filter(
-                (s) => s.status === 'OVERDUE'
-              ).length;
-              const isCurrentStage = stage === currentStage;
-
-              return (
-                <div
-                  key={stage}
-                  className={`border rounded-lg overflow-hidden ${
-                    isCurrentStage ? 'ring-2 ring-blue-500' : ''
-                  }`}
-                >
-                  <div className="bg-gray-50 px-4 py-2 border-b">
-                    <div className="flex items-center justify-between">
-                      <span className="font-semibold">
-                        {JOURNEY_STAGE_LABELS[stage as JourneyStage] || stage}
-                      </span>
-                      <span className="text-sm text-gray-600">
-                        {stageCompleted}/{steps.length} concluídas
-                        {stageOverdue > 0 && (
-                          <span className="text-red-600 ml-2">
-                            • {stageOverdue} atrasada
-                            {stageOverdue > 1 ? 's' : ''}
+                  return (
+                    <StageDroppableColumn
+                      key={stage}
+                      id={buildNavDropId(cancerType, stage)}
+                      className={
+                        steps.length === 0
+                          ? `rounded-lg border ${
+                              isCurrentStage ? 'ring-2 ring-blue-500' : ''
+                            }`
+                          : `overflow-hidden rounded-lg border ${
+                              isCurrentStage ? 'ring-2 ring-blue-500' : ''
+                            }`
+                      }
+                    >
+                      {steps.length === 0 ? (
+                        <div className="flex items-center justify-between gap-2 bg-gray-50 px-3 py-2">
+                          <span className="text-sm font-semibold">{stageLabel}</span>
+                          <span className="text-xs text-muted-foreground">
+                            Fase vazia — solte uma etapa aqui
                           </span>
-                        )}
-                      </span>
-                    </div>
-                  </div>
-                  <div className="p-4 space-y-2">
-                    {steps.map((step) => (
-                      <StepCard
-                        key={`${step.id}-${step.updatedAt}`}
-                        step={step}
-                        apiUrl={apiUrl}
-                      />
-                    ))}
-                  </div>
-                </div>
-              );
-            })
+                        </div>
+                      ) : (
+                        <>
+                          <div className="border-b bg-gray-50 px-4 py-2">
+                            <div className="flex items-center justify-between">
+                              <span className="font-semibold">{stageLabel}</span>
+                              <span className="text-sm text-gray-600">
+                                {`${stageCompleted}/${steps.length} concluídas`}
+                                {stageOverdue > 0 && (
+                                  <span className="ml-2 text-red-600">
+                                    • {stageOverdue} atrasada
+                                    {stageOverdue > 1 ? 's' : ''}
+                                  </span>
+                                )}
+                              </span>
+                            </div>
+                          </div>
+                          <div className="space-y-2 p-4">
+                            {steps.map((step) => (
+                              <DraggableNavigationStep
+                                key={step.id}
+                                stepId={step.id}
+                                useDragOverlay
+                              >
+                                {(dragHandle) => (
+                                  <StepCard
+                                    step={step}
+                                    apiUrl={apiUrl}
+                                    dragHandle={dragHandle}
+                                  />
+                                )}
+                              </DraggableNavigationStep>
+                            ))}
+                          </div>
+                        </>
+                      )}
+                    </StageDroppableColumn>
+                  );
+                })}
+              </div>
+              <DragOverlay dropAnimation={{ duration: 180, easing: 'ease-out' }} className="z-[1000]">
+                {activeDragStep ? (
+                  <NavigationStepDragPreview
+                    stepName={activeDragStep.stepName}
+                    stepDescription={activeDragStep.stepDescription}
+                  />
+                ) : null}
+              </DragOverlay>
+            </DndContext>
           )}
           <CreateNavigationStepDialog
             open={createStage !== null}
@@ -749,9 +857,10 @@ function PatientNavigationCard({
 interface StepCardProps {
   step: NavigationStep;
   apiUrl: string;
+  dragHandle?: React.ReactNode;
 }
 
-function StepCard({ step, apiUrl }: StepCardProps) {
+function StepCard({ step, apiUrl, dragHandle }: StepCardProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [notes, setNotes] = useState(step.notes || '');
   const [isCompleted, setIsCompleted] = useState(step.isCompleted);
@@ -871,6 +980,9 @@ function StepCard({ step, apiUrl }: StepCardProps) {
         STATUS_COLORS[step.status] || STATUS_COLORS.PENDING
       }`}
     >
+      {dragHandle && (
+        <div className="flex-shrink-0 mt-0.5">{dragHandle}</div>
+      )}
       <div className="flex-shrink-0 mt-0.5">
         {STATUS_ICONS[step.status] || STATUS_ICONS.PENDING}
       </div>
@@ -912,36 +1024,6 @@ function StepCard({ step, apiUrl }: StepCardProps) {
                 }`}
               />
             </button>
-            <label htmlFor={`onc-nav-move-${step.id}`} className="sr-only">
-              Mover etapa para outra fase
-            </label>
-            <select
-              id={`onc-nav-move-${step.id}`}
-              className="h-8 max-w-[10rem] rounded border border-input bg-background px-1.5 text-xs"
-              defaultValue=""
-              onChange={async (e) => {
-                const v = e.currentTarget.value as JourneyStage;
-                e.currentTarget.value = '';
-                if (!v || v === step.journeyStage) return;
-                try {
-                  await updateStep.mutateAsync({
-                    stepId: step.id,
-                    data: { journeyStage: v },
-                  });
-                  toast.success('Etapa movida para outra fase');
-                } catch {
-                  /* toast no hook */
-                }
-              }}
-              disabled={updateStep.isPending}
-            >
-              <option value="">Mover para fase…</option>
-              {JOURNEY_STAGES.filter((s) => s !== step.journeyStage).map((s) => (
-                <option key={s} value={s}>
-                  {JOURNEY_STAGE_LABELS[s]}
-                </option>
-              ))}
-            </select>
             {/* Botão de editar */}
             <button
               onClick={() => setIsEditing(!isEditing)}

--- a/frontend/src/components/patients/navigation-step-dnd.tsx
+++ b/frontend/src/components/patients/navigation-step-dnd.tsx
@@ -38,19 +38,44 @@ export function StageDroppableColumn({
   );
 }
 
+/** Preview leve para DragOverlay (fica acima de cards e modais durante o arraste). */
+export function NavigationStepDragPreview({
+  stepName,
+  stepDescription,
+}: {
+  stepName: string;
+  stepDescription?: string | null;
+}): React.ReactElement {
+  return (
+    <div className="flex max-w-md gap-2 rounded-lg border bg-background p-3 shadow-xl ring-2 ring-primary/25">
+      <GripVertical className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+      <div className="min-w-0 flex-1">
+        <div className="truncate font-semibold">{stepName}</div>
+        {stepDescription ? (
+          <p className="mt-0.5 line-clamp-2 text-sm text-muted-foreground">{stepDescription}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
 export function DraggableNavigationStep({
   stepId,
   children,
+  useDragOverlay = false,
 }: {
   stepId: string;
   children: (dragHandle: React.ReactNode) => React.ReactNode;
+  /** Com true, o movimento visual fica no DragOverlay; a origem some durante o arraste. */
+  useDragOverlay?: boolean;
 }): React.ReactElement {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: stepId,
   });
-  const style = transform
-    ? { transform: `translate3d(${transform.x}px,${transform.y}px,0)` }
-    : undefined;
+  const style =
+    !useDragOverlay && transform
+      ? { transform: `translate3d(${transform.x}px,${transform.y}px,0)` }
+      : undefined;
 
   const handle = (
     <button
@@ -71,7 +96,11 @@ export function DraggableNavigationStep({
     <div
       ref={setNodeRef}
       style={style}
-      className={cn('flex gap-2', isDragging && 'opacity-60')}
+      className={cn(
+        'flex min-w-0 w-full gap-2',
+        isDragging && useDragOverlay && 'pointer-events-none opacity-0',
+        isDragging && !useDragOverlay && 'opacity-60'
+      )}
     >
       {children(handle)}
     </div>

--- a/frontend/src/components/patients/navigation-step-dnd.tsx
+++ b/frontend/src/components/patients/navigation-step-dnd.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import React from 'react';
+import { useDraggable, useDroppable } from '@dnd-kit/core';
+import { cn } from '@/lib/utils';
+import { GripVertical } from 'lucide-react';
+import type { JourneyStage } from '@/lib/utils/journey-stage';
+
+export function buildNavDropId(typeKey: string, stage: JourneyStage): string {
+  return `nav-drop::${typeKey}::${stage}`;
+}
+
+export function parseNavDropId(
+  id: string
+): { typeKey: string; stage: JourneyStage } | null {
+  const parts = id.split('::');
+  if (parts.length !== 3 || parts[0] !== 'nav-drop') return null;
+  return { typeKey: parts[1], stage: parts[2] as JourneyStage };
+}
+
+export function StageDroppableColumn({
+  id,
+  className,
+  children,
+}: {
+  id: string;
+  className?: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  const { setNodeRef, isOver } = useDroppable({ id });
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(className, isOver && 'rounded-lg ring-2 ring-primary/40 ring-offset-2')}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function DraggableNavigationStep({
+  stepId,
+  children,
+}: {
+  stepId: string;
+  children: (dragHandle: React.ReactNode) => React.ReactNode;
+}): React.ReactElement {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: stepId,
+  });
+  const style = transform
+    ? { transform: `translate3d(${transform.x}px,${transform.y}px,0)` }
+    : undefined;
+
+  const handle = (
+    <button
+      type="button"
+      className={cn(
+        'touch-none rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+      )}
+      aria-label="Arrastar etapa para outra fase"
+      {...listeners}
+      {...attributes}
+    >
+      <GripVertical className="h-4 w-4 shrink-0" aria-hidden />
+    </button>
+  );
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn('flex gap-2', isDragging && 'opacity-60')}
+    >
+      {children(handle)}
+    </div>
+  );
+}

--- a/frontend/src/components/patients/patient-navigation-tab.tsx
+++ b/frontend/src/components/patients/patient-navigation-tab.tsx
@@ -8,6 +8,13 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
+import {
+  DndContext,
+  DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
 import { CheckCircle2, Clock, AlertCircle, Edit, Plus, Trash2, ChevronRight, Check } from 'lucide-react';
 import {
   Accordion,
@@ -36,6 +43,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import {
+  buildNavDropId,
+  DraggableNavigationStep,
+  parseNavDropId,
+  StageDroppableColumn,
+} from '@/components/patients/navigation-step-dnd';
 import { NavigationStep, navigationApi } from '@/lib/api/navigation';
 import { NavigationStepDialog } from './navigation-step-dialog';
 import { CreateNavigationStepDialog } from './create-navigation-step-dialog';
@@ -215,6 +228,10 @@ export function PatientNavigationTab({
   >([]);
   const [stepPickerLoading, setStepPickerLoading] = useState(false);
 
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
+  );
+
   const toggleCompleteMutation = useMutation({
     mutationFn: ({ stepId, isCompleted }: { stepId: string; isCompleted: boolean }) =>
       navigationApi.updateStep(stepId, {
@@ -229,6 +246,47 @@ export function PatientNavigationTab({
       toast.error(`Erro ao atualizar etapa: ${error.message}`);
     },
   });
+
+  const moveStepMutation = useMutation({
+    mutationFn: ({
+      stepId,
+      journeyStage,
+    }: {
+      stepId: string;
+      journeyStage: JourneyStage;
+    }) => navigationApi.updateStep(stepId, { journeyStage }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['patient', patient.id] });
+      queryClient.invalidateQueries({ queryKey: ['navigation-steps', patient.id] });
+      toast.success('Etapa movida para outra fase');
+    },
+    onError: (error: Error) => {
+      toast.error(`Erro ao mover etapa: ${error.message}`);
+    },
+  });
+
+  const handleDragEnd = (event: DragEndEvent): void => {
+    const { active, over } = event;
+    if (!over) return;
+    const parsed = parseNavDropId(String(over.id));
+    if (!parsed) return;
+    const stepId = String(active.id);
+    const step = patient.navigationSteps?.find((s) => s.id === stepId);
+    if (!step) return;
+    if ((step.cancerType || 'other').toLowerCase() !== parsed.typeKey) {
+      toast.error('Mova a etapa apenas dentro do mesmo tipo de câncer.');
+      return;
+    }
+    const current = (step.journeyStage || 'SCREENING').toUpperCase() as JourneyStage;
+    if (current === parsed.stage) return;
+    moveStepMutation.mutate({ stepId, journeyStage: parsed.stage });
+  };
+
+  const handleMoveStepToStage = (step: NavigationStep, journeyStage: JourneyStage): void => {
+    const current = (step.journeyStage || 'SCREENING').toUpperCase() as JourneyStage;
+    if (current === journeyStage) return;
+    moveStepMutation.mutate({ stepId: step.id, journeyStage });
+  };
 
   const createFromTemplateMutation = useMutation({
     mutationFn: ({ journeyStage, stepKey }: { journeyStage: string; stepKey: string }) =>
@@ -515,6 +573,7 @@ export function PatientNavigationTab({
           </div>
         </CardHeader>
         <CardContent>
+          <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
           <Accordion type="multiple" className="w-full">
             {cancerTypes.map((typeKey) => {
               const stageMap = stepsByCancerTypeAndStage.get(typeKey);
@@ -540,7 +599,11 @@ export function PatientNavigationTab({
                         const stageLabel = JOURNEY_STAGE_LABELS[stage] || stage;
 
                         return (
-                          <div key={stage}>
+                          <StageDroppableColumn
+                            key={stage}
+                            id={buildNavDropId(typeKey, stage)}
+                            className="space-y-2"
+                          >
                             <h4 className="text-sm font-medium text-muted-foreground mb-2">
                               {stageLabel}
                               <span className="ml-2 font-normal">
@@ -565,22 +628,22 @@ export function PatientNavigationTab({
                               ) : (
                                 <>
                                   {steps.map((step) => (
-                            <div
-                              key={step.id}
-                              className="border rounded-lg p-4 space-y-2"
-                            >
-                              <div className="flex items-center justify-between">
-                                <div className="flex items-center gap-2">
-                                  <div className="font-semibold">
+                            <DraggableNavigationStep key={step.id} stepId={step.id}>
+                            {(dragHandle) => (
+                            <div className="border rounded-lg p-4 space-y-2 flex-1 min-w-0 w-full">
+                              <div className="flex items-center justify-between gap-2 flex-wrap">
+                                <div className="flex items-center gap-2 min-w-0">
+                                  {dragHandle}
+                                  <div className="font-semibold truncate">
                                     {step.stepName}
                                   </div>
                                   {step.isRequired && (
-                                    <Badge variant="outline" className="text-xs">
+                                    <Badge variant="outline" className="text-xs shrink-0">
                                       Obrigatória
                                     </Badge>
                                   )}
                                 </div>
-                                <div className="flex items-center gap-2">
+                                <div className="flex items-center gap-2 flex-wrap justify-end">
                                   <Badge
                                     variant="outline"
                                     className={
@@ -596,6 +659,7 @@ export function PatientNavigationTab({
                                     </span>
                                   </Badge>
                                   <button
+                                    type="button"
                                     onClick={() =>
                                       toggleCompleteMutation.mutate({
                                         stepId: step.id,
@@ -612,6 +676,33 @@ export function PatientNavigationTab({
                                   >
                                     <Check className="h-4 w-4" />
                                   </button>
+                                  <div className="flex items-center gap-1">
+                                    <label htmlFor={`nav-move-${step.id}`} className="sr-only">
+                                      Mover etapa para outra fase
+                                    </label>
+                                    <select
+                                      id={`nav-move-${step.id}`}
+                                      className="h-8 max-w-[11rem] rounded-md border border-input bg-background px-2 text-xs md:text-sm"
+                                      defaultValue=""
+                                      onChange={(e) => {
+                                        const v = e.currentTarget.value as JourneyStage;
+                                        e.currentTarget.value = '';
+                                        if (v) handleMoveStepToStage(step, v);
+                                      }}
+                                      disabled={moveStepMutation.isPending}
+                                    >
+                                      <option value="">Mover para fase…</option>
+                                      {JOURNEY_STAGES.filter(
+                                        (s) =>
+                                          s !==
+                                          ((step.journeyStage || 'SCREENING').toUpperCase() as JourneyStage)
+                                      ).map((s) => (
+                                        <option key={s} value={s}>
+                                          {JOURNEY_STAGE_LABELS[s]}
+                                        </option>
+                                      ))}
+                                    </select>
+                                  </div>
                                   <Button
                                     size="sm"
                                     variant="outline"
@@ -731,6 +822,8 @@ export function PatientNavigationTab({
                               </div>
                             )}
                             </div>
+                            )}
+                            </DraggableNavigationStep>
                           ))}
                                   <Button
                                     size="sm"
@@ -743,7 +836,7 @@ export function PatientNavigationTab({
                                 </>
                               )}
                             </div>
-                          </div>
+                          </StageDroppableColumn>
                         );
                       })}
                     </div>
@@ -752,6 +845,7 @@ export function PatientNavigationTab({
               );
             })}
           </Accordion>
+          </DndContext>
         </CardContent>
       </Card>
 

--- a/frontend/src/components/patients/patient-navigation-tab.tsx
+++ b/frontend/src/components/patients/patient-navigation-tab.tsx
@@ -11,6 +11,8 @@ import { ptBR } from 'date-fns/locale';
 import {
   DndContext,
   DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
   PointerSensor,
   useSensor,
   useSensors,
@@ -46,6 +48,7 @@ import {
 import {
   buildNavDropId,
   DraggableNavigationStep,
+  NavigationStepDragPreview,
   parseNavDropId,
   StageDroppableColumn,
 } from '@/components/patients/navigation-step-dnd';
@@ -227,6 +230,7 @@ export function PatientNavigationTab({
     { stepKey: string; stepName: string; stepDescription?: string | null; isRequired: boolean; existingCount: number }[]
   >([]);
   const [stepPickerLoading, setStepPickerLoading] = useState(false);
+  const [activeDragStepId, setActiveDragStepId] = useState<string | null>(null);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
@@ -265,7 +269,12 @@ export function PatientNavigationTab({
     },
   });
 
+  const handleDragStart = (event: DragStartEvent): void => {
+    setActiveDragStepId(String(event.active.id));
+  };
+
   const handleDragEnd = (event: DragEndEvent): void => {
+    setActiveDragStepId(null);
     const { active, over } = event;
     if (!over) return;
     const parsed = parseNavDropId(String(over.id));
@@ -282,10 +291,8 @@ export function PatientNavigationTab({
     moveStepMutation.mutate({ stepId, journeyStage: parsed.stage });
   };
 
-  const handleMoveStepToStage = (step: NavigationStep, journeyStage: JourneyStage): void => {
-    const current = (step.journeyStage || 'SCREENING').toUpperCase() as JourneyStage;
-    if (current === journeyStage) return;
-    moveStepMutation.mutate({ stepId: step.id, journeyStage });
+  const handleDragCancel = (): void => {
+    setActiveDragStepId(null);
   };
 
   const createFromTemplateMutation = useMutation({
@@ -496,6 +503,11 @@ export function PatientNavigationTab({
     (patient.navigationSteps?.length ?? 0) > 0 ||
     (patient.cancerDiagnoses?.length ?? 0) > 0;
 
+  const activeDragStep = useMemo(() => {
+    if (!activeDragStepId || !patient.navigationSteps) return undefined;
+    return patient.navigationSteps.find((s) => s.id === activeDragStepId);
+  }, [activeDragStepId, patient.navigationSteps]);
+
   if (!hasStepsOrDiagnosis) {
     return (
       <Card>
@@ -573,7 +585,12 @@ export function PatientNavigationTab({
           </div>
         </CardHeader>
         <CardContent>
-          <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+          <DndContext
+            sensors={sensors}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+            onDragCancel={handleDragCancel}
+          >
           <Accordion type="multiple" className="w-full">
             {cancerTypes.map((typeKey) => {
               const stageMap = stepsByCancerTypeAndStage.get(typeKey);
@@ -602,33 +619,41 @@ export function PatientNavigationTab({
                           <StageDroppableColumn
                             key={stage}
                             id={buildNavDropId(typeKey, stage)}
-                            className="space-y-2"
+                            className={
+                              steps.length === 0 ? '' : 'space-y-2'
+                            }
                           >
-                            <h4 className="text-sm font-medium text-muted-foreground mb-2">
+                            {steps.length === 0 ? (
+                              <div className="flex flex-col gap-2 rounded-md border border-dashed bg-muted/20 px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
+                                <span className="text-sm font-medium text-muted-foreground">
+                                  {stageLabel}{' '}
+                                  <span className="font-normal">(0)</span>
+                                </span>
+                                <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+                                  <span className="text-xs text-muted-foreground">
+                                    Solte uma etapa aqui
+                                  </span>
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => openStepPicker(typeKey, stage)}
+                                  >
+                                    <Plus className="mr-2 h-4 w-4" />
+                                    Adicionar etapa
+                                  </Button>
+                                </div>
+                              </div>
+                            ) : (
+                              <>
+                            <h4 className="mb-2 text-sm font-medium text-muted-foreground">
                               {stageLabel}
                               <span className="ml-2 font-normal">
                                 ({steps.length})
                               </span>
                             </h4>
                             <div className="space-y-4">
-                              {steps.length === 0 ? (
-                                <div className="flex flex-col items-center gap-3 py-4 text-center rounded-lg border border-dashed">
-                                  <p className="text-sm text-muted-foreground">
-                                    Nenhuma etapa para esta fase.
-                                  </p>
-                                  <Button
-                                    size="sm"
-                                    variant="outline"
-                                    onClick={() => openStepPicker(typeKey, stage)}
-                                  >
-                                    <Plus className="h-4 w-4 mr-2" />
-                                    Adicionar etapa
-                                  </Button>
-                                </div>
-                              ) : (
-                                <>
                                   {steps.map((step) => (
-                            <DraggableNavigationStep key={step.id} stepId={step.id}>
+                            <DraggableNavigationStep key={step.id} stepId={step.id} useDragOverlay>
                             {(dragHandle) => (
                             <div className="border rounded-lg p-4 space-y-2 flex-1 min-w-0 w-full">
                               <div className="flex items-center justify-between gap-2 flex-wrap">
@@ -676,33 +701,6 @@ export function PatientNavigationTab({
                                   >
                                     <Check className="h-4 w-4" />
                                   </button>
-                                  <div className="flex items-center gap-1">
-                                    <label htmlFor={`nav-move-${step.id}`} className="sr-only">
-                                      Mover etapa para outra fase
-                                    </label>
-                                    <select
-                                      id={`nav-move-${step.id}`}
-                                      className="h-8 max-w-[11rem] rounded-md border border-input bg-background px-2 text-xs md:text-sm"
-                                      defaultValue=""
-                                      onChange={(e) => {
-                                        const v = e.currentTarget.value as JourneyStage;
-                                        e.currentTarget.value = '';
-                                        if (v) handleMoveStepToStage(step, v);
-                                      }}
-                                      disabled={moveStepMutation.isPending}
-                                    >
-                                      <option value="">Mover para fase…</option>
-                                      {JOURNEY_STAGES.filter(
-                                        (s) =>
-                                          s !==
-                                          ((step.journeyStage || 'SCREENING').toUpperCase() as JourneyStage)
-                                      ).map((s) => (
-                                        <option key={s} value={s}>
-                                          {JOURNEY_STAGE_LABELS[s]}
-                                        </option>
-                                      ))}
-                                    </select>
-                                  </div>
                                   <Button
                                     size="sm"
                                     variant="outline"
@@ -833,9 +831,9 @@ export function PatientNavigationTab({
                                     <Plus className="h-4 w-4 mr-2" />
                                     Adicionar etapa
                                   </Button>
-                                </>
-                              )}
                             </div>
+                              </>
+                            )}
                           </StageDroppableColumn>
                         );
                       })}
@@ -845,6 +843,14 @@ export function PatientNavigationTab({
               );
             })}
           </Accordion>
+          <DragOverlay dropAnimation={{ duration: 180, easing: 'ease-out' }} className="z-[1000]">
+            {activeDragStep ? (
+              <NavigationStepDragPreview
+                stepName={activeDragStep.stepName}
+                stepDescription={activeDragStep.stepDescription}
+              />
+            ) : null}
+          </DragOverlay>
           </DndContext>
         </CardContent>
       </Card>

--- a/frontend/src/lib/api/navigation.ts
+++ b/frontend/src/lib/api/navigation.ts
@@ -41,6 +41,13 @@ export interface UpdateNavigationStepData {
   findings?: string[];
   metadata?: unknown;
   notes?: string;
+  /** Mover etapa para outra fase (limpa dependências e prazos relativos no backend). */
+  journeyStage?:
+    | 'SCREENING'
+    | 'DIAGNOSIS'
+    | 'TREATMENT'
+    | 'FOLLOW_UP'
+    | 'PALLIATIVE';
 }
 
 /** Dados para criar uma nova etapa de navegação */

--- a/frontend/src/lib/api/oncology-navigation.ts
+++ b/frontend/src/lib/api/oncology-navigation.ts
@@ -76,6 +76,12 @@ export interface UpdateNavigationStepDto {
   findings?: string[]; // Lista de achados/alterações
   metadata?: Record<string, unknown>;
   notes?: string;
+  journeyStage?:
+    | 'SCREENING'
+    | 'DIAGNOSIS'
+    | 'TREATMENT'
+    | 'FOLLOW_UP'
+    | 'PALLIATIVE';
 }
 
 export const oncologyNavigationApi = {

--- a/frontend/src/lib/utils/__tests__/api-config.test.ts
+++ b/frontend/src/lib/utils/__tests__/api-config.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('api-config — HTTPS / mixed content', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('alinha NEXT_PUBLIC_WS_URL ws→wss quando a página está em HTTPS', async () => {
+    vi.stubGlobal('window', { location: { protocol: 'https:' } });
+    vi.stubEnv('NEXT_PUBLIC_WS_URL', 'ws://localhost:3002');
+    vi.stubEnv('NEXT_PUBLIC_API_URL', '');
+    const { getWebSocketUrl } = await import('../api-config');
+    expect(getWebSocketUrl()).toBe('wss://localhost:3002');
+  });
+
+  it('alinha NEXT_PUBLIC_API_URL http→https quando a página está em HTTPS', async () => {
+    vi.stubGlobal('window', { location: { protocol: 'https:' } });
+    vi.stubEnv('NEXT_PUBLIC_API_URL', 'http://localhost:3002');
+    const { getApiUrl } = await import('../api-config');
+    expect(getApiUrl()).toBe('https://localhost:3002');
+  });
+
+  it('mantém ws:// quando a página está em HTTP', async () => {
+    vi.stubGlobal('window', { location: { protocol: 'http:' } });
+    vi.stubEnv('NEXT_PUBLIC_WS_URL', 'ws://localhost:3002');
+    vi.stubEnv('NEXT_PUBLIC_API_URL', '');
+    const { getWebSocketUrl } = await import('../api-config');
+    expect(getWebSocketUrl()).toBe('ws://localhost:3002');
+  });
+});

--- a/frontend/src/lib/utils/api-config.ts
+++ b/frontend/src/lib/utils/api-config.ts
@@ -25,6 +25,22 @@ function detectProtocol(): 'https' | 'http' {
 }
 
 /**
+ * Páginas HTTPS não podem chamar API HTTP nem usar WebSocket `ws:` (mixed content).
+ * Quando a env aponta para `http://` ou `ws://` e a página está em HTTPS, alinha para TLS.
+ */
+function alignUrlWithPageSecurity(url: string): string {
+  if (typeof window === 'undefined') return url;
+  if (window.location.protocol !== 'https:') return url;
+  if (url.startsWith('http://')) {
+    return `https://${url.slice('http://'.length)}`;
+  }
+  if (url.startsWith('ws://')) {
+    return `wss://${url.slice('ws://'.length)}`;
+  }
+  return url;
+}
+
+/**
  * Obtém a URL base da API
  * Prioridade:
  * 1. Variável de ambiente NEXT_PUBLIC_API_URL (se definida e completa)
@@ -38,7 +54,7 @@ export function getApiUrl(): string {
     envUrl &&
     (envUrl.startsWith('http://') || envUrl.startsWith('https://'))
   ) {
-    return envUrl;
+    return alignUrlWithPageSecurity(envUrl);
   }
 
   // Caso contrário, detectar protocolo e construir URL
@@ -58,7 +74,7 @@ export function getWebSocketUrl(): string {
 
   // Se a variável de ambiente já tem protocolo completo, usar ela
   if (envUrl && (envUrl.startsWith('ws://') || envUrl.startsWith('wss://'))) {
-    return envUrl;
+    return alignUrlWithPageSecurity(envUrl);
   }
 
   // Caso contrário, detectar protocolo e construir URL


### PR DESCRIPTION
## Summary
- Navegação oncológica: RTU terapêutica, mover etapas entre fases (API + UI), etapas universais no backend.
- Frontend: arrastar etapas entre fases com **DragOverlay** (cartão acima do restante ao arrastar) e **fases vazias colapsadas** (faixa compacta, ainda droppável).
- Frontend: `getApiUrl` / `getWebSocketUrl` alinham http→https e ws→wss quando a página está em HTTPS (evita mixed content).
- AI service: `Settings` com pydantic-settings v2 (`SettingsConfigDict`), campos RAG opcionais e bump do pacote `anthropic` para compatibilidade com LangChain.
- Docs: README com links das URLs locais, comandos `python -m …` e numeração de passos corrigida.

## Por quê
Melhorar o fluxo clínico de navegação (incl. RTU em tratamento), dar alternativa acessível ao select de fase (só DnD com preview visível), e permitir dev HTTPS sem quebrar chamadas à API.

## Como testar
- [ ] `cd frontend && npm run test` e `npx vitest run src/lib/utils/__tests__/api-config.test.ts`
- [ ] `cd frontend && npm run build` ou `npx tsc --noEmit`
- [ ] Manual: painel Navegação oncológica e aba Etapas do paciente — arrastar etapa entre fases; soltar em fase vazia.
- [ ] Manual: app em `https://localhost:3000` com API em HTTP no .env — verificar que URLs passam a HTTPS/WSS conforme esperado.
- [ ] `cd ai-service && python -m pip install -r requirements.txt && python -m uvicorn main:app` — health OK.

## Checklist
- [ ] Testes passando
- [ ] Sem credenciais em commit
- [ ] Multi-tenant / backend inalterado neste PR além do já existente na branch base dos commits anteriores


Made with [Cursor](https://cursor.com)