### PR TITLE
feat: validação de paciente, jornada e sincronização de dados clínicos

### DIFF
--- a/backend/src/patients/patients.service.ts
+++ b/backend/src/patients/patients.service.ts
@@ -1209,6 +1209,13 @@ export class PatientsService {
             results: { orderBy: { performedAt: 'desc' } },
           },
         },
+        medications: {
+          where: { isActive: true },
+          orderBy: { updatedAt: 'desc' },
+        },
+        comorbidities: {
+          orderBy: { updatedAt: 'desc' },
+        },
         alerts: {
           where: {
             status: { not: 'RESOLVED' },

--- a/frontend/src/components/patients/comorbidities-form.tsx
+++ b/frontend/src/components/patients/comorbidities-form.tsx
@@ -10,6 +10,7 @@ import {
   type ComorbidityType,
   type ComorbiditySeverity,
 } from '@/lib/api/patients';
+import { patientEditFieldId } from '@/lib/utils/patient-form-anchors';
 
 /** Linha em edição — tipo/gravidade opcionais até o usuário escolher. */
 export type ComorbidityFormRow = {
@@ -173,6 +174,7 @@ export function ComorbiditiesForm({
             return (
               <div
                 key={index}
+                id={patientEditFieldId(`comorbidities.${index}`)}
                 className={`flex gap-2 items-start p-3 border rounded-lg ${
                   isHighRisk ? 'bg-red-50 border-red-200' : 'bg-gray-50'
                 }`}

--- a/frontend/src/components/patients/current-medications-form.tsx
+++ b/frontend/src/components/patients/current-medications-form.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { patientEditFieldId } from '@/lib/utils/patient-form-anchors';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -126,6 +127,7 @@ export function CurrentMedicationsForm({
             return (
               <div
                 key={index}
+                id={patientEditFieldId(`currentMedications.${index}`)}
                 className={`flex gap-2 items-start p-3 border rounded-lg ${
                   isRisky ? 'bg-amber-50 border-amber-200' : 'bg-gray-50'
                 }`}

--- a/frontend/src/components/patients/family-history-form.tsx
+++ b/frontend/src/components/patients/family-history-form.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { patientEditFieldId } from '@/lib/utils/patient-form-anchors';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -59,6 +60,7 @@ export function FamilyHistoryForm({
           {familyHistory.map((member, index) => (
             <div
               key={index}
+              id={patientEditFieldId(`familyHistory.${index}`)}
               className="flex gap-2 items-start p-3 border rounded-lg bg-gray-50"
             >
               <div className="flex-1 grid grid-cols-1 md:grid-cols-3 gap-2">

--- a/frontend/src/components/patients/patient-create-dialog.tsx
+++ b/frontend/src/components/patients/patient-create-dialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { useForm, useWatch } from 'react-hook-form';
+import { useForm, useWatch, type FieldErrors } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
   Dialog,
@@ -34,7 +34,15 @@ import { useEnabledCancerTypes } from '@/hooks/useEnabledCancerTypes';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { JOURNEY_STAGE_LABELS } from '@/lib/utils/journey-stage';
+import {
+  JOURNEY_STAGE_LABELS,
+  requiresCurrentTreatmentField,
+  requiresOncologyCoreFields,
+} from '@/lib/utils/journey-stage';
+import {
+  collectAllFormErrorMessages,
+  messagesFromZodError,
+} from '@/lib/utils/form-field-errors';
 import { ComorbiditiesForm } from './comorbidities-form';
 import { CurrentMedicationsForm } from './current-medications-form';
 import { FamilyHistoryForm } from './family-history-form';
@@ -44,6 +52,11 @@ import { StructuredClinicalRisksForm } from './structured-clinical-risks-form';
 interface PatientCreateDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+}
+
+function fieldErrorText(err: { message?: unknown } | undefined): string {
+  const m = err?.message;
+  return typeof m === 'string' ? m : '';
 }
 
 const STEPS = [
@@ -67,8 +80,10 @@ export function PatientCreateDialog({
     control,
     setValue,
     reset,
+    getValues,
   } = useForm<CreatePatientFormData>({
     resolver: zodResolver(createPatientSchema),
+    criteriaMode: 'all',
     defaultValues: {
       gender: undefined,
       cancerType: undefined,
@@ -106,18 +121,45 @@ export function PatientCreateDialog({
   const allergyEntries = useWatch({ control, name: 'allergyEntries' });
   const allergies = useWatch({ control, name: 'allergies' });
 
-  const needsDiagnosisFields =
-    currentStage === 'TREATMENT' ||
-    currentStage === 'FOLLOW_UP' ||
-    currentStage === 'PALLIATIVE';
-  const needsTreatmentField =
-    currentStage === 'TREATMENT' ||
-    currentStage === 'FOLLOW_UP' ||
-    currentStage === 'PALLIATIVE';
+  const needsOncologyCoreFields = requiresOncologyCoreFields(currentStage);
+  const needsTreatmentField = requiresCurrentTreatmentField(currentStage);
   const treatmentOptions = getTreatmentOptionsForCancerType(
     cancerType ?? null,
     currentStage === 'TREATMENT'
   );
+
+  const onValidationError = (errs: FieldErrors<CreatePatientFormData>) => {
+    const merged: CreatePatientFormData = {
+      ...getValues(),
+      gender,
+      cancerType,
+      currentStage,
+      performanceStatus,
+      currentTreatment,
+      comorbidities,
+      currentMedications,
+      familyHistory,
+      priorSurgeries,
+      priorHospitalizations,
+      smokingProfile,
+      alcoholProfile,
+      occupationalExposureEntries,
+      allergyEntries,
+      allergies,
+    };
+    const parsed = createPatientSchema.safeParse(merged);
+    const messages = parsed.success
+      ? collectAllFormErrorMessages(errs)
+      : messagesFromZodError(parsed.error);
+    if (messages.length === 0) {
+      toast.error('Corrija os campos destacados antes de continuar.');
+      return;
+    }
+    toast.error(messages.join('\n'), {
+      duration: 12_000,
+      className: 'whitespace-pre-wrap text-left max-w-lg',
+    });
+  };
 
   const createPatientMutation = useMutation({
     mutationFn: (data: CreatePatientDto) => patientsApi.create(data),
@@ -134,6 +176,20 @@ export function PatientCreateDialog({
   });
 
   const onSubmit = (data: CreatePatientFormData) => {
+    type RowFH = NonNullable<CreatePatientFormData['familyHistory']>[number];
+    type RowOcc = NonNullable<
+      CreatePatientFormData['occupationalExposureEntries']
+    >[number];
+    type RowAllergy = NonNullable<CreatePatientFormData['allergyEntries']>[number];
+    type RowComorb = NonNullable<CreatePatientFormData['comorbidities']>[number];
+    type RowMed = NonNullable<
+      CreatePatientFormData['currentMedications']
+    >[number];
+    type RowPS = NonNullable<CreatePatientFormData['priorSurgeries']>[number];
+    type RowPH = NonNullable<
+      CreatePatientFormData['priorHospitalizations']
+    >[number];
+
     // Helper: filtra array e retorna undefined se vazio
     const filterNonEmpty = <T,>(
       arr: T[] | undefined,
@@ -146,10 +202,10 @@ export function PatientCreateDialog({
 
     const filteredFamilyHistory = filterNonEmpty(
       data.familyHistory,
-      (h) =>
+      (h: RowFH) =>
         (h.relationship?.trim().length ?? 0) > 0 &&
         (h.cancerType?.trim().length ?? 0) > 0
-    )?.map((h) => ({
+    )?.map((h: RowFH) => ({
       relationship: h.relationship!,
       cancerType: h.cancerType!,
       ageAtDiagnosis: h.ageAtDiagnosis,
@@ -176,8 +232,8 @@ export function PatientCreateDialog({
 
     const occPayload = filterNonEmpty(
       data.occupationalExposureEntries,
-      (o) => (o.agent?.trim()?.length ?? 0) > 0
-    )?.map((o) => ({
+      (o: RowOcc) => (o.agent?.trim()?.length ?? 0) > 0
+    )?.map((o: RowOcc) => ({
       agent: o.agent!.trim(),
       yearsApprox: o.yearsApprox,
       notes: o.notes?.trim() || undefined,
@@ -185,8 +241,8 @@ export function PatientCreateDialog({
 
     const allergyPayload = filterNonEmpty(
       data.allergyEntries,
-      (a) => (a.substanceKey?.trim()?.length ?? 0) > 0
-    )?.map((a) => ({
+      (a: RowAllergy) => (a.substanceKey?.trim()?.length ?? 0) > 0
+    )?.map((a: RowAllergy) => ({
       substanceKey: a.substanceKey!.trim(),
       customLabel:
         a.substanceKey === 'OTHER' ? a.customLabel?.trim() : undefined,
@@ -213,11 +269,11 @@ export function PatientCreateDialog({
       familyHistory: filteredFamilyHistory,
       comorbidities: filterNonEmpty(
         data.comorbidities,
-        (c) =>
+        (c: RowComorb) =>
           (c.name?.trim().length ?? 0) > 0 &&
           Boolean(c.type) &&
           Boolean(c.severity)
-      )?.map((c) => ({
+      )?.map((c: RowComorb) => ({
         name: c.name!.trim(),
         type: c.type as ComorbidityType,
         severity: c.severity as ComorbiditySeverity,
@@ -225,9 +281,9 @@ export function PatientCreateDialog({
       })),
       currentMedications: filterNonEmpty(
         data.currentMedications,
-        (m) =>
+        (m: RowMed) =>
           Boolean(m.catalogKey?.trim()) || (m.name?.trim()?.length ?? 0) > 0
-      )?.map((m) => {
+      )?.map((m: RowMed) => {
         const ck = m.catalogKey?.trim();
         if (ck && ck !== 'OTHER') {
           return {
@@ -261,8 +317,8 @@ export function PatientCreateDialog({
       ehrId: data.ehrPatientId || undefined,
       priorSurgeries: filterNonEmpty(
         data.priorSurgeries,
-        (s) => (s.procedureName?.trim().length ?? 0) > 0
-      )?.map((s) => ({
+        (s: RowPS) => (s.procedureName?.trim().length ?? 0) > 0
+      )?.map((s: RowPS) => ({
         procedureName: s.procedureName!.trim(),
         year: s.year,
         institution: s.institution?.trim() || undefined,
@@ -270,8 +326,8 @@ export function PatientCreateDialog({
       })),
       priorHospitalizations: filterNonEmpty(
         data.priorHospitalizations,
-        (h) => (h.summary?.trim().length ?? 0) > 0
-      )?.map((h) => ({
+        (h: RowPH) => (h.summary?.trim().length ?? 0) > 0
+      )?.map((h: RowPH) => ({
         summary: h.summary!.trim(),
         year: h.year,
         durationDays: h.durationDays,
@@ -336,7 +392,10 @@ export function PatientCreateDialog({
           ))}
         </div>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+        <form
+          onSubmit={handleSubmit(onSubmit, onValidationError)}
+          className="space-y-6"
+        >
           {/* Etapa 1: Dados Básicos */}
           {currentStep === 1 && (
             <div className="space-y-4">
@@ -345,7 +404,7 @@ export function PatientCreateDialog({
                 <Input {...register('name')} placeholder="Nome completo" />
                 {errors.name && (
                   <p className="text-sm text-destructive mt-1">
-                    {errors.name.message}
+                    {fieldErrorText(errors.name)}
                   </p>
                 )}
               </div>
@@ -355,7 +414,7 @@ export function PatientCreateDialog({
                 <Input {...register('cpf')} placeholder="000.000.000-00" />
                 {errors.cpf && (
                   <p className="text-sm text-destructive mt-1">
-                    {errors.cpf.message}
+                    {fieldErrorText(errors.cpf)}
                   </p>
                 )}
               </div>
@@ -367,7 +426,7 @@ export function PatientCreateDialog({
                 <Input type="date" {...register('birthDate')} />
                 {errors.birthDate && (
                   <p className="text-sm text-destructive mt-1">
-                    {errors.birthDate.message}
+                    {fieldErrorText(errors.birthDate)}
                   </p>
                 )}
               </div>
@@ -389,7 +448,7 @@ export function PatientCreateDialog({
                 </Select>
                 {errors.gender && (
                   <p className="text-sm text-destructive mt-1">
-                    {errors.gender.message}
+                    {fieldErrorText(errors.gender)}
                   </p>
                 )}
               </div>
@@ -405,7 +464,7 @@ export function PatientCreateDialog({
                 />
                 {errors.phone && (
                   <p className="text-sm text-destructive mt-1">
-                    {errors.phone.message}
+                    {fieldErrorText(errors.phone)}
                   </p>
                 )}
               </div>
@@ -419,7 +478,7 @@ export function PatientCreateDialog({
                 />
                 {errors.email && (
                   <p className="text-sm text-destructive mt-1">
-                    {errors.email.message}
+                    {fieldErrorText(errors.email)}
                   </p>
                 )}
               </div>
@@ -439,7 +498,11 @@ export function PatientCreateDialog({
                   value={currentStage}
                   onValueChange={(value) => {
                     setValue('currentStage', value as any);
-                    if (value !== 'TREATMENT' && value !== 'FOLLOW_UP') {
+                    if (
+                      value !== 'TREATMENT' &&
+                      value !== 'FOLLOW_UP' &&
+                      value !== 'PALLIATIVE'
+                    ) {
                       setValue('currentTreatment', '', {
                         shouldValidate: true,
                       });
@@ -459,11 +522,11 @@ export function PatientCreateDialog({
                 </Select>
               </div>
 
-              {/* Tipo de Câncer — obrigatório quando em Tratamento ou Seguimento */}
+              {/* Tipo de Câncer — obrigatório após Rastreamento */}
               <div>
                 <label className="text-sm font-medium">
                   Tipo de Câncer{' '}
-                  {needsDiagnosisFields && (
+                  {needsOncologyCoreFields && (
                     <span className="text-red-600">*</span>
                   )}
                 </label>
@@ -487,13 +550,13 @@ export function PatientCreateDialog({
                 </Select>
                 {errors.cancerType && (
                   <p className="text-sm text-destructive mt-1">
-                    {errors.cancerType.message}
+                    {fieldErrorText(errors.cancerType)}
                   </p>
                 )}
               </div>
 
-              {/* Campos de diagnóstico: só em Tratamento ou Seguimento */}
-              {needsDiagnosisFields && (
+              {/* Campos de diagnóstico: obrigatórios após Rastreamento */}
+              {needsOncologyCoreFields && (
                 <>
                   <div>
                     <label className="text-sm font-medium">
@@ -503,6 +566,11 @@ export function PatientCreateDialog({
                       {...register('stage')}
                       placeholder="Ex: T2N1M0 ou Estágio II"
                     />
+                    {errors.stage && (
+                      <p className="text-sm text-destructive mt-1">
+                        {fieldErrorText(errors.stage)}
+                      </p>
+                    )}
                   </div>
 
                   <div>
@@ -512,7 +580,7 @@ export function PatientCreateDialog({
                     <Input type="date" {...register('diagnosisDate')} />
                     {errors.diagnosisDate && (
                       <p className="text-sm text-destructive mt-1">
-                        {errors.diagnosisDate.message}
+                        {fieldErrorText(errors.diagnosisDate)}
                       </p>
                     )}
                   </div>
@@ -567,7 +635,7 @@ export function PatientCreateDialog({
                     </Select>
                     {errors.performanceStatus && (
                       <p className="text-sm text-destructive mt-1">
-                        {errors.performanceStatus.message}
+                        {fieldErrorText(errors.performanceStatus)}
                       </p>
                     )}
                   </div>
@@ -601,7 +669,7 @@ export function PatientCreateDialog({
                   </Select>
                   {errors.currentTreatment && (
                     <p className="text-sm text-destructive mt-1">
-                      {errors.currentTreatment.message}
+                      {fieldErrorText(errors.currentTreatment)}
                     </p>
                   )}
                 </div>

--- a/frontend/src/components/patients/patient-edit-page.tsx
+++ b/frontend/src/components/patients/patient-edit-page.tsx
@@ -8,12 +8,27 @@ import {
   type ComorbiditySeverity,
   type ComorbidityType,
 } from '@/lib/api/patients';
-import { useForm } from 'react-hook-form';
+import {
+  Controller,
+  useForm,
+  type FieldErrors,
+  type Path,
+} from 'react-hook-form';
+import {
+  collectAllFormErrorMessages,
+  messagesFromZodError,
+} from '@/lib/utils/form-field-errors';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
-  createPatientSchema,
-  CreatePatientFormData,
+  editPatientSchema,
+  EditPatientFormData,
 } from '@/lib/validations/patient';
+import { getTreatmentOptionsForCancerType } from '@/lib/utils/patient-cancer-type';
+import {
+  JOURNEY_STAGE_LABELS,
+  requiresCurrentTreatmentField,
+  requiresOncologyCoreFields,
+} from '@/lib/utils/journey-stage';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -55,6 +70,11 @@ import {
 } from '@/lib/validations/cancer-diagnosis';
 import { getCancerTypeKey } from '@/lib/utils/patient-cancer-type';
 import { useEnabledCancerTypes } from '@/hooks/useEnabledCancerTypes';
+import { cn } from '@/lib/utils';
+import {
+  patientEditFieldId,
+  scrollFieldPathIntoView,
+} from '@/lib/utils/patient-form-anchors';
 import type {
   PriorHospitalizationItem,
   PriorSurgeryItem,
@@ -137,6 +157,44 @@ interface PatientEditPageProps {
   patientId: string;
 }
 
+function fieldErrorText(err: { message?: unknown } | undefined): string {
+  const m = err?.message;
+  return typeof m === 'string' ? m : '';
+}
+
+/** Primeiro path com erro, para foco (ex.: comorbidities.0.name). */
+function firstErrorFieldPath(
+  errs: FieldErrors<EditPatientFormData>
+): Path<EditPatientFormData> | undefined {
+  function walk(obj: unknown, prefix: string): string | undefined {
+    if (obj == null || typeof obj !== 'object') return undefined;
+    if (Array.isArray(obj)) {
+      for (let i = 0; i < obj.length; i++) {
+        const p = prefix ? `${prefix}.${i}` : String(i);
+        const sub = walk(obj[i], p);
+        if (sub) return sub;
+      }
+      return undefined;
+    }
+    const o = obj as Record<string, unknown>;
+    if (
+      'message' in o &&
+      typeof o.message === 'string' &&
+      o.message.length > 0
+    ) {
+      return prefix || undefined;
+    }
+    for (const [k, v] of Object.entries(o)) {
+      if (k === 'ref') continue;
+      const next = prefix ? `${prefix}.${k}` : k;
+      const sub = walk(v, next);
+      if (sub) return sub;
+    }
+    return undefined;
+  }
+  return walk(errs, '') as Path<EditPatientFormData> | undefined;
+}
+
 export function PatientEditPage({ patientId }: PatientEditPageProps) {
   const { data: patient, isLoading, error } = usePatientDetail(patientId);
   const updateMutation = usePatientUpdate();
@@ -150,12 +208,17 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
   const {
     register,
     handleSubmit,
+    setFocus,
+    control,
     formState: { errors },
     watch,
     setValue,
     reset,
-  } = useForm<CreatePatientFormData>({
-    resolver: zodResolver(createPatientSchema),
+    getValues,
+  } = useForm<EditPatientFormData>({
+    resolver: zodResolver(editPatientSchema),
+    shouldFocusError: true,
+    criteriaMode: 'all',
     defaultValues: {
       name: '',
       cpf: '',
@@ -163,6 +226,7 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
       phone: '',
       email: '',
       currentStage: 'SCREENING',
+      currentTreatment: '',
       smokingHistory: '',
       alcoholHistory: '',
       occupationalExposure: '',
@@ -206,7 +270,7 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
 
   // Preencher formulário com dados do paciente quando carregar
   useEffect(() => {
-    if (patient && !isLoading) {
+    if (patient) {
       // Obter cancerType do primeiro diagnóstico ativo ou do campo legacy (pode vir em PT ou EN)
       const primaryDiagnosis =
         patient.cancerDiagnoses?.find((d) => d.isPrimary && d.isActive) ||
@@ -270,20 +334,21 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
         'DIAGNOSIS',
         'TREATMENT',
         'FOLLOW_UP',
+        'PALLIATIVE',
       ] as const;
       const currentStageRaw =
         patient.currentStage?.toString?.()?.trim?.()?.toUpperCase?.() ?? '';
       const currentStageNormalized = (STAGES as readonly string[]).includes(
         currentStageRaw
       )
-        ? (currentStageRaw as CreatePatientFormData['currentStage'])
-        : ('SCREENING' as CreatePatientFormData['currentStage']);
+        ? (currentStageRaw as EditPatientFormData['currentStage'])
+        : ('SCREENING' as EditPatientFormData['currentStage']);
 
       const pExt = patient as typeof patient & {
-        smokingProfile?: CreatePatientFormData['smokingProfile'];
-        alcoholProfile?: CreatePatientFormData['alcoholProfile'];
-        occupationalExposureEntries?: CreatePatientFormData['occupationalExposureEntries'];
-        allergyEntries?: CreatePatientFormData['allergyEntries'];
+        smokingProfile?: EditPatientFormData['smokingProfile'];
+        alcoholProfile?: EditPatientFormData['alcoholProfile'];
+        occupationalExposureEntries?: EditPatientFormData['occupationalExposureEntries'];
+        allergyEntries?: EditPatientFormData['allergyEntries'];
       };
 
       let smokingProfile = pExt.smokingProfile;
@@ -325,7 +390,11 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
         })
       );
 
-      const formData: Partial<CreatePatientFormData> = {
+      const patientWithTreatment = patient as typeof patient & {
+        currentTreatment?: string | null;
+      };
+
+      const formData: Partial<EditPatientFormData> = {
         name: patient.name || '',
         cpf: patient.cpf || '',
         birthDate: patient.birthDate
@@ -334,13 +403,14 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
         gender: genderNormalized,
         phone: formatPhoneForDisplay(patient.phone),
         email: patient.email || '',
+        currentTreatment: patientWithTreatment.currentTreatment?.trim() || '',
         cancerType: (cancerType ||
-          undefined) as CreatePatientFormData['cancerType'],
+          undefined) as EditPatientFormData['cancerType'],
         stage: stage || undefined,
-        tStage: (tStage || undefined) as CreatePatientFormData['tStage'],
-        nStage: (nStage || undefined) as CreatePatientFormData['nStage'],
-        mStage: (mStage || undefined) as CreatePatientFormData['mStage'],
-        grade: (grade || undefined) as CreatePatientFormData['grade'],
+        tStage: (tStage || undefined) as EditPatientFormData['tStage'],
+        nStage: (nStage || undefined) as EditPatientFormData['nStage'],
+        mStage: (mStage || undefined) as EditPatientFormData['mStage'],
+        grade: (grade || undefined) as EditPatientFormData['grade'],
         diagnosisDate: diagnosisDate || undefined,
         currentStage: currentStageNormalized,
         // performanceStatus deve ser um número (não string) para o schema Zod
@@ -354,7 +424,12 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
         allergyEntries,
         allergies: patient.allergies || '',
         comorbidities: Array.isArray(patient.comorbidities)
-          ? patient.comorbidities
+          ? patient.comorbidities.map((c) => ({
+              name: c.name,
+              type: String(c.type),
+              severity: String(c.severity),
+              controlled: c.controlled ?? false,
+            }))
           : [],
         currentMedications: Array.isArray(patient.medications)
           ? patient.medications.map((m) => ({
@@ -421,7 +496,7 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
 
       return () => clearTimeout(timer);
     }
-  }, [patient, isLoading, reset, setValue]);
+  }, [patient, reset, setValue]);
 
   // Atualizar campo stage automaticamente quando campos TNM mudarem
   const tStage = watch('tStage');
@@ -444,7 +519,7 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
     }
   }, [tStage, nStage, mStage, grade, setValue]);
 
-  const onSubmit = async (data: CreatePatientFormData) => {
+  const onSubmit = async (data: EditPatientFormData) => {
     // Normalizar telefone para formato aceito pelo validador IsPhoneNumber('BR')
     // O validador aceita formatos como: +5511999999999, 5511999999999, (11) 99999-9999
     // O backend normaliza depois para 55XXXXXXXXXXX
@@ -527,13 +602,19 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
     if (data.occupationalExposureEntries !== undefined) {
       updateData.occupationalExposureEntries =
         data.occupationalExposureEntries?.filter(
-          (o) => (o.agent?.trim()?.length ?? 0) > 0
+          (o: { agent?: string }) => (o.agent?.trim()?.length ?? 0) > 0
         ) ?? [];
     }
     if (data.allergyEntries !== undefined) {
       updateData.allergyEntries = data.allergyEntries
-        ?.filter((a) => (a.substanceKey?.trim()?.length ?? 0) > 0)
-        .map((a) => ({
+        ?.filter((a: { substanceKey?: string }) =>
+          (a.substanceKey?.trim()?.length ?? 0) > 0
+        )
+        .map((a: {
+          substanceKey?: string;
+          customLabel?: string;
+          reactionNotes?: string;
+        }) => ({
           substanceKey: a.substanceKey!.trim(),
           customLabel:
             a.substanceKey === 'OTHER' ? a.customLabel?.trim() : undefined,
@@ -544,6 +625,9 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
       updateData.allergies = data.allergies?.trim() || undefined;
     if (data.ehrPatientId !== undefined)
       updateData.ehrId = data.ehrPatientId || undefined;
+    if (data.currentTreatment !== undefined) {
+      updateData.currentTreatment = data.currentTreatment?.trim() || undefined;
+    }
 
     // Comorbidades - apenas se houver itens válidos e completos
     if (data.comorbidities !== undefined) {
@@ -650,14 +734,14 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
       if (data.priorSurgeries.length > 0) {
         const valid = data.priorSurgeries
           .filter(
-            (s) =>
+            (s: PriorSurgeryItem | { procedureName?: string }) =>
               s &&
               typeof s === 'object' &&
               typeof (s as { procedureName?: string }).procedureName ===
                 'string' &&
               (s as { procedureName: string }).procedureName.trim().length > 0
           )
-          .map((s) => ({
+          .map((s: PriorSurgeryItem | { procedureName?: string }) => ({
             procedureName: (s as { procedureName: string }).procedureName.trim(),
             year:
               (s as { year?: number }).year !== undefined &&
@@ -677,13 +761,13 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
       if (data.priorHospitalizations.length > 0) {
         const validH = data.priorHospitalizations
           .filter(
-            (h) =>
+            (h: PriorHospitalizationItem | { summary?: string }) =>
               h &&
               typeof h === 'object' &&
               typeof (h as { summary?: string }).summary === 'string' &&
               (h as { summary: string }).summary.trim().length > 0
           )
-          .map((h) => ({
+          .map((h: PriorHospitalizationItem | { summary?: string }) => ({
             summary: (h as { summary: string }).summary.trim(),
             year:
               (h as { year?: number }).year !== undefined &&
@@ -757,6 +841,71 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
     }
   };
 
+  /** Alinha Controllers ao Zod: `getValues()` no submit inválido pode omitir/atrasar chaves e o `.default()` do schema mascarar a fase. */
+  const mergeWatchIntoValuesForZod = (): EditPatientFormData => {
+    const g = getValues();
+    return {
+      ...g,
+      name: watch('name') ?? g.name,
+      birthDate: watch('birthDate') ?? g.birthDate,
+      phone: watch('phone') ?? g.phone,
+      email: watch('email') ?? g.email,
+      gender: watch('gender') ?? g.gender,
+      cpf: watch('cpf') ?? g.cpf,
+      currentStage: (watch('currentStage') ??
+        g.currentStage) as EditPatientFormData['currentStage'],
+      cancerType: watch('cancerType') ?? g.cancerType,
+      diagnosisDate: watch('diagnosisDate') ?? g.diagnosisDate,
+      performanceStatus: watch('performanceStatus') ?? g.performanceStatus,
+      currentTreatment: watch('currentTreatment') ?? g.currentTreatment,
+      stage: watch('stage') ?? g.stage,
+      tStage: watch('tStage') ?? g.tStage,
+      nStage: watch('nStage') ?? g.nStage,
+      mStage: watch('mStage') ?? g.mStage,
+      grade: watch('grade') ?? g.grade,
+      smokingProfile: watch('smokingProfile') ?? g.smokingProfile,
+      alcoholProfile: watch('alcoholProfile') ?? g.alcoholProfile,
+      occupationalExposureEntries:
+        watch('occupationalExposureEntries') ?? g.occupationalExposureEntries,
+      allergyEntries: watch('allergyEntries') ?? g.allergyEntries,
+      allergies: watch('allergies') ?? g.allergies,
+      comorbidities: watch('comorbidities') ?? g.comorbidities,
+      currentMedications: watch('currentMedications') ?? g.currentMedications,
+      familyHistory: watch('familyHistory') ?? g.familyHistory,
+      priorSurgeries: watch('priorSurgeries') ?? g.priorSurgeries,
+      priorHospitalizations:
+        watch('priorHospitalizations') ?? g.priorHospitalizations,
+      smokingHistory: watch('smokingHistory') ?? g.smokingHistory,
+      alcoholHistory: watch('alcoholHistory') ?? g.alcoholHistory,
+      occupationalExposure:
+        watch('occupationalExposure') ?? g.occupationalExposure,
+      ehrPatientId: watch('ehrPatientId') ?? g.ehrPatientId,
+    };
+  };
+
+  const onValidationError = (errs: FieldErrors<EditPatientFormData>) => {
+    const merged = mergeWatchIntoValuesForZod();
+    const parsed = editPatientSchema.safeParse(merged);
+    const messages = parsed.success
+      ? collectAllFormErrorMessages(errs)
+      : messagesFromZodError(parsed.error);
+    const path = firstErrorFieldPath(errs);
+    if (messages.length === 0) {
+      toast.error('Corrija os campos destacados antes de salvar.');
+    } else {
+      toast.error(messages.join('\n'), {
+        duration: 12_000,
+        className: 'whitespace-pre-wrap text-left max-w-lg',
+      });
+    }
+    if (path) {
+      setFocus(path);
+      requestAnimationFrame(() => {
+        scrollFieldPathIntoView(String(path));
+      });
+    }
+  };
+
   const handleDeletePatient = async () => {
     if (!patientId) return;
     setIsDeleting(true);
@@ -810,6 +959,13 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
   }
 
   const currentStage = watch('currentStage');
+  const cancerTypeWatch = watch('cancerType');
+  const needsOncologyCoreFields = requiresOncologyCoreFields(currentStage);
+  const needsTreatmentField = requiresCurrentTreatmentField(currentStage);
+  const treatmentOptions = getTreatmentOptionsForCancerType(
+    cancerTypeWatch ?? null,
+    currentStage === 'TREATMENT'
+  );
 
   return (
     <div className="p-6 space-y-6">
@@ -832,106 +988,141 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
       </div>
 
       {/* Formulário */}
-      <form key={patientId} onSubmit={handleSubmit(onSubmit)}>
+      <form
+        key={patientId}
+        noValidate
+        onSubmit={handleSubmit(onSubmit, onValidationError)}
+      >
         <Card>
           <CardHeader>
             <CardTitle>Dados Básicos</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
+              <div id={patientEditFieldId('name')}>
                 <label className="text-sm font-medium mb-2 block">
                   Nome Completo *
                 </label>
                 <Input
                   {...register('name')}
                   placeholder="Nome completo do paciente"
+                  aria-invalid={!!errors.name}
+                  className={cn(errors.name && 'border-destructive')}
                 />
                 {errors.name && (
                   <p className="text-sm text-destructive mt-1">
-                    {errors.name.message}
+                    {fieldErrorText(errors.name)}
                   </p>
                 )}
               </div>
 
-              <div>
+              <div id={patientEditFieldId('cpf')}>
                 <label className="text-sm font-medium mb-2 block">CPF</label>
                 <Input
                   {...register('cpf')}
                   placeholder="000.000.000-00"
                   maxLength={14}
+                  aria-invalid={!!errors.cpf}
+                  className={cn(errors.cpf && 'border-destructive')}
                 />
                 {errors.cpf && (
                   <p className="text-sm text-destructive mt-1">
-                    {errors.cpf.message}
+                    {fieldErrorText(errors.cpf)}
                   </p>
                 )}
               </div>
 
-              <div>
+              <div id={patientEditFieldId('birthDate')}>
                 <label className="text-sm font-medium mb-2 block">
                   Data de Nascimento *
                 </label>
-                <Input type="date" {...register('birthDate')} />
+                <Input
+                  type="date"
+                  {...register('birthDate')}
+                  aria-invalid={!!errors.birthDate}
+                  className={cn(errors.birthDate && 'border-destructive')}
+                />
                 {errors.birthDate && (
                   <p className="text-sm text-destructive mt-1">
-                    {errors.birthDate.message}
+                    {fieldErrorText(errors.birthDate)}
                   </p>
                 )}
               </div>
 
-              <div>
-                <label className="text-sm font-medium mb-2 block">Sexo *</label>
-                <Select
-                  value={watch('gender') || ''}
-                  onValueChange={(value) => {
-                    if (value === '') {
-                      setValue('gender', undefined, { shouldValidate: true });
-                    } else {
-                      setValue('gender', value as 'male' | 'female' | 'other', {
-                        shouldValidate: true,
-                      });
-                    }
-                  }}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Selecione o sexo" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="male">Masculino</SelectItem>
-                    <SelectItem value="female">Feminino</SelectItem>
-                    <SelectItem value="other">Outro</SelectItem>
-                  </SelectContent>
-                </Select>
+              <div id={patientEditFieldId('gender')}>
+                <label className="text-sm font-medium mb-2 block">Sexo</label>
+                <Controller
+                  name="gender"
+                  control={control}
+                  render={({ field }) => (
+                    <Select
+                      value={field.value ?? ''}
+                      onValueChange={(value) => {
+                        field.onChange(
+                          value === ''
+                            ? undefined
+                            : (value as 'male' | 'female' | 'other')
+                        );
+                      }}
+                    >
+                      <SelectTrigger
+                        ref={field.ref}
+                        name={field.name}
+                        onBlur={field.onBlur}
+                        aria-invalid={!!errors.gender}
+                        className={cn(
+                          errors.gender && 'border-destructive ring-1 ring-destructive'
+                        )}
+                      >
+                        <SelectValue placeholder="Selecione o sexo" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="male">Masculino</SelectItem>
+                        <SelectItem value="female">Feminino</SelectItem>
+                        <SelectItem value="other">Outro</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  )}
+                />
                 {errors.gender && (
                   <p className="text-sm text-destructive mt-1">
-                    {errors.gender.message}
+                    {fieldErrorText(errors.gender)}
                   </p>
                 )}
               </div>
 
-              <div>
+              <div id={patientEditFieldId('phone')}>
                 <label className="text-sm font-medium mb-2 block">
-                  Telefone *
+                  Telefone{' '}
+                  <span className="text-muted-foreground font-normal">
+                    (opcional)
+                  </span>
                 </label>
-                <Input {...register('phone')} placeholder="(00) 00000-0000" />
+                <Input
+                  {...register('phone')}
+                  placeholder="(00) 00000-0000"
+                  aria-invalid={!!errors.phone}
+                  className={cn(errors.phone && 'border-destructive')}
+                />
                 {errors.phone && (
                   <p className="text-sm text-destructive mt-1">
-                    {errors.phone.message}
+                    {fieldErrorText(errors.phone)}
                   </p>
                 )}
               </div>
 
-              <div>
+              <div id={patientEditFieldId('email')}>
                 <label className="text-sm font-medium mb-2 block">E-mail</label>
                 <Input
                   type="email"
                   {...register('email')}
                   placeholder="email@exemplo.com"
+                  aria-invalid={!!errors.email}
+                  className={cn(errors.email && 'border-destructive')}
                 />
                 {errors.email && (
                   <p className="text-sm text-destructive mt-1">
-                    {errors.email.message}
+                    {fieldErrorText(errors.email)}
                   </p>
                 )}
               </div>
@@ -946,96 +1137,141 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
+              <div id={patientEditFieldId('currentStage')}>
                 <label className="text-sm font-medium mb-2 block">
                   Estágio da Jornada *
                 </label>
-                <Select
-                  value={watch('currentStage') || ''}
-                  onValueChange={(value) => {
-                    if (value === '') {
-                      setValue('currentStage', 'SCREENING', {
-                        shouldValidate: true,
-                      });
-                    } else {
-                      setValue(
-                        'currentStage',
-                        value as CreatePatientFormData['currentStage'],
-                        { shouldValidate: true }
-                      );
-                    }
-                  }}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Selecione o estágio" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="SCREENING">Rastreio</SelectItem>
-                    <SelectItem value="DIAGNOSIS">Diagnóstico</SelectItem>
-                    <SelectItem value="TREATMENT">Tratamento</SelectItem>
-                    <SelectItem value="FOLLOW_UP">Seguimento</SelectItem>
-                  </SelectContent>
-                </Select>
+                <Controller
+                  name="currentStage"
+                  control={control}
+                  render={({ field }) => (
+                    <Select
+                      value={field.value ?? ''}
+                      onValueChange={(value) => {
+                        const next =
+                          (value === ''
+                            ? 'SCREENING'
+                            : value) as EditPatientFormData['currentStage'];
+                        field.onChange(next);
+                        if (
+                          next !== 'TREATMENT' &&
+                          next !== 'FOLLOW_UP' &&
+                          next !== 'PALLIATIVE'
+                        ) {
+                          setValue('currentTreatment', '', {
+                            shouldValidate: true,
+                          });
+                        }
+                      }}
+                    >
+                      <SelectTrigger
+                        ref={field.ref}
+                        name={field.name}
+                        onBlur={field.onBlur}
+                        aria-invalid={!!errors.currentStage}
+                        className={cn(
+                          errors.currentStage &&
+                            'border-destructive ring-1 ring-destructive'
+                        )}
+                      >
+                        <SelectValue placeholder="Selecione o estágio" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="SCREENING">
+                          {JOURNEY_STAGE_LABELS.SCREENING}
+                        </SelectItem>
+                        <SelectItem value="DIAGNOSIS">
+                          {JOURNEY_STAGE_LABELS.DIAGNOSIS}
+                        </SelectItem>
+                        <SelectItem value="TREATMENT">
+                          {JOURNEY_STAGE_LABELS.TREATMENT}
+                        </SelectItem>
+                        <SelectItem value="FOLLOW_UP">
+                          {JOURNEY_STAGE_LABELS.FOLLOW_UP}
+                        </SelectItem>
+                        <SelectItem value="PALLIATIVE">
+                          {JOURNEY_STAGE_LABELS.PALLIATIVE}
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                  )}
+                />
                 {errors.currentStage && (
                   <p className="text-sm text-destructive mt-1">
-                    {errors.currentStage.message}
+                    {fieldErrorText(errors.currentStage)}
                   </p>
                 )}
               </div>
 
-              <div>
+              <div id={patientEditFieldId('cancerType')}>
                 <label className="text-sm font-medium mb-2 block">
                   Tipo de Câncer
+                  {needsOncologyCoreFields && ' *'}
                 </label>
-                <Select
-                  value={watch('cancerType') || ''}
-                  onValueChange={(value) => {
-                    if (value === '') {
-                      setValue('cancerType', undefined, {
-                        shouldValidate: true,
-                      });
-                    } else {
-                      setValue(
-                        'cancerType',
-                        value as CreatePatientFormData['cancerType'],
-                        { shouldValidate: true }
-                      );
-                    }
-                  }}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Selecione o tipo" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {Object.entries(enabledCancerLabels).map(([key, label]) => (
-                      <SelectItem key={key} value={key}>
-                        {label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <Controller
+                  name="cancerType"
+                  control={control}
+                  render={({ field }) => (
+                    <Select
+                      value={field.value ?? ''}
+                      onValueChange={(value) => {
+                        field.onChange(
+                          value === ''
+                            ? undefined
+                            : (value as EditPatientFormData['cancerType'])
+                        );
+                      }}
+                    >
+                      <SelectTrigger
+                        ref={field.ref}
+                        name={field.name}
+                        onBlur={field.onBlur}
+                        aria-invalid={!!errors.cancerType}
+                        className={cn(
+                          errors.cancerType &&
+                            'border-destructive ring-1 ring-destructive'
+                        )}
+                      >
+                        <SelectValue placeholder="Selecione o tipo" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {Object.entries(enabledCancerLabels).map(
+                          ([key, label]) => (
+                            <SelectItem key={key} value={key}>
+                              {label}
+                            </SelectItem>
+                          )
+                        )}
+                      </SelectContent>
+                    </Select>
+                  )}
+                />
                 {errors.cancerType && (
                   <p className="text-sm text-destructive mt-1">
-                    {errors.cancerType.message}
+                    {fieldErrorText(errors.cancerType)}
                   </p>
                 )}
               </div>
 
-              <div>
+              <div id={patientEditFieldId('stage')}>
                 <label className="text-sm font-medium mb-2 block">
                   Estágio (calculado automaticamente)
+                  {needsOncologyCoreFields && ' *'}
                 </label>
                 <Input
                   {...register('stage')}
                   placeholder="Preencha os campos TNM abaixo"
-                  value={watch('stage') ?? ''}
                   readOnly
-                  disabled
-                  className="bg-muted cursor-not-allowed"
+                  aria-readonly="true"
+                  aria-invalid={!!errors.stage}
+                  className={cn(
+                    'bg-muted cursor-not-allowed',
+                    errors.stage && 'border-destructive'
+                  )}
                 />
                 {errors.stage && (
                   <p className="text-sm text-destructive mt-1">
-                    {errors.stage.message}
+                    {fieldErrorText(errors.stage)}
                   </p>
                 )}
               </div>
@@ -1045,140 +1281,185 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
             <div className="mt-3">
               <label className="text-sm font-medium mb-2 block">
                 Estadiamento TNM Estruturado
+                {needsOncologyCoreFields && ' *'}
               </label>
               <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
-                <div>
+                <div id={patientEditFieldId('tStage')}>
                   <label className="text-sm font-medium mb-1 block">T</label>
-                  <Select
-                    value={watch('tStage') || ''}
-                    onValueChange={(value) => {
-                      if (value === '') {
-                        setValue('tStage', undefined, { shouldValidate: true });
-                      } else {
-                        setValue(
-                          'tStage',
-                          value as (typeof T_STAGE_VALUES)[number],
-                          { shouldValidate: true }
-                        );
-                      }
-                    }}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="T" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {T_STAGE_VALUES.map((value) => (
-                        <SelectItem key={value} value={value}>
-                          {value}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <Controller
+                    name="tStage"
+                    control={control}
+                    render={({ field }) => (
+                      <Select
+                        value={field.value ?? ''}
+                        onValueChange={(value) => {
+                          field.onChange(
+                            value === ''
+                              ? undefined
+                              : (value as (typeof T_STAGE_VALUES)[number])
+                          );
+                        }}
+                      >
+                        <SelectTrigger
+                          ref={field.ref}
+                          name={field.name}
+                          onBlur={field.onBlur}
+                          aria-invalid={!!errors.tStage}
+                          className={cn(
+                            errors.tStage &&
+                              'border-destructive ring-1 ring-destructive'
+                          )}
+                        >
+                          <SelectValue placeholder="T" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {T_STAGE_VALUES.map((value) => (
+                            <SelectItem key={value} value={value}>
+                              {value}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    )}
+                  />
                   {errors.tStage && (
                     <p className="text-sm text-destructive mt-1">
-                      {errors.tStage.message}
+                      {fieldErrorText(errors.tStage)}
                     </p>
                   )}
                 </div>
 
-                <div>
+                <div id={patientEditFieldId('nStage')}>
                   <label className="text-sm font-medium mb-1 block">N</label>
-                  <Select
-                    value={watch('nStage') || ''}
-                    onValueChange={(value) => {
-                      if (value === '') {
-                        setValue('nStage', undefined, { shouldValidate: true });
-                      } else {
-                        setValue(
-                          'nStage',
-                          value as (typeof N_STAGE_VALUES)[number],
-                          { shouldValidate: true }
-                        );
-                      }
-                    }}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="N" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {N_STAGE_VALUES.map((value) => (
-                        <SelectItem key={value} value={value}>
-                          {value}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <Controller
+                    name="nStage"
+                    control={control}
+                    render={({ field }) => (
+                      <Select
+                        value={field.value ?? ''}
+                        onValueChange={(value) => {
+                          field.onChange(
+                            value === ''
+                              ? undefined
+                              : (value as (typeof N_STAGE_VALUES)[number])
+                          );
+                        }}
+                      >
+                        <SelectTrigger
+                          ref={field.ref}
+                          name={field.name}
+                          onBlur={field.onBlur}
+                          aria-invalid={!!errors.nStage}
+                          className={cn(
+                            errors.nStage &&
+                              'border-destructive ring-1 ring-destructive'
+                          )}
+                        >
+                          <SelectValue placeholder="N" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {N_STAGE_VALUES.map((value) => (
+                            <SelectItem key={value} value={value}>
+                              {value}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    )}
+                  />
                   {errors.nStage && (
                     <p className="text-sm text-destructive mt-1">
-                      {errors.nStage.message}
+                      {fieldErrorText(errors.nStage)}
                     </p>
                   )}
                 </div>
 
-                <div>
+                <div id={patientEditFieldId('mStage')}>
                   <label className="text-sm font-medium mb-1 block">M</label>
-                  <Select
-                    value={watch('mStage') || ''}
-                    onValueChange={(value) => {
-                      if (value === '') {
-                        setValue('mStage', undefined, { shouldValidate: true });
-                      } else {
-                        setValue(
-                          'mStage',
-                          value as (typeof M_STAGE_VALUES)[number],
-                          { shouldValidate: true }
-                        );
-                      }
-                    }}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="M" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {M_STAGE_VALUES.map((value) => (
-                        <SelectItem key={value} value={value}>
-                          {value}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <Controller
+                    name="mStage"
+                    control={control}
+                    render={({ field }) => (
+                      <Select
+                        value={field.value ?? ''}
+                        onValueChange={(value) => {
+                          field.onChange(
+                            value === ''
+                              ? undefined
+                              : (value as (typeof M_STAGE_VALUES)[number])
+                          );
+                        }}
+                      >
+                        <SelectTrigger
+                          ref={field.ref}
+                          name={field.name}
+                          onBlur={field.onBlur}
+                          aria-invalid={!!errors.mStage}
+                          className={cn(
+                            errors.mStage &&
+                              'border-destructive ring-1 ring-destructive'
+                          )}
+                        >
+                          <SelectValue placeholder="M" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {M_STAGE_VALUES.map((value) => (
+                            <SelectItem key={value} value={value}>
+                              {value}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    )}
+                  />
                   {errors.mStage && (
                     <p className="text-sm text-destructive mt-1">
-                      {errors.mStage.message}
+                      {fieldErrorText(errors.mStage)}
                     </p>
                   )}
                 </div>
 
-                <div>
+                <div id={patientEditFieldId('grade')}>
                   <label className="text-sm font-medium mb-1 block">Grau</label>
-                  <Select
-                    value={watch('grade') || ''}
-                    onValueChange={(value) => {
-                      if (value === '') {
-                        setValue('grade', undefined, { shouldValidate: true });
-                      } else {
-                        setValue(
-                          'grade',
-                          value as (typeof GRADE_VALUES)[number],
-                          { shouldValidate: true }
-                        );
-                      }
-                    }}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Grau" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {GRADE_VALUES.map((value) => (
-                        <SelectItem key={value} value={value}>
-                          {value}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <Controller
+                    name="grade"
+                    control={control}
+                    render={({ field }) => (
+                      <Select
+                        value={field.value ?? ''}
+                        onValueChange={(value) => {
+                          field.onChange(
+                            value === ''
+                              ? undefined
+                              : (value as (typeof GRADE_VALUES)[number])
+                          );
+                        }}
+                      >
+                        <SelectTrigger
+                          ref={field.ref}
+                          name={field.name}
+                          onBlur={field.onBlur}
+                          aria-invalid={!!errors.grade}
+                          className={cn(
+                            errors.grade &&
+                              'border-destructive ring-1 ring-destructive'
+                          )}
+                        >
+                          <SelectValue placeholder="Grau" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {GRADE_VALUES.map((value) => (
+                            <SelectItem key={value} value={value}>
+                              {value}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    )}
+                  />
                   {errors.grade && (
                     <p className="text-sm text-destructive mt-1">
-                      {errors.grade.message}
+                      {fieldErrorText(errors.grade)}
                     </p>
                   )}
                 </div>
@@ -1187,62 +1468,119 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
                 {`O campo "Estágio" acima será calculado automaticamente a partir dos campos TNM preenchidos.`}
               </p>
 
-              <div>
+              <div id={patientEditFieldId('diagnosisDate')}>
                 <label className="text-sm font-medium mb-2 block">
                   Data de Diagnóstico
-                  {currentStage !== 'SCREENING' && ' *'}
+                  {needsOncologyCoreFields && ' *'}
                 </label>
-                <Input type="date" {...register('diagnosisDate')} />
+                <Input
+                  type="date"
+                  {...register('diagnosisDate')}
+                  aria-invalid={!!errors.diagnosisDate}
+                  className={cn(errors.diagnosisDate && 'border-destructive')}
+                />
                 {errors.diagnosisDate && (
                   <p className="text-sm text-destructive mt-1">
-                    {errors.diagnosisDate.message}
+                    {fieldErrorText(errors.diagnosisDate)}
                   </p>
                 )}
               </div>
 
-              <div>
+              <div id={patientEditFieldId('performanceStatus')}>
                 <label className="text-sm font-medium mb-2 block">
-                  Performance Status
+                  Performance Status (ECOG)
+                  {needsOncologyCoreFields && ' *'}
                 </label>
-                <Select
-                  value={
-                    watch('performanceStatus') !== null &&
-                    watch('performanceStatus') !== undefined
-                      ? String(watch('performanceStatus'))
-                      : ''
-                  }
-                  onValueChange={(value) => {
-                    if (value === '' || value === undefined) {
-                      setValue('performanceStatus', undefined, {
-                        shouldValidate: true,
-                      });
-                    } else {
-                      const numValue = parseInt(value, 10);
-                      if (!isNaN(numValue)) {
-                        setValue('performanceStatus', numValue, {
-                          shouldValidate: true,
-                        });
+                <Controller
+                  name="performanceStatus"
+                  control={control}
+                  render={({ field }) => (
+                    <Select
+                      value={
+                        field.value !== null && field.value !== undefined
+                          ? String(field.value)
+                          : ''
                       }
-                    }
-                  }}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Selecione o status" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="0">ECOG 0</SelectItem>
-                    <SelectItem value="1">ECOG 1</SelectItem>
-                    <SelectItem value="2">ECOG 2</SelectItem>
-                    <SelectItem value="3">ECOG 3</SelectItem>
-                    <SelectItem value="4">ECOG 4</SelectItem>
-                  </SelectContent>
-                </Select>
+                      onValueChange={(value) => {
+                        if (value === '' || value === undefined) {
+                          field.onChange(undefined);
+                        } else {
+                          const numValue = parseInt(value, 10);
+                          if (!isNaN(numValue)) field.onChange(numValue);
+                        }
+                      }}
+                    >
+                      <SelectTrigger
+                        ref={field.ref}
+                        name={field.name}
+                        onBlur={field.onBlur}
+                        aria-invalid={!!errors.performanceStatus}
+                        className={cn(
+                          errors.performanceStatus &&
+                            'border-destructive ring-1 ring-destructive'
+                        )}
+                      >
+                        <SelectValue placeholder="Selecione o status" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="0">ECOG 0</SelectItem>
+                        <SelectItem value="1">ECOG 1</SelectItem>
+                        <SelectItem value="2">ECOG 2</SelectItem>
+                        <SelectItem value="3">ECOG 3</SelectItem>
+                        <SelectItem value="4">ECOG 4</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  )}
+                />
                 {errors.performanceStatus && (
                   <p className="text-sm text-destructive mt-1">
-                    {errors.performanceStatus.message}
+                    {fieldErrorText(errors.performanceStatus)}
                   </p>
                 )}
               </div>
+
+              {needsTreatmentField && (
+                <div id={patientEditFieldId('currentTreatment')}>
+                  <label className="text-sm font-medium mb-2 block">
+                    Tratamento atual *
+                  </label>
+                  <Controller
+                    name="currentTreatment"
+                    control={control}
+                    render={({ field }) => (
+                      <Select
+                        value={field.value ?? ''}
+                        onValueChange={(value) => field.onChange(value)}
+                      >
+                        <SelectTrigger
+                          ref={field.ref}
+                          name={field.name}
+                          onBlur={field.onBlur}
+                          aria-invalid={!!errors.currentTreatment}
+                          className={cn(
+                            errors.currentTreatment &&
+                              'border-destructive ring-1 ring-destructive'
+                          )}
+                        >
+                          <SelectValue placeholder="Selecione o tratamento" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {treatmentOptions.map((opt) => (
+                            <SelectItem key={opt} value={opt}>
+                              {opt}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    )}
+                  />
+                  {errors.currentTreatment && (
+                    <p className="text-sm text-destructive mt-1">
+                      {fieldErrorText(errors.currentTreatment)}
+                    </p>
+                  )}
+                </div>
+              )}
             </div>
           </CardContent>
         </Card>
@@ -1279,7 +1617,13 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
               }
             />
 
-            <div>
+            <div
+              id={patientEditFieldId('comorbidities')}
+              className={cn(
+                errors.comorbidities &&
+                  'rounded-md p-1 ring-2 ring-destructive ring-offset-2'
+              )}
+            >
               <ComorbiditiesForm
                 value={watch('comorbidities') as any}
                 onChange={(comorbidities) =>
@@ -1288,12 +1632,18 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
               />
               {errors.comorbidities && (
                 <p className="text-sm text-destructive mt-1">
-                  {errors.comorbidities.message}
+                  {fieldErrorText(errors.comorbidities)}
                 </p>
               )}
             </div>
 
-            <div>
+            <div
+              id={patientEditFieldId('currentMedications')}
+              className={cn(
+                errors.currentMedications &&
+                  'rounded-md p-1 ring-2 ring-destructive ring-offset-2'
+              )}
+            >
               <CurrentMedicationsForm
                 value={watch('currentMedications') as any}
                 onChange={(currentMedications) =>
@@ -1302,12 +1652,18 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
               />
               {errors.currentMedications && (
                 <p className="text-sm text-destructive mt-1">
-                  {errors.currentMedications.message}
+                  {fieldErrorText(errors.currentMedications)}
                 </p>
               )}
             </div>
 
-            <div>
+            <div
+              id={patientEditFieldId('familyHistory')}
+              className={cn(
+                errors.familyHistory &&
+                  'rounded-md p-1 ring-2 ring-destructive ring-offset-2'
+              )}
+            >
               <FamilyHistoryForm
                 value={watch('familyHistory') as any}
                 onChange={(familyHistory) =>
@@ -1316,7 +1672,7 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
               />
               {errors.familyHistory && (
                 <p className="text-sm text-destructive mt-1">
-                  {errors.familyHistory.message}
+                  {fieldErrorText(errors.familyHistory)}
                 </p>
               )}
             </div>
@@ -1339,17 +1695,19 @@ export function PatientEditPage({ patientId }: PatientEditPageProps) {
             <CardTitle>Integração EHR (Opcional)</CardTitle>
           </CardHeader>
           <CardContent>
-            <div>
+            <div id={patientEditFieldId('ehrPatientId')}>
               <label className="text-sm font-medium mb-2 block">
                 ID do Paciente no EHR
               </label>
               <Input
                 {...register('ehrPatientId')}
                 placeholder="ID do paciente no sistema EHR"
+                aria-invalid={!!errors.ehrPatientId}
+                className={cn(errors.ehrPatientId && 'border-destructive')}
               />
               {errors.ehrPatientId && (
                 <p className="text-sm text-destructive mt-1">
-                  {errors.ehrPatientId.message}
+                  {fieldErrorText(errors.ehrPatientId)}
                 </p>
               )}
             </div>

--- a/frontend/src/components/patients/structured-clinical-risks-form.tsx
+++ b/frontend/src/components/patients/structured-clinical-risks-form.tsx
@@ -54,12 +54,12 @@ export interface AllergyEntryForm {
 }
 
 interface StructuredClinicalRisksFormProps {
-  smokingProfile?: SmokingProfileForm;
-  alcoholProfile?: AlcoholProfileForm;
-  occupationalExposureEntries?: OccupationalExposureEntryForm[];
-  allergyEntries?: AllergyEntryForm[];
+  smokingProfile?: SmokingProfileForm | null;
+  alcoholProfile?: AlcoholProfileForm | null;
+  occupationalExposureEntries?: OccupationalExposureEntryForm[] | null;
+  allergyEntries?: AllergyEntryForm[] | null;
   /** Texto livre complementar (legado / observações gerais). */
-  allergyNotes?: string;
+  allergyNotes?: string | null;
   onSmokingProfileChange: (v: SmokingProfileForm | undefined) => void;
   onAlcoholProfileChange: (v: AlcoholProfileForm | undefined) => void;
   onOccupationalEntriesChange: (v: OccupationalExposureEntryForm[]) => void;
@@ -68,28 +68,34 @@ interface StructuredClinicalRisksFormProps {
 }
 
 export function StructuredClinicalRisksForm({
-  smokingProfile = {},
-  alcoholProfile = {},
-  occupationalExposureEntries = [],
-  allergyEntries = [],
-  allergyNotes = '',
+  smokingProfile,
+  alcoholProfile,
+  occupationalExposureEntries,
+  allergyEntries,
+  allergyNotes,
   onSmokingProfileChange,
   onAlcoholProfileChange,
   onOccupationalEntriesChange,
   onAllergyEntriesChange,
   onAllergyNotesChange,
 }: StructuredClinicalRisksFormProps) {
+  const smoking = smokingProfile ?? {};
+  const alcohol = alcoholProfile ?? {};
+  const occEntries = occupationalExposureEntries ?? [];
+  const allergies = allergyEntries ?? [];
+  const allergyNotesSafe = allergyNotes ?? '';
+
   const patchSmoking = (partial: Partial<SmokingProfileForm>) => {
-    onSmokingProfileChange({ ...smokingProfile, ...partial });
+    onSmokingProfileChange({ ...smoking, ...partial });
   };
 
   const patchAlcohol = (partial: Partial<AlcoholProfileForm>) => {
-    onAlcoholProfileChange({ ...alcoholProfile, ...partial });
+    onAlcoholProfileChange({ ...alcohol, ...partial });
   };
 
   const addOcc = () => {
     onOccupationalEntriesChange([
-      ...occupationalExposureEntries,
+      ...occEntries,
       { agent: '', yearsApprox: undefined, notes: '' },
     ]);
   };
@@ -99,20 +105,20 @@ export function StructuredClinicalRisksForm({
     field: keyof OccupationalExposureEntryForm,
     val: unknown
   ) => {
-    const next = [...occupationalExposureEntries];
+    const next = [...occEntries];
     next[index] = { ...next[index], [field]: val };
     onOccupationalEntriesChange(next);
   };
 
   const removeOcc = (index: number) => {
     onOccupationalEntriesChange(
-      occupationalExposureEntries.filter((_, i) => i !== index)
+      occEntries.filter((_, i) => i !== index)
     );
   };
 
   const addAllergy = () => {
     onAllergyEntriesChange([
-      ...allergyEntries,
+      ...allergies,
       { substanceKey: '', customLabel: '', reactionNotes: '' },
     ]);
   };
@@ -122,7 +128,7 @@ export function StructuredClinicalRisksForm({
     field: keyof AllergyEntryForm,
     val: string
   ) => {
-    const next = [...allergyEntries];
+    const next = [...allergies];
     next[index] = { ...next[index], [field]: val };
     if (field === 'substanceKey' && val !== 'OTHER') {
       next[index].customLabel = '';
@@ -131,7 +137,7 @@ export function StructuredClinicalRisksForm({
   };
 
   const removeAllergy = (index: number) => {
-    onAllergyEntriesChange(allergyEntries.filter((_, i) => i !== index));
+    onAllergyEntriesChange(allergies.filter((_, i) => i !== index));
   };
 
   return (
@@ -142,7 +148,7 @@ export function StructuredClinicalRisksForm({
           <div>
             <Label className="text-xs">Situação</Label>
             <Select
-              value={smokingProfile.status ?? ''}
+              value={smoking.status ?? ''}
               onValueChange={(v) =>
                 patchSmoking({
                   status: v ? (v as SmokingStatus) : undefined,
@@ -168,9 +174,9 @@ export function StructuredClinicalRisksForm({
               step={0.1}
               placeholder="Opcional"
               value={
-                smokingProfile.packYears === undefined
+                smoking.packYears === undefined
                   ? ''
-                  : String(smokingProfile.packYears)
+                  : String(smoking.packYears)
               }
               onChange={(e) => {
                 const raw = e.target.value;
@@ -187,9 +193,9 @@ export function StructuredClinicalRisksForm({
               min={0}
               placeholder="Se ex-fumante"
               value={
-                smokingProfile.yearsQuit === undefined
+                smoking.yearsQuit === undefined
                   ? ''
-                  : String(smokingProfile.yearsQuit)
+                  : String(smoking.yearsQuit)
               }
               onChange={(e) => {
                 const raw = e.target.value;
@@ -202,7 +208,7 @@ export function StructuredClinicalRisksForm({
           <div className="md:col-span-2">
             <Label className="text-xs">Notas</Label>
             <Input
-              value={smokingProfile.notes ?? ''}
+              value={smoking.notes ?? ''}
               onChange={(e) => patchSmoking({ notes: e.target.value })}
               placeholder="Observações sobre tabagismo"
             />
@@ -216,7 +222,7 @@ export function StructuredClinicalRisksForm({
           <div>
             <Label className="text-xs">Padrão</Label>
             <Select
-              value={alcoholProfile.status ?? ''}
+              value={alcohol.status ?? ''}
               onValueChange={(v) =>
                 patchAlcohol({
                   status: v ? (v as AlcoholStatus) : undefined,
@@ -242,9 +248,9 @@ export function StructuredClinicalRisksForm({
               min={0}
               placeholder="Opcional"
               value={
-                alcoholProfile.drinksPerWeek === undefined
+                alcohol.drinksPerWeek === undefined
                   ? ''
-                  : String(alcoholProfile.drinksPerWeek)
+                  : String(alcohol.drinksPerWeek)
               }
               onChange={(e) => {
                 const raw = e.target.value;
@@ -257,7 +263,7 @@ export function StructuredClinicalRisksForm({
           <div className="md:col-span-2">
             <Label className="text-xs">Notas</Label>
             <Input
-              value={alcoholProfile.notes ?? ''}
+              value={alcohol.notes ?? ''}
               onChange={(e) => patchAlcohol({ notes: e.target.value })}
               placeholder="Observações sobre etilismo"
             />
@@ -273,13 +279,13 @@ export function StructuredClinicalRisksForm({
             Adicionar
           </Button>
         </div>
-        {occupationalExposureEntries.length === 0 ? (
+        {occEntries.length === 0 ? (
           <p className="text-sm text-muted-foreground">
             Nenhuma exposição registrada.
           </p>
         ) : (
           <div className="space-y-2">
-            {occupationalExposureEntries.map((row, index) => (
+            {occEntries.map((row, index) => (
               <div
                 key={index}
                 className="flex flex-wrap gap-2 items-end p-2 border rounded-md bg-background"
@@ -350,14 +356,14 @@ export function StructuredClinicalRisksForm({
           Selecione a substância; a categoria é atribuída automaticamente. Use
           &quot;Outra&quot; para especificar texto livre.
         </p>
-        {allergyEntries.length === 0 ? (
+        {allergies.length === 0 ? (
           <p className="text-sm text-muted-foreground">
             Nenhuma alergia listada. Adicione ou informe apenas observações
             abaixo.
           </p>
         ) : (
           <div className="space-y-3">
-            {allergyEntries.map((row, index) => {
+            {allergies.map((row, index) => {
               const cat =
                 row.substanceKey &&
                 ALLERGY_SUBSTANCE_CATALOG[row.substanceKey]?.category;
@@ -430,7 +436,7 @@ export function StructuredClinicalRisksForm({
             Observações adicionais sobre alergias (opcional)
           </Label>
           <Textarea
-            value={allergyNotes}
+            value={allergyNotesSafe}
             onChange={(e) => onAllergyNotesChange(e.target.value)}
             placeholder="Notas gerais, intolerâncias ou detalhes não listados acima"
             rows={3}

--- a/frontend/src/lib/api/patients.ts
+++ b/frontend/src/lib/api/patients.ts
@@ -575,6 +575,39 @@ export interface ImportSpreadsheetResult {
   errors: Array<{ row: number; errors: string[] }>;
 }
 
+/** Garante objeto paciente mesmo com `{ data: patient }` ou aninhamento acidental. */
+function unwrapPatientDetailPayload(raw: unknown): PatientDetail {
+  const looksLikePatient = (x: unknown): x is PatientDetail =>
+    !!x &&
+    typeof x === 'object' &&
+    'id' in x &&
+    'name' in x &&
+    typeof (x as { name?: unknown }).name === 'string';
+
+  if (looksLikePatient(raw)) {
+    return raw;
+  }
+  let current: unknown = raw;
+  for (let depth = 0; depth < 3; depth++) {
+    if (current && typeof current === 'object' && 'data' in current) {
+      const inner = (current as { data: unknown }).data;
+      if (looksLikePatient(inner)) {
+        return inner;
+      }
+      current = inner;
+    } else {
+      break;
+    }
+  }
+  if (process.env.NODE_ENV === 'development') {
+    console.warn(
+      '[patientsApi.getDetail] Payload inesperado; campos podem ficar vazios no formulário.',
+      raw
+    );
+  }
+  return raw as PatientDetail;
+}
+
 export const patientsApi = {
   async getAll(): Promise<Patient[]> {
     const data = await apiClient.get<Patient[] | null>('/patients');
@@ -586,14 +619,8 @@ export const patientsApi = {
   },
 
   async getDetail(id: string): Promise<PatientDetail> {
-    const response = await apiClient.get<
-      { data: PatientDetail } | PatientDetail
-    >(`/patients/${id}/detail`);
-    // Backend retorna { data: patient }; garantir que retornamos o objeto paciente
-    if (response && typeof response === 'object' && 'data' in response) {
-      return (response as { data: PatientDetail }).data;
-    }
-    return response as PatientDetail;
+    const response = await apiClient.get<unknown>(`/patients/${id}/detail`);
+    return unwrapPatientDetailPayload(response);
   },
 
   async create(data: CreatePatientDto): Promise<Patient> {

--- a/frontend/src/lib/utils/__tests__/form-field-errors.test.ts
+++ b/frontend/src/lib/utils/__tests__/form-field-errors.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { editPatientSchema } from '@/lib/validations/patient';
+import {
+  collectAllFormErrorMessages,
+  messagesFromZodError,
+} from '../form-field-errors';
+
+describe('collectAllFormErrorMessages', () => {
+  it('expande vários "Required" do Zod em mensagens por campo', () => {
+    const errs = {
+      name: { type: 'invalid_type', message: 'Required' },
+      birthDate: { type: 'invalid_type', message: 'Required' },
+    };
+    const msgs = collectAllFormErrorMessages(errs);
+    expect(msgs).toContain('Nome completo: preenchimento obrigatório');
+    expect(msgs).toContain('Data de nascimento: preenchimento obrigatório');
+    expect(msgs.length).toBe(2);
+  });
+
+  it('preserva mensagens customizadas do Zod', () => {
+    const errs = {
+      email: { type: 'custom', message: 'Email inválido' },
+    };
+    expect(collectAllFormErrorMessages(errs)).toEqual(['Email inválido']);
+  });
+});
+
+describe('messagesFromZodError', () => {
+  it('lista um item por issue do Zod (núcleo oncológico)', () => {
+    const parsed = editPatientSchema.safeParse({
+      name: 'Maria Silva',
+      birthDate: '1980-06-15',
+      phone: '',
+      email: '',
+      currentStage: 'DIAGNOSIS',
+      cancerType: undefined,
+      diagnosisDate: '',
+      stage: '',
+      performanceStatus: undefined,
+    });
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      const msgs = messagesFromZodError(parsed.error);
+      expect(msgs.length).toBeGreaterThanOrEqual(3);
+      expect(msgs.some((m) => /tipo de câncer/i.test(m))).toBe(true);
+      expect(msgs.some((m) => /diagnóstico/i.test(m))).toBe(true);
+    }
+  });
+});

--- a/frontend/src/lib/utils/form-field-errors.ts
+++ b/frontend/src/lib/utils/form-field-errors.ts
@@ -1,0 +1,176 @@
+import type { FieldErrors, FieldValues } from 'react-hook-form';
+import type { ZodError } from 'zod';
+
+/** Rótulos PT por segmento de path (evita toast genérico em "Required"). */
+const SEGMENT_LABEL_PT: Record<string, string> = {
+  name: 'Nome',
+  birthDate: 'Data de nascimento',
+  phone: 'Telefone',
+  email: 'E-mail',
+  gender: 'Sexo',
+  cpf: 'CPF',
+  currentStage: 'Estágio da jornada',
+  cancerType: 'Tipo de câncer',
+  stage: 'Estágio (TNM)',
+  diagnosisDate: 'Data do diagnóstico',
+  performanceStatus: 'Performance status (ECOG)',
+  currentTreatment: 'Tratamento atual',
+  tStage: 'TNM — T',
+  nStage: 'TNM — N',
+  mStage: 'TNM — M',
+  grade: 'Grau',
+  comorbidities: 'Comorbidades',
+  currentMedications: 'Medicamentos em uso',
+  allergyEntries: 'Alergia',
+  allergies: 'Observações de alergias',
+  familyHistory: 'História familiar',
+  smokingProfile: 'Tabagismo',
+  alcoholProfile: 'Álcool',
+  occupationalExposureEntries: 'Exposição ocupacional',
+  ehrPatientId: 'ID do paciente no EHR',
+  priorSurgeries: 'Cirurgia prévia',
+  priorHospitalizations: 'Internação prévia',
+  relationship: 'Parentesco',
+  substanceKey: 'Substância',
+  customLabel: 'Nome (outra substância)',
+  reactionNotes: 'Reação',
+  catalogKey: 'Medicamento (catálogo)',
+  dosage: 'Dose',
+  frequency: 'Frequência',
+  indication: 'Indicação',
+  type: 'Tipo',
+  severity: 'Gravidade',
+  procedureName: 'Procedimento',
+  summary: 'Resumo',
+};
+
+function labelForPath(path: string[]): string {
+  if (path.length === 0) return 'Campo';
+
+  if (path.length === 1) {
+    const k = path[0];
+    if (k === 'name') return 'Nome completo';
+    return SEGMENT_LABEL_PT[k] ?? k;
+  }
+
+  const [a, b, c] = path;
+
+  const indexed = (
+    blockSingular: string,
+    indexStr: string | undefined,
+    leafKey?: string
+  ) => {
+    if (!indexStr || !/^\d+$/.test(indexStr)) return blockSingular;
+    const line = Number(indexStr) + 1;
+    const leaf = leafKey ? (SEGMENT_LABEL_PT[leafKey] ?? leafKey) : '';
+    return leaf
+      ? `${blockSingular} (linha ${line}) — ${leaf}`
+      : `${blockSingular} (linha ${line})`;
+  };
+
+  if (a === 'comorbidities') return indexed('Comorbidade', b, c);
+  if (a === 'familyHistory') return indexed('História familiar', b, c);
+  if (a === 'allergyEntries') return indexed('Alergia', b, c);
+  if (a === 'currentMedications') return indexed('Medicamento', b, c);
+  if (a === 'occupationalExposureEntries')
+    return indexed('Exposição ocupacional', b, c);
+  if (a === 'priorSurgeries') return indexed('Cirurgia prévia', b, c);
+  if (a === 'priorHospitalizations') return indexed('Internação prévia', b, c);
+
+  const leaf = path[path.length - 1];
+  return SEGMENT_LABEL_PT[leaf] ?? path.join(' › ');
+}
+
+function isZodRequiredMessage(msg: string): boolean {
+  const t = msg.trim();
+  if (t === 'Required' || /^required$/i.test(t)) return true;
+  // Zod PT / mensagens curtas de tipo ausente
+  if (/^expected/i.test(t) && /required/i.test(t)) return true;
+  return false;
+}
+
+type LeafError = { path: string[]; message: string };
+
+function collectLeafErrors(err: unknown, pathPrefix: string[]): LeafError[] {
+  const out: LeafError[] = [];
+  if (err == null || typeof err !== 'object') return out;
+
+  if (Array.isArray(err)) {
+    for (let i = 0; i < err.length; i++) {
+      out.push(...collectLeafErrors(err[i], [...pathPrefix, String(i)]));
+    }
+    return out;
+  }
+
+  const rec = err as Record<string, unknown>;
+  if (typeof rec.message === 'string' && rec.message.length > 0) {
+    out.push({ path: pathPrefix, message: rec.message });
+    return out;
+  }
+
+  // RHF: alguns resolvers guardam texto só em `types`
+  if (rec.types && typeof rec.types === 'object' && !Array.isArray(rec.types)) {
+    for (const v of Object.values(rec.types as Record<string, unknown>)) {
+      if (typeof v === 'string' && v.length > 0) {
+        out.push({ path: pathPrefix, message: v });
+      }
+    }
+    if (out.length > 0) return out;
+  }
+
+  for (const [k, v] of Object.entries(rec)) {
+    if (k === 'ref' || k === 'type' || k === 'types') continue;
+    out.push(...collectLeafErrors(v, [...pathPrefix, k]));
+  }
+  return out;
+}
+
+function formatLeafError(e: LeafError): string {
+  const msg = e.message.trim();
+  if (isZodRequiredMessage(msg)) {
+    return `${labelForPath(e.path)}: preenchimento obrigatório`;
+  }
+  return msg;
+}
+
+/**
+ * Mensagens para toast — uma entrada por campo; vários "Required" do Zod
+ * viram linhas distintas com o nome do campo, em vez de um texto genérico único.
+ */
+export function collectAllFormErrorMessages<T extends FieldValues>(
+  errs: FieldErrors<T>
+): string[] {
+  const leaves = collectLeafErrors(errs, []);
+  const formatted = leaves.map(formatLeafError);
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const f of formatted) {
+    if (!seen.has(f)) {
+      seen.add(f);
+      out.push(f);
+    }
+  }
+  return out;
+}
+
+/**
+ * Lista de mensagens a partir do `ZodError` (parse falhou).
+ * Preferir isto no `onInvalid` do formulário: o objeto `errors` do RHF pode
+ * omitir ou fundir issues; o Zod lista todas com `path` confiável.
+ */
+export function messagesFromZodError(zerr: ZodError): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const issue of zerr.issues) {
+    const path = issue.path.map((p) => String(p));
+    const raw = issue.message.trim();
+    const line = isZodRequiredMessage(raw)
+      ? `${labelForPath(path)}: preenchimento obrigatório`
+      : raw;
+    if (!seen.has(line)) {
+      seen.add(line);
+      out.push(line);
+    }
+  }
+  return out;
+}

--- a/frontend/src/lib/utils/journey-stage.ts
+++ b/frontend/src/lib/utils/journey-stage.ts
@@ -28,3 +28,24 @@ export const JOURNEY_STAGE_ORDER: Record<JourneyStage, number> = {
   FOLLOW_UP: 3,
   PALLIATIVE: 4,
 };
+
+/**
+ * Núcleo oncológico (tipo, estadiamento/TNM, data do diagnóstico, ECOG) obrigatório
+ * em qualquer fase após Rastreamento — alinhado ao schema Zod em `validations/patient.ts`.
+ */
+export function requiresOncologyCoreFields(
+  stage: JourneyStage | string | undefined | null
+): boolean {
+  if (stage === undefined || stage === null || stage === '') return false;
+  const s = String(stage).trim().toUpperCase() as JourneyStage;
+  return s !== 'SCREENING';
+}
+
+/** Tratamento atual obrigatório apenas após o diagnóstico estar estabelecido na jornada. */
+export function requiresCurrentTreatmentField(
+  stage: JourneyStage | string | undefined | null
+): boolean {
+  if (stage === undefined || stage === null || stage === '') return false;
+  const s = String(stage).trim().toUpperCase() as JourneyStage;
+  return s === 'TREATMENT' || s === 'FOLLOW_UP' || s === 'PALLIATIVE';
+}

--- a/frontend/src/lib/utils/patient-form-anchors.ts
+++ b/frontend/src/lib/utils/patient-form-anchors.ts
@@ -1,0 +1,18 @@
+/** ID estável para scroll/destaque na validação (path RHF com `.` → `--`). */
+export function patientEditFieldId(path: string): string {
+  return `patient-edit-field-${path.replace(/\./g, '--')}`;
+}
+
+/** Faz scroll até o primeiro elemento existente (path completo ou prefixos). */
+export function scrollFieldPathIntoView(fieldPath: string): void {
+  if (typeof document === 'undefined') return;
+  const segments = fieldPath.split('.');
+  for (let len = segments.length; len >= 1; len--) {
+    const tryPath = segments.slice(0, len).join('.');
+    const el = document.getElementById(patientEditFieldId(tryPath));
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      return;
+    }
+  }
+}

--- a/frontend/src/lib/validations/__tests__/patient.test.ts
+++ b/frontend/src/lib/validations/__tests__/patient.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createPatientSchema } from '../patient';
+import { createPatientSchema, editPatientSchema } from '../patient';
 
 // Dados mínimos válidos para um paciente em Rastreamento
 const base = {
@@ -133,9 +133,21 @@ describe('createPatientSchema — validações cruzadas para TREATMENT', () => {
     expect(createPatientSchema.safeParse(followUp).success).toBe(true);
   });
 
-  it('aceita DIAGNOSIS sem campos de diagnóstico (validação não se aplica)', () => {
+  it('rejeita DIAGNOSIS sem núcleo oncológico (tipo, TNM, data, ECOG)', () => {
     const result = createPatientSchema.safeParse({ ...base, currentStage: 'DIAGNOSIS' });
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
+  });
+
+  it('aceita DIAGNOSIS com núcleo oncológico completo sem tratamento atual', () => {
+    const diagnosisOnly = {
+      ...base,
+      currentStage: 'DIAGNOSIS' as const,
+      cancerType: 'bladder' as const,
+      diagnosisDate: '2023-08-01',
+      stage: 'T2N0M0',
+      performanceStatus: 1,
+    };
+    expect(createPatientSchema.safeParse(diagnosisOnly).success).toBe(true);
   });
 });
 
@@ -161,5 +173,18 @@ describe('createPatientSchema — campos TNM opcionais', () => {
     (['M0', 'M1', 'Mx'] as const).forEach((mStage) => {
       expect(createPatientSchema.safeParse({ ...base, mStage }).success).toBe(true);
     });
+  });
+});
+
+describe('editPatientSchema — edição (telefone opcional)', () => {
+  it('aceita telefone vazio quando demais campos válidos (cadastro legado)', () => {
+    expect(
+      editPatientSchema.safeParse({ ...base, phone: '' }).success
+    ).toBe(true);
+  });
+
+  it('rejeita telefone preenchido com menos de 10 caracteres', () => {
+    const result = editPatientSchema.safeParse({ ...base, phone: '1199999' });
+    expect(result.success).toBe(false);
   });
 });

--- a/frontend/src/lib/validations/patient.ts
+++ b/frontend/src/lib/validations/patient.ts
@@ -5,6 +5,7 @@ import {
   M_STAGE_VALUES,
   GRADE_VALUES,
 } from './cancer-diagnosis';
+import { requiresCurrentTreatmentField, requiresOncologyCoreFields } from '@/lib/utils/journey-stage';
 
 /** Linha de comorbidade: pode estar em branco até o usuário preencher tipo/gravidade/nome. */
 export const comorbiditySchema = z.object({
@@ -35,23 +36,33 @@ export const priorHospitalizationItemSchema = z.object({
   notes: z.string().optional(),
 });
 
+const smokingProfileObjectSchema = z.object({
+  status: z.enum(['never', 'former', 'current', 'unknown']).optional(),
+  packYears: z.number().optional(),
+  yearsQuit: z.number().optional(),
+  notes: z.string().optional(),
+});
+
 const smokingProfileSchema = z
-  .object({
-    status: z.enum(['never', 'former', 'current', 'unknown']).optional(),
-    packYears: z.number().optional(),
-    yearsQuit: z.number().optional(),
-    notes: z.string().optional(),
-  })
+  .preprocess(
+    (v) => (v === null ? undefined : v),
+    smokingProfileObjectSchema
+  )
   .optional();
 
+const alcoholProfileObjectSchema = z.object({
+  status: z
+    .enum(['never', 'occasional', 'moderate', 'heavy', 'unknown'])
+    .optional(),
+  drinksPerWeek: z.number().optional(),
+  notes: z.string().optional(),
+});
+
 const alcoholProfileSchema = z
-  .object({
-    status: z
-      .enum(['never', 'occasional', 'moderate', 'heavy', 'unknown'])
-      .optional(),
-    drinksPerWeek: z.number().optional(),
-    notes: z.string().optional(),
-  })
+  .preprocess(
+    (v) => (v === null ? undefined : v),
+    alcoholProfileObjectSchema
+  )
   .optional();
 
 const occupationalExposureEntrySchema = z.object({
@@ -75,108 +86,123 @@ export const currentMedicationSchema = z.object({
   indication: z.string().optional(),
 });
 
-export const createPatientSchema = z
-  .object({
-    // Etapa 1 - Dados Básicos
-    name: z.string().min(2, 'Nome deve ter pelo menos 2 caracteres'),
-    cpf: z.string().optional(),
-    birthDate: z.string().min(1, 'Data de nascimento é obrigatória'),
-    gender: z.enum(['male', 'female', 'other']).optional(),
-    phone: z
-      .string()
-      .min(10, 'Telefone é obrigatório e deve ter pelo menos 10 dígitos'),
-    email: z.string().email('Email inválido').optional().or(z.literal('')),
+/** Campos comuns (cadastro e edição); `phone` é definido em cada schema final. */
+const patientFormSharedFields = {
+  // Etapa 1 - Dados Básicos
+  name: z.string().min(2, 'Nome deve ter pelo menos 2 caracteres'),
+  cpf: z.string().optional(),
+  birthDate: z.string().min(1, 'Data de nascimento é obrigatória'),
+  gender: z.enum(['male', 'female', 'other']).optional(),
+  email: z.preprocess(
+    (v) => (v === null || v === undefined ? '' : v),
+    z.union([z.literal(''), z.string().email('Email inválido')])
+  ),
 
-    // Etapa 2 - Dados Oncológicos Essenciais
-    cancerType: z
-      .enum([
-        'breast',
-        'lung',
-        'colorectal',
-        'prostate',
-        'kidney',
-        'bladder',
-        'testicular',
-        'other',
-      ])
-      .optional(),
-    stage: z.string().optional(),
-    // Campos TNM estruturados
-    tStage: z.enum(T_STAGE_VALUES).optional(),
-    nStage: z.enum(N_STAGE_VALUES).optional(),
-    mStage: z.enum(M_STAGE_VALUES).optional(),
-    grade: z.enum(GRADE_VALUES).optional(),
-    diagnosisDate: z.string().optional(),
-    performanceStatus: z.preprocess(
-      (val) =>
-        typeof val === 'number' && Number.isNaN(val) ? undefined : val,
-      z
-        .number()
-        .min(0)
-        .max(4, 'ECOG deve ser entre 0 e 4')
-        .optional()
-    ),
-    currentStage: z
-      .enum(['SCREENING', 'DIAGNOSIS', 'TREATMENT', 'FOLLOW_UP', 'PALLIATIVE'])
-      .default('SCREENING'),
+  // Etapa 2 - Dados Oncológicos Essenciais
+  cancerType: z
+    .enum([
+      'breast',
+      'lung',
+      'colorectal',
+      'prostate',
+      'kidney',
+      'bladder',
+      'testicular',
+      'other',
+    ])
+    .optional(),
+  stage: z.string().optional(),
+  // Campos TNM estruturados
+  tStage: z.enum(T_STAGE_VALUES).optional(),
+  nStage: z.enum(N_STAGE_VALUES).optional(),
+  mStage: z.enum(M_STAGE_VALUES).optional(),
+  grade: z.enum(GRADE_VALUES).optional(),
+  diagnosisDate: z.string().optional(),
+  performanceStatus: z.preprocess(
+    (val) =>
+      typeof val === 'number' && Number.isNaN(val) ? undefined : val,
+    z
+      .number()
+      .min(0)
+      .max(4, 'ECOG deve ser entre 0 e 4')
+      .optional()
+  ),
+  currentStage: z
+    .enum(['SCREENING', 'DIAGNOSIS', 'TREATMENT', 'FOLLOW_UP', 'PALLIATIVE'])
+    .default('SCREENING'),
 
-    // Tratamento atual (obrigatório em seguimento)
-    currentTreatment: z.string().optional(),
+  // Tratamento atual (obrigatório em seguimento)
+  currentTreatment: z.string().optional(),
 
-    // Comorbidades e Fatores de Risco
-    comorbidities: z.array(comorbiditySchema).optional(),
-    currentMedications: z.array(currentMedicationSchema).optional(),
-    smokingProfile: smokingProfileSchema,
-    alcoholProfile: alcoholProfileSchema,
-    occupationalExposureEntries: z
-      .array(occupationalExposureEntrySchema)
-      .optional(),
-    allergyEntries: z.array(allergyEntrySchema).optional(),
-    smokingHistory: z.string().optional(),
-    alcoholHistory: z.string().optional(),
-    occupationalExposure: z.string().optional(),
-    familyHistory: z.array(familyHistorySchema).optional(),
-    priorSurgeries: z.array(priorSurgeryItemSchema).optional(),
-    priorHospitalizations: z.array(priorHospitalizationItemSchema).optional(),
-    allergies: z.string().max(16000).optional(),
+  // Comorbidades e Fatores de Risco
+  comorbidities: z.array(comorbiditySchema).optional(),
+  currentMedications: z.array(currentMedicationSchema).optional(),
+  smokingProfile: smokingProfileSchema,
+  alcoholProfile: alcoholProfileSchema,
+  occupationalExposureEntries: z
+    .array(occupationalExposureEntrySchema)
+    .optional(),
+  allergyEntries: z.array(allergyEntrySchema).optional(),
+  smokingHistory: z.string().optional(),
+  alcoholHistory: z.string().optional(),
+  occupationalExposure: z.string().optional(),
+  familyHistory: z.array(familyHistorySchema).optional(),
+  priorSurgeries: z.array(priorSurgeryItemSchema).optional(),
+  priorHospitalizations: z.array(priorHospitalizationItemSchema).optional(),
+  allergies: z.string().max(16000).optional(),
 
-    // Etapa 3 - Integração EHR
-    ehrPatientId: z.string().optional(),
-  })
+  // Etapa 3 - Integração EHR
+  ehrPatientId: z.string().optional(),
+};
+
+const patientFormRefines = <T extends z.ZodTypeAny>(schema: T) =>
+  schema
+    .superRefine((data, ctx) => {
+      if (!requiresOncologyCoreFields(data.currentStage)) return;
+      const d = data as {
+        cancerType?: string | null;
+        diagnosisDate?: string | null;
+        stage?: string | null;
+        performanceStatus?: number | null | undefined;
+      };
+      if (!d.cancerType?.trim()) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['cancerType'],
+          message: 'Selecione o tipo de câncer.',
+        });
+      }
+      if (!d.diagnosisDate?.trim()) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['diagnosisDate'],
+          message: 'Informe a data do diagnóstico.',
+        });
+      }
+      if (!d.stage?.trim()) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['stage'],
+          message:
+            'Preencha o estadiamento TNM (T, N e M) para gerar o estágio, ou informe o estágio quando aplicável.',
+        });
+      }
+      if (d.performanceStatus === undefined || d.performanceStatus === null) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['performanceStatus'],
+          message: 'Selecione o Performance Status (ECOG).',
+        });
+      }
+    })
   .refine(
     (data) => {
-      // Em tratamento, seguimento ou paliativo: diagnóstico obrigatório (tipo, estágio TNM, data, ECOG)
-      const needsDiagnosis =
-        data.currentStage === 'TREATMENT' ||
-        data.currentStage === 'FOLLOW_UP' ||
-        data.currentStage === 'PALLIATIVE';
-      if (!needsDiagnosis) return true;
-      if (!data.cancerType?.trim()) return false;
-      if (!data.diagnosisDate?.trim()) return false;
-      if (!data.stage?.trim()) return false;
-      if (data.performanceStatus === undefined || data.performanceStatus === null)
-        return false;
-      return true;
-    },
-    {
-      message:
-        'Para pacientes em Tratamento ou Seguimento, preencha Tipo de Câncer, Estágio TNM, Data do Diagnóstico e Performance Status (ECOG).',
-      path: ['cancerType'],
-    }
-  )
-  .refine(
-    (data) => {
-      // Em tratamento, seguimento ou paliativo: tratamento obrigatório (em tratamento pode ser "A definir")
-      const needsTreatment =
-        data.currentStage === 'TREATMENT' ||
-        data.currentStage === 'FOLLOW_UP' ||
-        data.currentStage === 'PALLIATIVE';
-      if (!needsTreatment) return true;
+      if (!requiresCurrentTreatmentField(data.currentStage)) return true;
       return !!data.currentTreatment?.trim();
     },
     {
       message:
-        'Para pacientes em Tratamento ou Seguimento, informe o tratamento (ou "A definir").',
+        'Em Tratamento, Seguimento ou Cuidados Paliativos, informe o tratamento atual (ou "A definir").',
       path: ['currentTreatment'],
     }
   )
@@ -250,4 +276,33 @@ export const createPatientSchema = z
     }
   );
 
+/** Cadastro: telefone obrigatório (mín. 10 caracteres no campo). */
+export const createPatientSchema = patientFormRefines(
+  z.object({
+    ...patientFormSharedFields,
+    phone: z
+      .string()
+      .min(10, 'Telefone é obrigatório e deve ter pelo menos 10 dígitos'),
+  })
+);
+
+/** Edição: permite telefone vazio (paciente sem telefone no cadastro legado). */
+export const editPatientSchema = patientFormRefines(
+  z.object({
+    ...patientFormSharedFields,
+    // Normaliza null/undefined para '' — union sem preprocess falha com "Required" (Zod) quando o valor vem ausente.
+    phone: z.preprocess(
+      (v) => (v === null || v === undefined ? '' : v),
+      z.union([
+        z.literal(''),
+        z.string().min(
+          10,
+          'Telefone deve ter pelo menos 10 dígitos quando informado'
+        ),
+      ])
+    ),
+  })
+);
+
 export type CreatePatientFormData = z.infer<typeof createPatientSchema>;
+export type EditPatientFormData = z.infer<typeof editPatientSchema>;


### PR DESCRIPTION
## O quê
- Backend: inclusão de medicações ativas e comorbidades ordenadas na consulta do paciente (para alinhar cadastro/prontuário).
- Frontend: reforço das validações Zod (`patient.ts`), testes atualizados, utilitários de erro de campo e âncoras de formulário, ajustes em `patient-create-dialog` e `patient-edit-page`, formulários estruturados (comorbidades, medicações, histórico familiar, riscos clínicos), API client e estágios de jornada.

## Por quê
Melhorar consistência entre dados exibidos no cadastro e no prontuário e dar feedback de validação mais claro e navegável nos formulários de paciente.

## Como testar
- [ ] `cd frontend && npm test` (inclui `patient.test` e `form-field-errors.test`)
- [ ] Criar/editar paciente no fluxo de cadastro e edição; verificar mensagens de erro e rolagem/âncora aos campos inválidos.
- [ ] Confirmar que medicações ativas e comorbidades carregam corretamente na tela que consome o detalhe do paciente.

## Checklist
- [ ] Testes passando no frontend
- [ ] Queries/serviços com isolamento de tenant inalterado onde aplicável
- [ ] Sem inclusão de arquivos `.cursor/` ou planos locais no repositório

Made with [Cursor](https://cursor.com)