### PR TITLE
feat: paginação de pacientes, otimização do agente e textareas adaptativos

### DIFF
--- a/ai-service/src/agent/orchestrator.py
+++ b/ai-service/src/agent/orchestrator.py
@@ -53,6 +53,9 @@ class AgentOrchestrator:
         conversation_history = request.get("conversation_history", [])
         agent_state = request.get("agent_state", {})
         agent_config = request.get("agent_config") or {}
+        # Uma resolução por request — has_any_llm_key relê .env a cada chamada
+        has_llm_keys = llm_provider.has_any_llm_key(agent_config)
+        has_anthropic = llm_provider.has_anthropic_key(agent_config)
 
         patient_id = request.get("patient_id", "")
         tenant_id = request.get("tenant_id", "")
@@ -62,6 +65,8 @@ class AgentOrchestrator:
             result = await self._process_with_trace(
                 trace, message, clinical_context, protocol,
                 conversation_history, agent_state, agent_config,
+                has_llm_keys=has_llm_keys,
+                has_anthropic=has_anthropic,
             )
         except Exception as exc:
             tracer.finish_trace(trace, error=str(exc))
@@ -79,20 +84,26 @@ class AgentOrchestrator:
         conversation_history: List[Dict[str, str]],
         agent_state: Dict[str, Any],
         agent_config: Dict[str, Any],
+        *,
+        has_llm_keys: bool,
+        has_anthropic: bool,
     ) -> Dict[str, Any]:
         """Inner implementation of process(), called with an active trace."""
 
         # 1. Check if we're in a questionnaire flow
         if agent_state.get("active_questionnaire"):
             trace.pipeline_path = "questionnaire"
-            return await self._process_questionnaire_answer({
-                "message": message,
-                "clinical_context": clinical_context,
-                "protocol": protocol,
-                "conversation_history": conversation_history,
-                "agent_state": agent_state,
-                "agent_config": agent_config,
-            })
+            return await self._process_questionnaire_answer(
+                {
+                    "message": message,
+                    "clinical_context": clinical_context,
+                    "protocol": protocol,
+                    "conversation_history": conversation_history,
+                    "agent_state": agent_state,
+                    "agent_config": agent_config,
+                },
+                has_llm_keys=has_llm_keys,
+            )
 
         # 1.5. Classify intent for differentiated handling (with LLM fallback for ambiguous)
         span_intent = tracer.start_span(trace, "intent_classification")
@@ -111,7 +122,6 @@ class AgentOrchestrator:
                 trace.pipeline_path = "emergency"
                 # Run symptom analysis even for emergency path to register the symptom
                 cancer_type = clinical_context.get("patient", {}).get("cancerType")
-                has_llm_keys = llm_provider.has_any_llm_key(agent_config)
                 use_llm_analysis = agent_config.get("use_llm_symptom_analysis", True) and has_llm_keys
                 symptom_analysis = await symptom_analyzer.analyze(
                     message=message,
@@ -137,8 +147,6 @@ class AgentOrchestrator:
         # 2. Analyze symptoms (keyword + optional LLM for nuanced detection)
         cancer_type = clinical_context.get("patient", {}).get("cancerType")
         journey_stage = clinical_context.get("patient", {}).get("currentStage")
-        has_llm_keys = llm_provider.has_any_llm_key(agent_config)
-        has_anthropic = llm_provider.has_anthropic_key(agent_config)
         logger.info(
             "LLM key check: has_any=%s has_anthropic=%s agent_config_keys=%s",
             has_llm_keys, has_anthropic,
@@ -306,7 +314,7 @@ class AgentOrchestrator:
         }
 
     async def _process_questionnaire_answer(
-        self, request: Dict[str, Any]
+        self, request: Dict[str, Any], *, has_llm_keys: bool
     ) -> Dict[str, Any]:
         """Handle a message that's part of an active questionnaire flow."""
         agent_state = request.get("agent_state", {})
@@ -314,7 +322,7 @@ class AgentOrchestrator:
         message = request.get("message", "")
         questionnaire_progress = agent_state.get("active_questionnaire", {})
 
-        use_llm = llm_provider.has_any_llm_key(agent_config)
+        use_llm = has_llm_keys
 
         is_complete, updated_progress, next_content = await questionnaire_engine.process_answer(
             answer_text=message,

--- a/backend/prisma/migrations/20260412153805_add_patient_tenant_priority_created_index/migration.sql
+++ b/backend/prisma/migrations/20260412153805_add_patient_tenant_priority_created_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "patients_tenantId_priorityScore_createdAt_idx" ON "patients"("tenantId", "priorityScore", "createdAt");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -158,6 +158,8 @@ model Patient {
 
   @@index([tenantId])
   @@index([priorityScore])
+  /// Listagem por tenant ordenada por prioridade e data (findAll)
+  @@index([tenantId, priorityScore, createdAt])
   @@index([currentStage])
   @@index([status])
   @@index([ehrPatientId])

--- a/backend/src/patients/dto/query-patients.dto.ts
+++ b/backend/src/patients/dto/query-patients.dto.ts
@@ -1,0 +1,18 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+/** Query opcional para paginação de GET /patients (cap alinhado ao service: 100). */
+export class QueryPatientsDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  offset?: number;
+}

--- a/backend/src/patients/patients.controller.ts
+++ b/backend/src/patients/patients.controller.ts
@@ -12,6 +12,7 @@ import {
   UploadedFile,
   BadRequestException,
   ParseUUIDPipe,
+  Query,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { PatientsService } from './patients.service';
@@ -21,6 +22,7 @@ import { UpdatePriorityDto } from './dto/update-priority.dto';
 import { CreateCancerDiagnosisDto } from './dto/create-cancer-diagnosis.dto';
 import { UpdateCancerDiagnosisDto } from './dto/update-cancer-diagnosis.dto';
 import { ImportSpreadsheetDto } from './dto/import-spreadsheet.dto';
+import { QueryPatientsDto } from './dto/query-patients.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { TenantGuard } from '../auth/guards/tenant.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -49,8 +51,11 @@ export class PatientsController {
     UserRole.NURSE,
     UserRole.COORDINATOR
   )
-  findAll(@CurrentUser() user: any) {
-    return this.patientsService.findAll(user.tenantId);
+  findAll(@CurrentUser() user: any, @Query() query: QueryPatientsDto) {
+    return this.patientsService.findAll(user.tenantId, {
+      limit: query.limit,
+      offset: query.offset,
+    });
   }
 
   @Get('by-phone/:phone')

--- a/backend/src/patients/patients.service.spec.ts
+++ b/backend/src/patients/patients.service.spec.ts
@@ -131,14 +131,14 @@ describe('PatientsService', () => {
       expect((result[0] as any).pendingAlertsCount).toBe(3);
     });
 
-    it('deve respeitar o limite máximo de 500', async () => {
+    it('deve respeitar o limite máximo de 100', async () => {
       mockPrisma.patient.findMany.mockResolvedValue([]);
       mockPrisma.alert.groupBy.mockResolvedValue([]);
 
       await service.findAll(TENANT, { limit: 9999 });
 
       expect(mockPrisma.patient.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({ take: 500 })
+        expect.objectContaining({ take: 100 })
       );
     });
   });

--- a/backend/src/patients/patients.service.ts
+++ b/backend/src/patients/patients.service.ts
@@ -86,9 +86,9 @@ export class PatientsService {
     tenantId: string,
     options?: { limit?: number; offset?: number }
   ): Promise<Patient[]> {
-    // Limite padrão de 200 pacientes para evitar problemas de performance
+    // Cap 100 por página (performance); default 100
     const limit =
-      options?.limit && options.limit > 0 ? Math.min(options.limit, 500) : 200;
+      options?.limit && options.limit > 0 ? Math.min(options.limit, 100) : 100;
     const offset = options?.offset && options.offset > 0 ? options.offset : 0;
 
     const patients = await this.prisma.patient.findMany({

--- a/frontend/src/components/oncology-navigation/navigation-step-edit-panel.tsx
+++ b/frontend/src/components/oncology-navigation/navigation-step-edit-panel.tsx
@@ -21,7 +21,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
+import { AutoResizeTextarea } from '@/components/ui/auto-resize-textarea';
 import {
   Select,
   SelectContent,
@@ -385,12 +385,11 @@ export function NavigationStepEditPanel({
                 return (
                   <div key={field.key} className="space-y-2">
                     <Label htmlFor={fid}>{field.label}</Label>
-                    <Textarea
+                    <AutoResizeTextarea
                       id={fid}
                       value={stepDetail[field.key] ?? ''}
                       onChange={(e) => onStepDetailFieldChange(field.key, e.target.value)}
-                      rows={field.rows ?? 3}
-                      className="min-h-[72px] resize-y"
+                      minRows={field.rows ?? 3}
                     />
                     {field.helper ? (
                       <p className="text-xs text-muted-foreground">{field.helper}</p>
@@ -417,7 +416,7 @@ export function NavigationStepEditPanel({
                 ? 'Observações complementares (opcional)'
                 : 'Observações'}
             </Label>
-            <Textarea
+            <AutoResizeTextarea
               id={notesId}
               value={notes}
               onChange={(e) => onNotesChange(e.target.value)}
@@ -426,8 +425,7 @@ export function NavigationStepEditPanel({
                   ? 'Notas administrativas ou detalhes que não couberam nos campos da evolução…'
                   : 'Contexto clínico, próximos passos, orientações ao paciente…'
               }
-              rows={4}
-              className="min-h-[100px] resize-y"
+              minRows={4}
             />
           </div>
 

--- a/frontend/src/components/patients/patient-list-page.tsx
+++ b/frontend/src/components/patients/patient-list-page.tsx
@@ -1,24 +1,30 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { usePatients } from '@/hooks/usePatients';
 import { PatientFilters } from './patient-filters';
 import { PatientTable } from './patient-table';
 import { Button } from '@/components/ui/button';
 import { QueryErrorRetry } from '@/components/shared/query-error-retry';
-import { Plus, Upload } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Plus, Upload } from 'lucide-react';
 import { PatientImportDialog } from './patient-import-dialog';
 import { PatientCreateDialog } from './patient-create-dialog';
 import { Patient } from '@/lib/api/patients';
 
+const PATIENTS_PAGE_SIZE = 100;
+
 export function PatientListPage() {
+  const [page, setPage] = useState(1);
   const {
     data: patients = [],
     isLoading,
     error,
     refetch,
     isFetching,
-  } = usePatients();
+  } = usePatients({
+    limit: PATIENTS_PAGE_SIZE,
+    offset: (page - 1) * PATIENTS_PAGE_SIZE,
+  });
   const [searchTerm, setSearchTerm] = useState('');
   const [cancerTypeFilter, setCancerTypeFilter] = useState('all');
   const [stageFilter, setStageFilter] = useState('all');
@@ -26,6 +32,16 @@ export function PatientListPage() {
   const [navigationStageFilter, setNavigationStageFilter] = useState('all');
   const [showImportDialog, setShowImportDialog] = useState(false);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
+
+  useEffect(() => {
+    setPage(1);
+  }, [
+    searchTerm,
+    cancerTypeFilter,
+    stageFilter,
+    priorityFilter,
+    navigationStageFilter,
+  ]);
 
   const filteredPatients = useMemo(() => {
     if (!patients) return [];
@@ -135,8 +151,37 @@ export function PatientListPage() {
         </div>
       ) : (
         <div>
-          <div className="mb-4 text-sm text-muted-foreground">
-            {filteredPatients.length} paciente(s) encontrado(s)
+          <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+            <p className="text-sm text-muted-foreground">
+              {filteredPatients.length} paciente(s) nesta página
+              {page > 1 ? ` · página ${page}` : ''}
+            </p>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={page <= 1 || isFetching}
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                aria-label="Página anterior"
+              >
+                <ChevronLeft className="h-4 w-4" aria-hidden />
+                Anterior
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={
+                  patients.length < PATIENTS_PAGE_SIZE || isFetching
+                }
+                onClick={() => setPage((p) => p + 1)}
+                aria-label="Próxima página"
+              >
+                Próxima
+                <ChevronRight className="h-4 w-4" aria-hidden />
+              </Button>
+            </div>
           </div>
           <PatientTable patients={filteredPatients} />
         </div>

--- a/frontend/src/components/patients/patient-list-page.tsx
+++ b/frontend/src/components/patients/patient-list-page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 import { usePatients } from '@/hooks/usePatients';
 import { PatientFilters } from './patient-filters';
 import { PatientTable } from './patient-table';
@@ -32,16 +32,6 @@ export function PatientListPage() {
   const [navigationStageFilter, setNavigationStageFilter] = useState('all');
   const [showImportDialog, setShowImportDialog] = useState(false);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
-
-  useEffect(() => {
-    setPage(1);
-  }, [
-    searchTerm,
-    cancerTypeFilter,
-    stageFilter,
-    priorityFilter,
-    navigationStageFilter,
-  ]);
 
   const filteredPatients = useMemo(() => {
     if (!patients) return [];
@@ -133,15 +123,30 @@ export function PatientListPage() {
       {/* Filtros */}
       <PatientFilters
         searchTerm={searchTerm}
-        onSearchChange={setSearchTerm}
+        onSearchChange={(value) => {
+          setSearchTerm(value);
+          setPage(1);
+        }}
         cancerTypeFilter={cancerTypeFilter}
-        onCancerTypeChange={setCancerTypeFilter}
+        onCancerTypeChange={(value) => {
+          setCancerTypeFilter(value);
+          setPage(1);
+        }}
         stageFilter={stageFilter}
-        onStageChange={setStageFilter}
+        onStageChange={(value) => {
+          setStageFilter(value);
+          setPage(1);
+        }}
         priorityFilter={priorityFilter}
-        onPriorityChange={setPriorityFilter}
+        onPriorityChange={(value) => {
+          setPriorityFilter(value);
+          setPage(1);
+        }}
         navigationStageFilter={navigationStageFilter}
-        onNavigationStageChange={setNavigationStageFilter}
+        onNavigationStageChange={(value) => {
+          setNavigationStageFilter(value);
+          setPage(1);
+        }}
       />
 
       {/* Tabela */}

--- a/frontend/src/components/patients/patient-prontuario-tab.tsx
+++ b/frontend/src/components/patients/patient-prontuario-tab.tsx
@@ -28,6 +28,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Label } from '@/components/ui/label';
+import { AutoResizeTextarea } from '@/components/ui/auto-resize-textarea';
 import { Textarea } from '@/components/ui/textarea';
 import {
   AlertDialog,
@@ -678,7 +679,7 @@ export function PatientProntuarioTab({
                 {CLINICAL_NOTE_SECTION_KEYS.map((key) => (
                   <div key={key} className="space-y-1">
                     <Label htmlFor={`sec-${key}`}>{SECTION_LABELS[key]}</Label>
-                    <Textarea
+                    <AutoResizeTextarea
                       id={`sec-${key}`}
                       value={draftSections[key] ?? ''}
                       readOnly={
@@ -691,7 +692,7 @@ export function PatientProntuarioTab({
                           [key]: e.target.value,
                         }))
                       }
-                      rows={3}
+                      minRows={3}
                       className="text-sm"
                     />
                   </div>

--- a/frontend/src/components/ui/auto-resize-textarea.tsx
+++ b/frontend/src/components/ui/auto-resize-textarea.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import * as React from 'react';
+import { Textarea, type TextareaProps } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+
+function mergeRefs<T>(
+  ...refs: Array<React.Ref<T> | undefined | null>
+): React.RefCallback<T> {
+  return (node: T | null) => {
+    for (const ref of refs) {
+      if (ref == null) continue;
+      if (typeof ref === 'function') ref(node);
+      else (ref as React.MutableRefObject<T | null>).current = node;
+    }
+  };
+}
+
+export interface AutoResizeTextareaProps extends TextareaProps {
+  /** Linhas mínimas visíveis antes de crescer com o conteúdo (aprox. line-height do tema). */
+  minRows?: number;
+}
+
+export const AutoResizeTextarea = React.forwardRef<
+  HTMLTextAreaElement,
+  AutoResizeTextareaProps
+>(({ className, onChange, minRows: minRowsProp = 3, style, ...props }, ref) => {
+  const innerRef = React.useRef<HTMLTextAreaElement | null>(null);
+  const mergedRef = React.useMemo(() => mergeRefs(innerRef, ref), [ref]);
+
+  const adjustHeight = React.useCallback(() => {
+    const el = innerRef.current;
+    if (!el) return;
+    el.style.height = '0px';
+    el.style.height = `${el.scrollHeight}px`;
+  }, []);
+
+  React.useLayoutEffect(() => {
+    adjustHeight();
+  }, [adjustHeight, props.value]);
+
+  return (
+    <Textarea
+      ref={mergedRef}
+      {...props}
+      rows={1}
+      onChange={(e) => {
+        adjustHeight();
+        onChange?.(e);
+      }}
+      style={{
+        minHeight: `${minRowsProp * 1.5}rem`,
+        ...style,
+      }}
+      className={cn('resize-none overflow-hidden', className)}
+    />
+  );
+});
+AutoResizeTextarea.displayName = 'AutoResizeTextarea';

--- a/frontend/src/hooks/usePatients.ts
+++ b/frontend/src/hooks/usePatients.ts
@@ -5,12 +5,13 @@ import {
   Patient,
   CreatePatientDto,
   UpdatePatientDto,
+  type PatientsListParams,
 } from '@/lib/api/patients';
 
-export const usePatients = () => {
+export const usePatients = (listParams?: PatientsListParams) => {
   return useQuery({
-    queryKey: ['patients'],
-    queryFn: () => patientsApi.getAll(),
+    queryKey: ['patients', listParams ?? {}],
+    queryFn: () => patientsApi.getAll(listParams),
     staleTime: 5 * 60 * 1000, // 5 minutos
   });
 };
@@ -20,6 +21,7 @@ export const usePatient = (id: string, options?: { enabled?: boolean }) => {
     queryKey: ['patients', id],
     queryFn: () => patientsApi.getById(id),
     enabled: options?.enabled !== undefined ? options.enabled : !!id,
+    staleTime: 60_000, // 1 min — detalhe de paciente
   });
 };
 

--- a/frontend/src/lib/api/patients.ts
+++ b/frontend/src/lib/api/patients.ts
@@ -607,9 +607,22 @@ function unwrapPatientDetailPayload(raw: unknown): PatientDetail {
   return raw as PatientDetail;
 }
 
+export type PatientsListParams = {
+  limit?: number;
+  offset?: number;
+};
+
 export const patientsApi = {
-  async getAll(): Promise<Patient[]> {
-    const data = await apiClient.get<Patient[] | null>('/patients');
+  async getAll(params?: PatientsListParams): Promise<Patient[]> {
+    const data = await apiClient.get<Patient[] | null>('/patients', {
+      params:
+        params?.limit != null || params?.offset != null
+          ? {
+              ...(params.limit != null ? { limit: params.limit } : {}),
+              ...(params.offset != null ? { offset: params.offset } : {}),
+            }
+          : undefined,
+    });
     return data ?? [];
   },
 


### PR DESCRIPTION
## O quê
- Paginação e limite na listagem de pacientes (backend DTO/controller/service, índice Prisma + migration), cliente API, hook React Query e página de lista com navegação por página (cap 100).
- Cache de verificação de chaves LLM no orchestrator do ai-service (uma vez por request).
- Componente `AutoResizeTextarea` e uso no painel de etapas de navegação oncológica e nas notas do prontuário.

## Por quê
Melhorar desempenho da listagem e do pipeline do agente, e UX de campos de texto longos.

## Como testar
- Backend: testes de `patients.service` e validação Prisma.
- Frontend: listagem de pacientes com paginação.
- AI Service: testes do agent/orchestrator se existirem.
- UI: editar etapa de navegação e seções do prontuário — textarea acompanha o conteúdo.

## Checklist
- [ ] Testes passando
- [ ] Migration aplicável ao ambiente alvo
- [ ] Sem dados sensíveis em logs

Made with [Cursor](https://cursor.com)