### PR TITLE
feat(backend/patients): GET /patients/:id/timeline (linha do tempo unificada)

### DIFF
--- a/backend/src/patients/dto/timeline-query.dto.ts
+++ b/backend/src/patients/dto/timeline-query.dto.ts
@@ -1,0 +1,22 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+/** Query string para GET /patients/:id/timeline — types como lista separada por vírgula (alinhado ao frontend). */
+export class TimelineQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  offset?: number;
+
+  @IsOptional()
+  @IsString()
+  types?: string;
+}

--- a/backend/src/patients/patients.controller.ts
+++ b/backend/src/patients/patients.controller.ts
@@ -23,6 +23,7 @@ import { CreateCancerDiagnosisDto } from './dto/create-cancer-diagnosis.dto';
 import { UpdateCancerDiagnosisDto } from './dto/update-cancer-diagnosis.dto';
 import { ImportSpreadsheetDto } from './dto/import-spreadsheet.dto';
 import { QueryPatientsDto } from './dto/query-patients.dto';
+import { TimelineQueryDto } from './dto/timeline-query.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { TenantGuard } from '../auth/guards/tenant.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -150,6 +151,21 @@ export class PatientsController {
   ) {
     const patient = await this.patientsService.getDetail(id, user.tenantId);
     return { data: patient };
+  }
+
+  @Get(':id/timeline')
+  @Roles(
+    UserRole.ADMIN,
+    UserRole.ONCOLOGIST,
+    UserRole.NURSE,
+    UserRole.COORDINATOR
+  )
+  getTimeline(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: any,
+    @Query() query: TimelineQueryDto
+  ) {
+    return this.patientsService.getTimeline(id, user.tenantId, query);
   }
 
   @Get(':id/cancer-diagnoses')

--- a/backend/src/patients/patients.service.spec.ts
+++ b/backend/src/patients/patients.service.spec.ts
@@ -17,6 +17,43 @@ const mockPrisma = {
   },
   alert: {
     groupBy: jest.fn(),
+    findMany: jest.fn(),
+    count: jest.fn(),
+  },
+  observation: {
+    findMany: jest.fn(),
+    count: jest.fn(),
+  },
+  complementaryExamResult: {
+    findMany: jest.fn(),
+    count: jest.fn(),
+  },
+  navigationStep: {
+    findMany: jest.fn(),
+    count: jest.fn(),
+  },
+  clinicalNote: {
+    findMany: jest.fn(),
+    count: jest.fn(),
+  },
+  cancerDiagnosis: {
+    findMany: jest.fn(),
+    count: jest.fn(),
+  },
+  treatment: {
+    findMany: jest.fn(),
+  },
+  internalNote: {
+    findMany: jest.fn(),
+    count: jest.fn(),
+  },
+  intervention: {
+    findMany: jest.fn(),
+    count: jest.fn(),
+  },
+  questionnaireResponse: {
+    findMany: jest.fn(),
+    count: jest.fn(),
   },
   tenant: {
     findUnique: jest.fn(),
@@ -71,6 +108,25 @@ describe('PatientsService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    mockPrisma.observation.count.mockResolvedValue(0);
+    mockPrisma.observation.findMany.mockResolvedValue([]);
+    mockPrisma.alert.count.mockResolvedValue(0);
+    mockPrisma.alert.findMany.mockResolvedValue([]);
+    mockPrisma.complementaryExamResult.count.mockResolvedValue(0);
+    mockPrisma.complementaryExamResult.findMany.mockResolvedValue([]);
+    mockPrisma.navigationStep.count.mockResolvedValue(0);
+    mockPrisma.navigationStep.findMany.mockResolvedValue([]);
+    mockPrisma.clinicalNote.count.mockResolvedValue(0);
+    mockPrisma.clinicalNote.findMany.mockResolvedValue([]);
+    mockPrisma.cancerDiagnosis.count.mockResolvedValue(0);
+    mockPrisma.cancerDiagnosis.findMany.mockResolvedValue([]);
+    mockPrisma.treatment.findMany.mockResolvedValue([]);
+    mockPrisma.internalNote.count.mockResolvedValue(0);
+    mockPrisma.internalNote.findMany.mockResolvedValue([]);
+    mockPrisma.intervention.count.mockResolvedValue(0);
+    mockPrisma.intervention.findMany.mockResolvedValue([]);
+    mockPrisma.questionnaireResponse.count.mockResolvedValue(0);
+    mockPrisma.questionnaireResponse.findMany.mockResolvedValue([]);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -328,6 +384,78 @@ describe('PatientsService', () => {
       expect(mockPrisma.patient.delete).toHaveBeenCalledWith({
         where: { id: PATIENT_ID, tenantId: TENANT },
       });
+    });
+  });
+
+  // ─── getTimeline ───────────────────────────────────────────────────────────
+
+  describe('getTimeline', () => {
+    it('deve lançar NotFoundException quando o paciente não existe no tenant', async () => {
+      mockPrisma.patient.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.getTimeline(PATIENT_ID, TENANT, {})
+      ).rejects.toThrow(NotFoundException);
+
+      expect(mockPrisma.observation.findMany).not.toHaveBeenCalled();
+    });
+
+    it('deve retornar lista vazia e total 0 quando não há eventos', async () => {
+      mockPrisma.patient.findFirst.mockResolvedValue({ id: PATIENT_ID });
+
+      const result = await service.getTimeline(PATIENT_ID, TENANT, {});
+
+      expect(result).toEqual({
+        data: [],
+        total: 0,
+        limit: 50,
+        offset: 0,
+      });
+      expect(mockPrisma.observation.count).toHaveBeenCalledWith({
+        where: { patientId: PATIENT_ID, tenantId: TENANT },
+      });
+    });
+
+    it('deve escopar contagens e leituras ao tenantId do paciente', async () => {
+      mockPrisma.patient.findFirst.mockResolvedValue({ id: PATIENT_ID });
+      mockPrisma.alert.count.mockResolvedValue(1);
+      mockPrisma.alert.findMany.mockResolvedValue([
+        {
+          id: 'a1',
+          tenantId: TENANT,
+          patientId: PATIENT_ID,
+          type: 'CRITICAL_SYMPTOM',
+          severity: 'HIGH',
+          message: 'Teste',
+          status: 'PENDING',
+          context: null,
+          createdAt: new Date('2024-06-01T12:00:00.000Z'),
+          updatedAt: new Date('2024-06-01T12:00:00.000Z'),
+        },
+      ]);
+
+      await service.getTimeline(PATIENT_ID, TENANT, { types: 'alert' });
+
+      expect(mockPrisma.alert.count).toHaveBeenCalledWith({
+        where: { patientId: PATIENT_ID, tenantId: TENANT },
+      });
+      expect(mockPrisma.alert.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { patientId: PATIENT_ID, tenantId: TENANT },
+        })
+      );
+    });
+
+    it('deve respeitar limit máximo 100 e offset', async () => {
+      mockPrisma.patient.findFirst.mockResolvedValue({ id: PATIENT_ID });
+
+      const result = await service.getTimeline(PATIENT_ID, TENANT, {
+        limit: 999,
+        offset: 5,
+      });
+
+      expect(result.limit).toBe(100);
+      expect(result.offset).toBe(5);
     });
   });
 });

--- a/backend/src/patients/patients.service.ts
+++ b/backend/src/patients/patients.service.ts
@@ -16,6 +16,7 @@ import { ImportSpreadsheetRowDto } from './dto/import-spreadsheet.dto';
 import { PatientDetailResponse } from './dto/patient-detail-response.dto';
 import { CreateCancerDiagnosisDto } from './dto/create-cancer-diagnosis.dto';
 import { UpdateCancerDiagnosisDto } from './dto/update-cancer-diagnosis.dto';
+import { TimelineQueryDto } from './dto/timeline-query.dto';
 import { Patient, Prisma, JourneyStage } from '@generated/prisma/client';
 import { OncologyNavigationService } from '../oncology-navigation/oncology-navigation.service';
 import { PriorityRecalculationService } from '../oncology-navigation/priority-recalculation.service';
@@ -34,6 +35,24 @@ type PatientWithDiagnoses = Prisma.PatientGetPayload<{
     cancerDiagnoses: true;
   };
 }>;
+
+/** Tipos de evento alinhados ao contrato `TimelineEventType` do frontend. */
+const TIMELINE_EVENT_TYPES = [
+  'symptom',
+  'alert',
+  'exam',
+  'navigation_step',
+  'consultation',
+  'diagnosis',
+  'treatment',
+  'note',
+  'intervention',
+  'questionnaire',
+] as const;
+
+type TimelineEventType = (typeof TIMELINE_EVENT_TYPES)[number];
+
+const TIMELINE_SOURCE_FETCH_CAP = 2500;
 
 @Injectable()
 export class PatientsService {
@@ -1521,6 +1540,489 @@ export class PatientsService {
       orderBy: [{ isPrimary: 'desc' }, { diagnosisDate: 'desc' }],
       take: 100,
     });
+  }
+
+  /**
+   * Linha do tempo unificada (sintomas FHIR, alertas, exames, etapas, TCLE, etc.)
+   * com escopo obrigatório por tenant via paciente.
+   */
+  async getTimeline(
+    patientId: string,
+    tenantId: string,
+    query: TimelineQueryDto
+  ): Promise<{
+    data: Array<{ type: TimelineEventType; date: string; payload: Record<string, unknown> }>;
+    total: number;
+    limit: number;
+    offset: number;
+  }> {
+    const patient = await this.prisma.patient.findFirst({
+      where: { id: patientId, tenantId },
+      select: { id: true },
+    });
+
+    if (!patient) {
+      throw new NotFoundException(`Patient with ID ${patientId} not found`);
+    }
+
+    const limit = Math.min(Math.max(1, query.limit ?? 50), 100);
+    const offset = Math.max(0, query.offset ?? 0);
+    const typeSet = this.parseTimelineTypesParam(query.types);
+
+    const baseWhere = { patientId, tenantId } as const;
+    const cap = TIMELINE_SOURCE_FETCH_CAP;
+
+    try {
+      const countPromises: Promise<number>[] = [];
+
+      if (typeSet.has('symptom')) {
+        countPromises.push(
+          this.prisma.observation.count({ where: baseWhere })
+        );
+      }
+      if (typeSet.has('alert')) {
+        countPromises.push(this.prisma.alert.count({ where: baseWhere }));
+      }
+      if (typeSet.has('exam')) {
+        countPromises.push(
+          this.prisma.complementaryExamResult.count({
+            where: {
+              tenantId,
+              deletedAt: null,
+              exam: baseWhere,
+            },
+          })
+        );
+      }
+      if (typeSet.has('navigation_step')) {
+        countPromises.push(
+          this.prisma.navigationStep.count({ where: baseWhere })
+        );
+      }
+      if (typeSet.has('consultation')) {
+        countPromises.push(
+          this.prisma.clinicalNote.count({ where: baseWhere })
+        );
+      }
+      if (typeSet.has('diagnosis')) {
+        countPromises.push(
+          this.prisma.cancerDiagnosis.count({ where: baseWhere })
+        );
+      }
+      if (typeSet.has('treatment')) {
+        countPromises.push(
+          this.prisma.treatment
+            .findMany({
+              where: baseWhere,
+              select: { startDate: true, actualEndDate: true },
+            })
+            .then((rows) =>
+              rows.reduce((acc, t) => {
+                let n = 0;
+                if (t.startDate) {
+                  n++;
+                }
+                if (t.actualEndDate) {
+                  n++;
+                }
+                if (!t.startDate && !t.actualEndDate) {
+                  n++;
+                }
+                return acc + n;
+              }, 0)
+            )
+        );
+      }
+      if (typeSet.has('note')) {
+        countPromises.push(
+          this.prisma.internalNote.count({ where: baseWhere })
+        );
+      }
+      if (typeSet.has('intervention')) {
+        countPromises.push(
+          this.prisma.intervention.count({ where: baseWhere })
+        );
+      }
+      if (typeSet.has('questionnaire')) {
+        countPromises.push(
+          this.prisma.questionnaireResponse.count({ where: baseWhere })
+        );
+      }
+
+      const countResults = await Promise.all(countPromises);
+      const total = countResults.reduce((a, b) => a + b, 0);
+
+      const merged: Array<{
+        sortAt: Date;
+        type: TimelineEventType;
+        payload: Record<string, unknown>;
+      }> = [];
+
+      const fetches: Promise<void>[] = [];
+
+      if (typeSet.has('symptom')) {
+        fetches.push(
+          this.prisma.observation
+            .findMany({
+              where: baseWhere,
+              orderBy: { effectiveDateTime: 'desc' },
+              take: cap,
+            })
+            .then((rows) => {
+              for (const o of rows) {
+                merged.push({
+                  sortAt: o.effectiveDateTime,
+                  type: 'symptom',
+                  payload: {
+                    id: o.id,
+                    code: o.code,
+                    display: o.display,
+                    valueQuantity:
+                      o.valueQuantity === null || o.valueQuantity === undefined
+                        ? null
+                        : Number(o.valueQuantity),
+                    valueString: o.valueString,
+                    unit: o.unit,
+                    messageId: o.messageId,
+                  },
+                });
+              }
+            })
+        );
+      }
+
+      if (typeSet.has('alert')) {
+        fetches.push(
+          this.prisma.alert
+            .findMany({
+              where: baseWhere,
+              orderBy: { createdAt: 'desc' },
+              take: cap,
+            })
+            .then((rows) => {
+              for (const a of rows) {
+                merged.push({
+                  sortAt: a.createdAt,
+                  type: 'alert',
+                  payload: {
+                    id: a.id,
+                    type: a.type,
+                    severity: a.severity,
+                    message: a.message,
+                    status: a.status,
+                    context: a.context,
+                  },
+                });
+              }
+            })
+        );
+      }
+
+      if (typeSet.has('exam')) {
+        fetches.push(
+          this.prisma.complementaryExamResult
+            .findMany({
+              where: {
+                tenantId,
+                deletedAt: null,
+                exam: baseWhere,
+              },
+              include: {
+                exam: { select: { id: true, name: true, type: true } },
+              },
+              orderBy: { performedAt: 'desc' },
+              take: cap,
+            })
+            .then((rows) => {
+              for (const r of rows) {
+                merged.push({
+                  sortAt: r.performedAt,
+                  type: 'exam',
+                  payload: {
+                    id: r.id,
+                    examId: r.examId,
+                    examName: r.exam.name,
+                    examType: r.exam.type,
+                    valueNumeric: r.valueNumeric,
+                    valueText: r.valueText,
+                    unit: r.unit,
+                    referenceRange: r.referenceRange,
+                    isAbnormal: r.isAbnormal,
+                    criticalHigh: r.criticalHigh,
+                    criticalLow: r.criticalLow,
+                    report: r.report,
+                    components: r.components,
+                  },
+                });
+              }
+            })
+        );
+      }
+
+      if (typeSet.has('navigation_step')) {
+        fetches.push(
+          this.prisma.navigationStep
+            .findMany({
+              where: baseWhere,
+              orderBy: { updatedAt: 'desc' },
+              take: cap,
+            })
+            .then((rows) => {
+              for (const s of rows) {
+                const sortAt =
+                  s.completedAt ??
+                  s.actualDate ??
+                  s.dueDate ??
+                  s.expectedDate ??
+                  s.createdAt;
+                merged.push({
+                  sortAt,
+                  type: 'navigation_step',
+                  payload: {
+                    id: s.id,
+                    stepKey: s.stepKey,
+                    stepName: s.stepName,
+                    status: s.status,
+                    journeyStage: s.journeyStage,
+                    cancerType: s.cancerType,
+                    professionalName: s.professionalName,
+                    institutionName: s.institutionName,
+                    result: s.result,
+                    completedAt: s.completedAt,
+                    dueDate: s.dueDate,
+                    actualDate: s.actualDate,
+                  },
+                });
+              }
+            })
+        );
+      }
+
+      if (typeSet.has('consultation')) {
+        fetches.push(
+          this.prisma.clinicalNote
+            .findMany({
+              where: baseWhere,
+              orderBy: { createdAt: 'desc' },
+              take: cap,
+            })
+            .then((rows) => {
+              for (const n of rows) {
+                merged.push({
+                  sortAt: n.createdAt,
+                  type: 'consultation',
+                  payload: {
+                    id: n.id,
+                    noteType: n.noteType,
+                    status: n.status,
+                    stepName:
+                      n.noteType === 'MEDICAL'
+                        ? 'Consulta / evolução médica'
+                        : 'Evolução de enfermagem',
+                    professionalName: null as string | null,
+                  },
+                });
+              }
+            })
+        );
+      }
+
+      if (typeSet.has('diagnosis')) {
+        fetches.push(
+          this.prisma.cancerDiagnosis
+            .findMany({
+              where: baseWhere,
+              orderBy: { diagnosisDate: 'desc' },
+              take: cap,
+            })
+            .then((rows) => {
+              for (const d of rows) {
+                merged.push({
+                  sortAt: d.diagnosisDate,
+                  type: 'diagnosis',
+                  payload: {
+                    id: d.id,
+                    cancerType: d.cancerType,
+                    stage: d.stage,
+                    isPrimary: d.isPrimary,
+                    diagnosisConfirmed: d.diagnosisConfirmed,
+                    icd10Code: d.icd10Code,
+                  },
+                });
+              }
+            })
+        );
+      }
+
+      if (typeSet.has('treatment')) {
+        fetches.push(
+          this.prisma.treatment
+            .findMany({
+              where: baseWhere,
+              orderBy: { updatedAt: 'desc' },
+              take: cap,
+            })
+            .then((rows) => {
+              for (const t of rows) {
+                const basePayload = {
+                  id: t.id,
+                  diagnosisId: t.diagnosisId,
+                  treatmentType: t.treatmentType,
+                  treatmentName: t.treatmentName,
+                  protocol: t.protocol,
+                  intent: t.intent,
+                  status: t.status,
+                  currentCycle: t.currentCycle,
+                  totalCycles: t.totalCycles,
+                };
+                if (t.startDate) {
+                  merged.push({
+                    sortAt: t.startDate,
+                    type: 'treatment',
+                    payload: { ...basePayload, subEvent: 'start' },
+                  });
+                }
+                if (t.actualEndDate) {
+                  merged.push({
+                    sortAt: t.actualEndDate,
+                    type: 'treatment',
+                    payload: { ...basePayload, subEvent: 'end' },
+                  });
+                }
+                if (!t.startDate && !t.actualEndDate) {
+                  merged.push({
+                    sortAt: t.updatedAt,
+                    type: 'treatment',
+                    payload: { ...basePayload, subEvent: 'start' },
+                  });
+                }
+              }
+            })
+        );
+      }
+
+      if (typeSet.has('note')) {
+        fetches.push(
+          this.prisma.internalNote
+            .findMany({
+              where: baseWhere,
+              orderBy: { createdAt: 'desc' },
+              take: cap,
+            })
+            .then((rows) => {
+              for (const n of rows) {
+                merged.push({
+                  sortAt: n.createdAt,
+                  type: 'note',
+                  payload: {
+                    id: n.id,
+                    authorId: n.authorId,
+                    content: n.content,
+                  },
+                });
+              }
+            })
+        );
+      }
+
+      if (typeSet.has('intervention')) {
+        fetches.push(
+          this.prisma.intervention
+            .findMany({
+              where: baseWhere,
+              orderBy: { createdAt: 'desc' },
+              take: cap,
+            })
+            .then((rows) => {
+              for (const i of rows) {
+                merged.push({
+                  sortAt: i.createdAt,
+                  type: 'intervention',
+                  payload: {
+                    id: i.id,
+                    interventionType: i.type,
+                    notes: i.notes,
+                    userId: i.userId,
+                    messageId: i.messageId,
+                  },
+                });
+              }
+            })
+        );
+      }
+
+      if (typeSet.has('questionnaire')) {
+        fetches.push(
+          this.prisma.questionnaireResponse
+            .findMany({
+              where: baseWhere,
+              include: {
+                questionnaire: { select: { code: true, name: true, type: true } },
+              },
+              orderBy: { completedAt: 'desc' },
+              take: cap,
+            })
+            .then((rows) => {
+              for (const q of rows) {
+                merged.push({
+                  sortAt: q.completedAt,
+                  type: 'questionnaire',
+                  payload: {
+                    id: q.id,
+                    questionnaire: {
+                      code: q.questionnaire.code,
+                      name: q.questionnaire.name,
+                      type: q.questionnaire.type,
+                    },
+                    scores: q.scores,
+                    responses: q.responses,
+                  },
+                });
+              }
+            })
+        );
+      }
+
+      await Promise.all(fetches);
+
+      merged.sort(
+        (a, b) => b.sortAt.getTime() - a.sortAt.getTime() || String(b.payload.id).localeCompare(String(a.payload.id))
+      );
+
+      const page = merged.slice(offset, offset + limit);
+
+      return {
+        data: page.map((e) => ({
+          type: e.type,
+          date: e.sortAt.toISOString(),
+          payload: e.payload,
+        })),
+        total,
+        limit,
+        offset,
+      };
+    } catch (err) {
+      this.logger.error(
+        'Falha ao montar a linha do tempo do paciente',
+        err instanceof Error ? err.stack : String(err)
+      );
+      throw err;
+    }
+  }
+
+  private parseTimelineTypesParam(types?: string): Set<TimelineEventType> {
+    const allowed = new Set<string>(TIMELINE_EVENT_TYPES);
+    if (!types?.trim()) {
+      return new Set(TIMELINE_EVENT_TYPES);
+    }
+    const out = new Set<TimelineEventType>();
+    for (const raw of types.split(',')) {
+      const t = raw.trim().toLowerCase();
+      if (allowed.has(t)) {
+        out.add(t as TimelineEventType);
+      }
+    }
+    return out.size > 0 ? out : new Set(TIMELINE_EVENT_TYPES);
   }
 
   /**


### PR DESCRIPTION
## O quê

- Novo endpoint `GET /api/v1/patients/:id/timeline` com resposta `{ data, total, limit, offset }` alinhada ao `TimelineResponse` do frontend.
- Agregação de eventos (observações FHIR, alertas, resultados de exames complementares, etapas de navegação, notas clínicas, diagnósticos, tratamentos, notas internas, intervenções, questionários).
- Query opcional: `limit` (1–100, default 50), `offset`, `types` (lista separada por vírgula).
- DTO `TimelineQueryDto` com validação; `ParseUUIDPipe` no `patientId`; mesmas `@Roles` que `getDetail`.

## Por quê

- O frontend (`usePatientTimeline` / `PatientSymptomTimeline`) já chamava essa rota; sem handler no Nest a chamada falhava (ex.: 404) e a UI exibia erro ao carregar a linha do tempo.

## Segurança

- `tenantId` apenas do JWT (`@CurrentUser`); todas as consultas Prisma escopadas por paciente + tenant (ou relação equivalente).
- Log de falha sem identificador de paciente no texto da mensagem.

## Como testar

- `cd backend && npm test -- --testPathPattern=patients.service.spec`
- Com backend e sessão válidos: abrir ficha do paciente e confirmar que a timeline carrega ou lista vazia sem erro vermelho.

## Checklist

- [x] Isolamento multi-tenant nas queries
- [x] Testes unitários do `getTimeline` (not found, vazio, escopo tenant, cap de limit)


Made with [Cursor](https://cursor.com)