### PR TITLE
fix(frontend): ajustar URL do probe de sessão

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -22,3 +22,8 @@ NEXT_PUBLIC_META_APP_CONFIG_ID=your-meta-config-id
 
 # Produção: hosts extra em connect-src (CSP), separados por espaço (ex.: https://api.tercdn.com)
 NEXT_PUBLIC_CSP_CONNECT_EXTRA=
+
+# URL interna do servidor Next.js para o probe de sessão no middleware.
+# Padrão: http://localhost:PORT (sempre correto em Docker). Sobrescrever somente se o servidor
+# escutar em endereço diferente (ex.: container sem acesso ao loopback).
+# INTERNAL_APP_URL=http://localhost:3000

--- a/frontend/src/middleware.test.ts
+++ b/frontend/src/middleware.test.ts
@@ -46,10 +46,51 @@ describe('middleware auth gating (probe no backend)', () => {
     expect(response.headers.get('location')).toBeNull();
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [calledUrl, init] = fetchMock.mock.calls[0] as unknown as [URL, RequestInit];
-    expect(String(calledUrl)).toBe('https://onconav.local/api/v1/auth/profile');
+    const [calledUrl, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    // Probe usa URL interna (loopback) — não o hostname externo da requisição original.
+    // Isso evita roundtrip HTTPS externo no Docker de produção.
+    expect(calledUrl).toBe('http://localhost:3000/api/v1/auth/profile');
     expect(init?.method).toBe('GET');
     expect((init?.headers as Record<string, string>)?.cookie).toContain('access_token=token');
+  });
+
+  it('usa INTERNAL_APP_URL quando hostname é .internal (permitido)', async () => {
+    process.env.INTERNAL_APP_URL = 'http://app.internal:4000';
+    const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    await middleware(buildRequest('/dashboard', 'access_token=token'));
+    const [calledUrl] = fetchMock.mock.calls[0] as unknown as [string];
+    expect(calledUrl).toBe('http://app.internal:4000/api/v1/auth/profile');
+    delete process.env.INTERNAL_APP_URL;
+  });
+
+  it('cai para localhost quando INTERNAL_APP_URL tem hostname externo não permitido', async () => {
+    process.env.INTERNAL_APP_URL = 'http://169.254.169.254/';
+    const fetchMock = vi.fn(async () => new Response(null, { status: 401 }));
+    vi.stubGlobal('fetch', fetchMock);
+    await middleware(buildRequest('/dashboard', 'access_token=token'));
+    const [calledUrl] = fetchMock.mock.calls[0] as unknown as [string];
+    // Deve usar loopback, não o hostname malicioso
+    expect(calledUrl).toContain('localhost');
+    expect(calledUrl).not.toContain('169.254');
+    delete process.env.INTERNAL_APP_URL;
+  });
+
+  it('sanitiza CR/LF no header cookie para evitar header injection', async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Simula `headers.get('cookie')` retornando string com newlines
+    // (Headers nativa rejeita newlines; aqui testamos que a sanitização
+    //  funciona mesmo se o valor chegar por outro caminho, ex: mock de ambiente)
+    const req = buildRequest('/dashboard');
+    vi.spyOn(req.headers, 'get').mockReturnValue('access_token=token\r\nX-Evil: injected');
+
+    await middleware(req);
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const cookie = (init?.headers as Record<string, string>)?.cookie ?? '';
+    expect(cookie).not.toMatch(/[\r\n]/);
+    expect(cookie).toContain('access_token=token');
   });
 
   it('redireciona rota protegida quando o backend retorna 401 no probe', async () => {

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -17,17 +17,39 @@ function isResetPasswordRoute(pathname: string): boolean {
 const SESSION_PROBE_PATH = '/api/v1/auth/profile';
 const SESSION_PROBE_TIMEOUT_MS = 2000;
 
+/**
+ * URL interna do servidor Next.js para o probe de sessão.
+ * Usa loopback (localhost) para evitar roundtrip HTTPS externo no Docker.
+ * Em produção o container escuta em 0.0.0.0:3000; localhost sempre resolve localmente.
+ *
+ * Quando INTERNAL_APP_URL está definido, o hostname é validado para prevenir
+ * SSRF interno: somente loopback e sufixo `.internal` são permitidos.
+ */
+function internalProbeUrl(): string {
+  const raw =
+    process.env.INTERNAL_APP_URL ??
+    `http://localhost:${process.env.PORT ?? 3000}`;
+  const parsed = new URL(raw); // lança se malformada
+  const ALLOWED = new Set(['localhost', '127.0.0.1', '::1']);
+  if (!ALLOWED.has(parsed.hostname) && !parsed.hostname.endsWith('.internal')) {
+    // Falha segura: hostname não permitido → usa loopback padrão.
+    return new URL(SESSION_PROBE_PATH, `http://localhost:${process.env.PORT ?? 3000}`).toString();
+  }
+  return new URL(SESSION_PROBE_PATH, raw).toString();
+}
+
 async function hasActiveSession(request: NextRequest): Promise<boolean> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), SESSION_PROBE_TIMEOUT_MS);
 
   try {
-    const url = new URL(SESSION_PROBE_PATH, request.url);
+    const url = internalProbeUrl();
     const res = await fetch(url, {
       method: 'GET',
       headers: {
         // Importante: repassar cookies para o backend validar `access_token`/`refresh_token` HttpOnly.
-        cookie: request.headers.get('cookie') ?? '',
+        // Remover CR/LF para prevenir HTTP header injection.
+        cookie: (request.headers.get('cookie') ?? '').replace(/[\r\n]/g, ''),
       },
       cache: 'no-store',
       signal: controller.signal,
@@ -61,5 +83,7 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
+  // Exclui /api/* intencionalmente: o probe interno usa /api/v1/auth/profile e não
+  // deve ser interceptado pelo middleware para evitar loop infinito.
   matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
 };


### PR DESCRIPTION
## Summary
- Ajusta URL do probe de sessão para usar loopback interno, evitando rota incorreta.

## Test plan
- [ ] Subir `frontend` e validar que o probe de sessão chama o endpoint esperado
- [ ] Verificar que não quebra login/sessão

Made with [Cursor](https://cursor.com)