### PR TITLE
chore(deps): follow-redirects patched (Dependabot medium)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6503,15 +6503,16 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -84,6 +84,7 @@
     "vite": "^8.0.5",
     "lodash": "^4.18.0",
     "path-to-regexp": "^8.4.0",
-    "defu": "^6.1.5"
+    "defu": "^6.1.5",
+    "follow-redirects": "^1.16.0"
   }
 }


### PR DESCRIPTION
## Objetivo
Remover alerta Dependabot **medium** de `follow-redirects` no `frontend/package-lock.json` via `npm overrides`.

## Alerta
- #33 `follow-redirects` — [GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653) — patched `1.16.0`

## Test plan
- `frontend/`: `npm audit --audit-level=moderate` (0 vulns)
- `frontend/`: `npm run lint` (só warnings existentes do repo)
- `frontend/`: `npm run type-check`


Made with [Cursor](https://cursor.com)