### PR TITLE
chore(deps): pytest 9.0.3 (Dependabot medium)

### DIFF
--- a/ai-service/requirements-dev.txt
+++ b/ai-service/requirements-dev.txt
@@ -1,8 +1,8 @@
 -r requirements.txt
 
 # Testing
-pytest==8.3.5
-pytest-asyncio==0.24.0
+pytest==9.0.3
+pytest-asyncio==1.3.0
 
 # Linting
 ruff==0.9.0


### PR DESCRIPTION
## Objetivo
Remover alerta Dependabot **medium** do ecossistema Python no `ai-service/requirements-dev.txt`.

## Alerta
- #1 `pytest` — [GHSA-6w46-j5rx-g56g](https://github.com/advisories/GHSA-6w46-j5rx-g56g) — patched `9.0.3`

## Mudanças
- `pytest`: `8.3.5` → `9.0.3`
- `pytest-asyncio`: `0.24.0` → `1.3.0` (necessário para compatibilidade com pytest 9)

## Test plan
- `ai-service/`: `pytest -q` (97 passed, 2 skipped)


Made with [Cursor](https://cursor.com)