### PR TITLE
feat(login): endurecer sessão e vincular evoluções

### DIFF
--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -3,6 +3,7 @@ import { AuthService } from '@/auth/auth.service';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import { ServiceUnavailableException } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 import { PrismaService } from '@/prisma/prisma.service';
 import { RedisService } from '@/redis/redis.service';
@@ -240,6 +241,65 @@ describe('AuthService', () => {
       expect(result).toHaveProperty('refresh_token');
       expect(result.user.email).toBe('nurse@example.com');
       expect(result.user).not.toHaveProperty('password');
+    });
+  });
+
+  describe('refresh', () => {
+    it('deve lançar UnauthorizedException quando refresh token não existir no Redis', async () => {
+      mockRedis.get.mockResolvedValueOnce(null);
+
+      await expect(service.refresh('rt-inexistente')).rejects.toThrow(UnauthorizedException);
+      expect(mockRedis.get).toHaveBeenCalledWith('rt:rt-inexistente');
+    });
+
+    it('deve lançar ServiceUnavailableException quando Redis falhar ao ler token', async () => {
+      mockRedis.get.mockRejectedValueOnce(new Error('Redis down'));
+
+      await expect(service.refresh('qualquer')).rejects.toThrow(ServiceUnavailableException);
+    });
+
+    it('deve rotacionar refresh token e emitir novo access token quando válido', async () => {
+      mockRedis.get.mockResolvedValueOnce('user-1');
+      mockRedis.del.mockResolvedValue(1);
+      mockRedis.set.mockResolvedValue('OK');
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 'user-1',
+        email: 'user@example.com',
+        tenantId: 'tenant-1',
+        role: 'NURSE',
+        tenant: { id: 'tenant-1', name: 'Hospital Teste' },
+      });
+
+      const result = await service.refresh('old-refresh');
+
+      expect(mockRedis.del).toHaveBeenCalledWith('rt:old-refresh');
+      expect(mockRedis.set).toHaveBeenCalledWith(
+        expect.stringMatching(/^rt:/),
+        'user-1',
+        expect.any(Number)
+      );
+      expect(result).toEqual(
+        expect.objectContaining({
+          access_token: 'mock-access-token',
+          refresh_token: expect.any(String),
+        })
+      );
+    });
+  });
+
+  describe('logout', () => {
+    it('deve lançar ServiceUnavailableException quando Redis falhar ao deletar refresh token', async () => {
+      mockRedis.del.mockRejectedValueOnce(new Error('Redis down'));
+
+      await expect(service.logout('rt-1')).rejects.toThrow(ServiceUnavailableException);
+      expect(mockRedis.del).toHaveBeenCalledWith('rt:rt-1');
+    });
+
+    it('não deve lançar erro quando deletar refresh token com sucesso', async () => {
+      mockRedis.del.mockResolvedValueOnce(1);
+
+      await expect(service.logout('rt-ok')).resolves.toBeUndefined();
+      expect(mockRedis.del).toHaveBeenCalledWith('rt:rt-ok');
     });
   });
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -3,6 +3,7 @@ import {
   UnauthorizedException,
   ForbiddenException,
   ConflictException,
+  ServiceUnavailableException,
   Logger,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
@@ -204,7 +205,16 @@ export class AuthService {
 
   async refresh(refreshToken: string) {
     const key = `rt:${refreshToken}`;
-    const userId = await this.redisService.get(key);
+    let userId: string | null = null;
+    try {
+      userId = await this.redisService.get(key);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`Redis error while reading refresh token: ${message}`);
+      throw new ServiceUnavailableException(
+        'Serviço de sessão indisponível. Tente novamente em instantes.'
+      );
+    }
 
     if (!userId) {
       throw new UnauthorizedException('Refresh token inválido ou expirado');
@@ -221,7 +231,16 @@ export class AuthService {
     }
 
     // Rotate refresh token (invalidate old, issue new)
-    await this.redisService.del(key);
+    try {
+      await this.redisService.del(key);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`Redis error while invalidating refresh token: ${message}`);
+      throw new ServiceUnavailableException(
+        'Serviço de sessão indisponível. Tente novamente em instantes.'
+      );
+    }
+
     const newRefreshToken = await this.generateRefreshToken(user.id);
 
     const payload: JwtPayload = {
@@ -249,7 +268,15 @@ export class AuthService {
 
   async logout(refreshToken: string, userId?: string, tenantId?: string): Promise<void> {
     if (refreshToken) {
-      await this.redisService.del(`rt:${refreshToken}`);
+      try {
+        await this.redisService.del(`rt:${refreshToken}`);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.logger.warn(`Redis error while deleting refresh token on logout: ${message}`);
+        throw new ServiceUnavailableException(
+          'Serviço de sessão indisponível. Tente novamente em instantes.'
+        );
+      }
     }
     // [A-03] Audit logout when caller context is available
     if (userId && tenantId) {
@@ -273,11 +300,15 @@ export class AuthService {
 
   private async generateRefreshToken(userId: string): Promise<string> {
     const token = crypto.randomBytes(40).toString('hex');
-    await this.redisService.set(
-      `rt:${token}`,
-      userId,
-      REFRESH_TOKEN_TTL_SECONDS
-    );
+    try {
+      await this.redisService.set(`rt:${token}`, userId, REFRESH_TOKEN_TTL_SECONDS);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`Redis error while issuing refresh token: ${message}`);
+      throw new ServiceUnavailableException(
+        'Serviço de sessão indisponível. Tente novamente em instantes.'
+      );
+    }
     return token;
   }
 

--- a/backend/src/clinical-notes/clinical-notes.service.spec.ts
+++ b/backend/src/clinical-notes/clinical-notes.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import {
   ClinicalNoteStatus,
   ClinicalNoteType,
@@ -15,6 +15,19 @@ import { CLINICAL_NOTE_SECTION_KEYS } from './clinical-notes.constants';
 describe('ClinicalNotesService', () => {
   let service: ClinicalNotesService;
 
+  const mockPrisma = {
+    navigationStep: {
+      findFirst: jest.fn(),
+    },
+    patient: {
+      findFirst: jest.fn(),
+    },
+    clinicalNote: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+  };
+
   const mockAudit = { log: jest.fn() };
 
   beforeEach(async () => {
@@ -24,7 +37,7 @@ describe('ClinicalNotesService', () => {
         ClinicalNotesService,
         {
           provide: PrismaService,
-          useValue: {},
+          useValue: mockPrisma,
         },
         {
           provide: ConfigService,
@@ -122,6 +135,98 @@ describe('ClinicalNotesService', () => {
     });
   });
 
+  describe('validateNavigationStepForEvolution', () => {
+    const patientId = 'patient-1';
+    const tenantId = 'tenant-1';
+
+    it('deve lançar NotFoundException quando navigationStep não existir para patient/tenant', async () => {
+      mockPrisma.navigationStep.findFirst.mockResolvedValueOnce(null);
+
+      await expect(
+        service.validateNavigationStepForEvolution(
+          'step-1',
+          patientId,
+          tenantId,
+          ClinicalNoteType.MEDICAL
+        )
+      ).rejects.toThrow(NotFoundException);
+
+      expect(mockPrisma.navigationStep.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            id: 'step-1',
+            tenantId,
+            patientId,
+          }),
+        })
+      );
+    });
+
+    it('deve lançar BadRequestException quando stepKey não corresponder ao tipo MEDICAL', async () => {
+      mockPrisma.navigationStep.findFirst.mockResolvedValueOnce({
+        id: 'step-1',
+        stepKey: 'navigation_consultation',
+      });
+
+      await expect(
+        service.validateNavigationStepForEvolution(
+          'step-1',
+          patientId,
+          tenantId,
+          ClinicalNoteType.MEDICAL
+        )
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('deve lançar BadRequestException quando stepKey não corresponder ao tipo NURSING', async () => {
+      mockPrisma.navigationStep.findFirst.mockResolvedValueOnce({
+        id: 'step-1',
+        stepKey: 'specialist_consultation',
+      });
+
+      await expect(
+        service.validateNavigationStepForEvolution(
+          'step-1',
+          patientId,
+          tenantId,
+          ClinicalNoteType.NURSING
+        )
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('deve aceitar quando stepKey corresponder ao tipo MEDICAL', async () => {
+      mockPrisma.navigationStep.findFirst.mockResolvedValueOnce({
+        id: 'step-1',
+        stepKey: 'specialist_consultation',
+      });
+
+      await expect(
+        service.validateNavigationStepForEvolution(
+          'step-1',
+          patientId,
+          tenantId,
+          ClinicalNoteType.MEDICAL
+        )
+      ).resolves.toBeUndefined();
+    });
+
+    it('deve aceitar quando stepKey corresponder ao tipo NURSING', async () => {
+      mockPrisma.navigationStep.findFirst.mockResolvedValueOnce({
+        id: 'step-1',
+        stepKey: 'navigation_consultation',
+      });
+
+      await expect(
+        service.validateNavigationStepForEvolution(
+          'step-1',
+          patientId,
+          tenantId,
+          ClinicalNoteType.NURSING
+        )
+      ).resolves.toBeUndefined();
+    });
+  });
+
   describe('toMutationResponse', () => {
     it('maps latest version', () => {
       const r = service.toMutationResponse({
@@ -137,6 +242,87 @@ describe('ClinicalNotesService', () => {
       expect(r.latestVersionNumber).toBe(2);
       expect(r.sectionsContentHash).toBe('abc');
       expect(r.navigationStepId).toBe('ns-1');
+    });
+  });
+
+  describe('findAllForPatient', () => {
+    const TENANT = 'tenant-1';
+    const PATIENT = 'patient-1';
+    const STEP = '11111111-1111-4111-8111-111111111111';
+
+    beforeEach(() => {
+      mockPrisma.patient.findFirst.mockReset();
+      mockPrisma.clinicalNote.findMany.mockReset();
+      mockPrisma.clinicalNote.count.mockReset();
+    });
+
+    it('deve lançar NotFoundException quando paciente não existir no tenant', async () => {
+      mockPrisma.patient.findFirst.mockResolvedValueOnce(null);
+
+      await expect(service.findAllForPatient(PATIENT, TENANT)).rejects.toThrow(
+        NotFoundException
+      );
+      expect(mockPrisma.patient.findFirst).toHaveBeenCalledWith({
+        where: { id: PATIENT, tenantId: TENANT },
+        select: { id: true },
+      });
+    });
+
+    it('deve listar notas sem navigationStepId quando filtro não é fornecido', async () => {
+      mockPrisma.patient.findFirst.mockResolvedValueOnce({ id: PATIENT });
+      mockPrisma.clinicalNote.findMany.mockResolvedValueOnce([]);
+      mockPrisma.clinicalNote.count.mockResolvedValueOnce(0);
+
+      await service.findAllForPatient(PATIENT, TENANT, 1, 20);
+
+      expect(mockPrisma.clinicalNote.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            tenantId: TENANT,
+            patientId: PATIENT,
+            status: { not: ClinicalNoteStatus.VOIDED },
+          }),
+        })
+      );
+      const callArg = (mockPrisma.clinicalNote.findMany as jest.Mock).mock.calls[0]?.[0];
+      expect(callArg?.where).not.toHaveProperty('navigationStepId');
+    });
+
+    it('deve incluir navigationStepId no where quando filtro é fornecido', async () => {
+      mockPrisma.patient.findFirst.mockResolvedValueOnce({ id: PATIENT });
+      mockPrisma.clinicalNote.findMany.mockResolvedValueOnce([]);
+      mockPrisma.clinicalNote.count.mockResolvedValueOnce(0);
+
+      await service.findAllForPatient(PATIENT, TENANT, 1, 20, STEP);
+
+      expect(mockPrisma.clinicalNote.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            tenantId: TENANT,
+            patientId: PATIENT,
+            navigationStepId: STEP,
+            status: { not: ClinicalNoteStatus.VOIDED },
+          }),
+        })
+      );
+      expect(mockPrisma.clinicalNote.count).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ navigationStepId: STEP }),
+        })
+      );
+    });
+
+    it('não deve vazar dados de outro tenant (patient.findFirst scoped)', async () => {
+      mockPrisma.patient.findFirst.mockResolvedValueOnce(null);
+
+      await expect(
+        service.findAllForPatient(PATIENT, 'other-tenant')
+      ).rejects.toThrow(NotFoundException);
+      expect(mockPrisma.patient.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: PATIENT, tenantId: 'other-tenant' },
+        })
+      );
     });
   });
 });

--- a/backend/src/clinical-notes/clinical-notes.service.ts
+++ b/backend/src/clinical-notes/clinical-notes.service.ts
@@ -306,7 +306,8 @@ export class ClinicalNotesService {
     patientId: string,
     tenantId: string,
     page = 1,
-    limit = 20
+    limit = 20,
+    navigationStepId?: string
   ) {
     const take = Math.min(Math.max(limit, 1), 100);
     const skip = (Math.max(page, 1) - 1) * take;
@@ -323,6 +324,7 @@ export class ClinicalNotesService {
       tenantId,
       patientId,
       status: { not: ClinicalNoteStatus.VOIDED },
+      ...(navigationStepId ? { navigationStepId } : {}),
     };
 
     const [items, total] = await Promise.all([

--- a/backend/src/clinical-notes/patient-clinical-notes.controller.spec.ts
+++ b/backend/src/clinical-notes/patient-clinical-notes.controller.spec.ts
@@ -1,0 +1,78 @@
+import { BadRequestException } from '@nestjs/common';
+import { PatientClinicalNotesController } from './patient-clinical-notes.controller';
+
+describe('PatientClinicalNotesController', () => {
+  const clinicalNotesService = {
+    findAllForPatient: jest.fn(),
+    create: jest.fn(),
+  };
+  const sectionSuggestionService = {
+    getSectionSuggestions: jest.fn(),
+  };
+
+  const user = {
+    id: 'user-1',
+    email: 'user@example.com',
+    tenantId: 'tenant-1',
+    role: 'NURSE',
+    clinicalSubrole: null,
+  } as any;
+
+  const PATIENT_ID = '22222222-2222-4222-8222-222222222222';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findAll', () => {
+    it('deve lançar BadRequestException quando navigationStepId for inválido', async () => {
+      const controller = new PatientClinicalNotesController(
+        clinicalNotesService as any,
+        sectionSuggestionService as any
+      );
+
+      expect(() =>
+        controller.findAll(PATIENT_ID, user, 1, 20, 'not-a-uuid')
+      ).toThrow(BadRequestException);
+      expect(clinicalNotesService.findAllForPatient).not.toHaveBeenCalled();
+    });
+
+    it('deve tratar navigationStepId vazio como undefined (sem filtro)', async () => {
+      const controller = new PatientClinicalNotesController(
+        clinicalNotesService as any,
+        sectionSuggestionService as any
+      );
+      clinicalNotesService.findAllForPatient.mockResolvedValueOnce({ data: [], total: 0 });
+
+      await controller.findAll(PATIENT_ID, user, 1, 20, '');
+
+      expect(clinicalNotesService.findAllForPatient).toHaveBeenCalledWith(
+        PATIENT_ID,
+        user.tenantId,
+        1,
+        20,
+        undefined
+      );
+    });
+
+    it('deve repassar navigationStepId válido como filtro para o service', async () => {
+      const controller = new PatientClinicalNotesController(
+        clinicalNotesService as any,
+        sectionSuggestionService as any
+      );
+      clinicalNotesService.findAllForPatient.mockResolvedValueOnce({ data: [], total: 0 });
+      const stepId = '11111111-1111-4111-8111-111111111111';
+
+      await controller.findAll(PATIENT_ID, user, 1, 20, stepId);
+
+      expect(clinicalNotesService.findAllForPatient).toHaveBeenCalledWith(
+        PATIENT_ID,
+        user.tenantId,
+        1,
+        20,
+        stepId
+      );
+    });
+  });
+});
+

--- a/backend/src/clinical-notes/patient-clinical-notes.controller.ts
+++ b/backend/src/clinical-notes/patient-clinical-notes.controller.ts
@@ -123,13 +123,26 @@ export class PatientClinicalNotesController {
     @Param('patientId', ParseUUIDPipe) patientId: string,
     @CurrentUser() user: CurrentUserType,
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
-    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+    @Query('navigationStepId') navigationStepId: string | undefined
   ) {
+    const uuidRe =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    if (
+      navigationStepId !== undefined &&
+      navigationStepId !== '' &&
+      !uuidRe.test(navigationStepId)
+    ) {
+      throw new BadRequestException('navigationStepId inválido');
+    }
+    const stepFilter =
+      navigationStepId && navigationStepId !== '' ? navigationStepId : undefined;
     return this.clinicalNotesService.findAllForPatient(
       patientId,
       user.tenantId,
       page,
-      limit
+      limit,
+      stepFilter
     );
   }
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -139,6 +139,9 @@ async function bootstrap(): Promise<void> {
     'https://127.0.0.1:3000',
     'http://frontend:3000',
     'https://frontend:3000',
+    // Playwright E2E webServer (default in frontend/playwright.config.ts)
+    'http://127.0.0.1:3330',
+    'http://localhost:3330',
     frontendUrl,
     ...extraOrigins,
   ];

--- a/frontend/src/app/oncology-navigation/page.tsx
+++ b/frontend/src/app/oncology-navigation/page.tsx
@@ -67,11 +67,13 @@ import {
   StageDroppableColumn,
 } from '@/components/patients/navigation-step-dnd';
 import { NavigationStepEditPanel } from '@/components/oncology-navigation/navigation-step-edit-panel';
+import { NavigationStepLinkedEvolutions } from '@/components/oncology-navigation/navigation-step-linked-evolutions';
 import { cn } from '@/lib/utils';
 import {
   getFilledStepDetailEntries,
   getNavStepFormVariant,
   parseStepDetailFromMetadata,
+  usesProntuarioEvolutionModel,
   VARIANT_SECTION_TITLE,
 } from '@/lib/utils/nav-step-form-variants';
 
@@ -869,6 +871,10 @@ function StepCard({ step, apiUrl, dragHandle }: StepCardProps) {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
 
   const variant = useMemo(() => getNavStepFormVariant(step.stepKey), [step.stepKey]);
+  const integratesProntuarioEvolutions = useMemo(
+    () => usesProntuarioEvolutionModel(step.stepKey),
+    [step.stepKey]
+  );
 
   // Novos campos do formulário
   const [institutionName, setInstitutionName] = useState(
@@ -1128,6 +1134,14 @@ function StepCard({ step, apiUrl, dragHandle }: StepCardProps) {
           <NavigationStepEditPanel
             stepKey={step.stepKey}
             variant={variant}
+            variantSectionReplacement={
+              integratesProntuarioEvolutions ? (
+                <NavigationStepLinkedEvolutions
+                  patientId={step.patientId}
+                  navigationStepId={step.id}
+                />
+              ) : undefined
+            }
             stepDetail={stepDetail}
             onStepDetailFieldChange={(key, value) =>
               setStepDetail((prev) => ({ ...prev, [key]: value }))
@@ -1201,18 +1215,26 @@ function StepCard({ step, apiUrl, dragHandle }: StepCardProps) {
               </div>
             )}
 
-            {variant !== 'generic' && detailPreview.length > 0 && (
-              <div className="space-y-3 rounded-md border border-primary/25 bg-primary/5 p-3">
-                <p className="text-sm font-semibold text-foreground">
-                  {VARIANT_SECTION_TITLE[variant]}
-                </p>
-                {detailPreview.map((row, idx) => (
-                  <div key={`${row.label}-${idx}`} className="space-y-0.5">
-                    <p className="text-xs font-medium text-muted-foreground">{row.label}</p>
-                    <p className="text-sm whitespace-pre-wrap text-foreground">{row.value}</p>
-                  </div>
-                ))}
-              </div>
+            {integratesProntuarioEvolutions ? (
+              <NavigationStepLinkedEvolutions
+                patientId={step.patientId}
+                navigationStepId={step.id}
+              />
+            ) : (
+              variant !== 'generic' &&
+              detailPreview.length > 0 && (
+                <div className="space-y-3 rounded-md border border-primary/25 bg-primary/5 p-3">
+                  <p className="text-sm font-semibold text-foreground">
+                    {VARIANT_SECTION_TITLE[variant]}
+                  </p>
+                  {detailPreview.map((row, idx) => (
+                    <div key={`${row.label}-${idx}`} className="space-y-0.5">
+                      <p className="text-xs font-medium text-muted-foreground">{row.label}</p>
+                      <p className="text-sm whitespace-pre-wrap text-foreground">{row.value}</p>
+                    </div>
+                  ))}
+                </div>
+              )
             )}
 
             {/* Resultado */}

--- a/frontend/src/app/patients/[id]/page.tsx
+++ b/frontend/src/app/patients/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { use, useEffect } from 'react';
+import { use, useEffect, Suspense } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuthStore } from '@/stores/auth-store';
 import { NavigationBar } from '@/components/shared/navigation-bar';
@@ -41,7 +41,15 @@ export default function PatientDetailRoute(props: { params: Params }) {
     <div className="min-h-screen bg-gray-50 flex flex-col">
       <NavigationBar />
       <div className="flex-1">
-        <PatientDetailPage patientId={params.id} />
+        <Suspense
+          fallback={
+            <div className="p-6 text-center text-muted-foreground">
+              Carregando…
+            </div>
+          }
+        >
+          <PatientDetailPage patientId={params.id} />
+        </Suspense>
       </div>
     </div>
   );

--- a/frontend/src/components/oncology-navigation/navigation-step-edit-panel.tsx
+++ b/frontend/src/components/oncology-navigation/navigation-step-edit-panel.tsx
@@ -53,6 +53,11 @@ export interface NavigationStepEditPanelProps {
   stepKey: string;
   /** Define quais campos específicos são exibidos (consulta = SOAP, imagem, patologia, etc.) */
   variant: NavStepFormVariant;
+  /**
+   * Quando definido (ex.: consultas com evolução no prontuário), substitui o bloco SOAP/metadata
+   * da variante — evita modelo clínico duplicado.
+   */
+  variantSectionReplacement?: React.ReactNode;
   stepDetail: Record<string, string>;
   onStepDetailFieldChange: (key: string, value: string) => void;
   dueDate: string;
@@ -125,6 +130,7 @@ function variantSectionIcon(v: NavStepFormVariant): React.ElementType {
 export function NavigationStepEditPanel({
   stepKey,
   variant,
+  variantSectionReplacement,
   stepDetail,
   onStepDetailFieldChange,
   dueDate,
@@ -284,7 +290,9 @@ export function NavigationStepEditPanel({
 
         <Separator />
 
-        {variant === 'generic' ? (
+        {variantSectionReplacement != null ? (
+          <div className="space-y-3">{variantSectionReplacement}</div>
+        ) : variant === 'generic' ? (
           <section
             className="space-y-3 rounded-md border border-border/80 bg-muted/30 p-3"
             aria-labelledby={`${idPrefix}-sec-result`}
@@ -414,7 +422,9 @@ export function NavigationStepEditPanel({
           <div className="space-y-2">
             <Label htmlFor={notesId}>
               {variant === 'clinical_consultation'
-                ? 'Observações complementares (opcional)'
+                ? variantSectionReplacement != null
+                  ? 'Notas operacionais (opcional)'
+                  : 'Observações complementares (opcional)'
                 : 'Observações'}
             </Label>
             <AutoResizeTextarea
@@ -423,7 +433,9 @@ export function NavigationStepEditPanel({
               onChange={(e) => onNotesChange(e.target.value)}
               placeholder={
                 variant === 'clinical_consultation'
-                  ? 'Notas administrativas ou detalhes que não couberam nos campos da evolução…'
+                  ? variantSectionReplacement != null
+                    ? 'Lembretes internos, logística ou detalhes que não vão no prontuário…'
+                    : 'Notas administrativas ou detalhes que não couberam nos campos da evolução…'
                   : 'Contexto clínico, próximos passos, orientações ao paciente…'
               }
               minRows={4}

--- a/frontend/src/components/oncology-navigation/navigation-step-linked-evolutions.tsx
+++ b/frontend/src/components/oncology-navigation/navigation-step-linked-evolutions.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { FileText } from 'lucide-react';
+import { useClinicalNotesForNavigationStep } from '@/hooks/use-clinical-notes';
+import {
+  clinicalNoteTypeLabel,
+  type ClinicalNoteListItem,
+} from '@/lib/api/clinical-notes';
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { Badge } from '@/components/ui/badge';
+
+function statusLabel(status: ClinicalNoteListItem['status']): string {
+  if (status === 'SIGNED') return 'Assinada';
+  if (status === 'VOIDED') return 'Anulada';
+  return 'Rascunho';
+}
+
+export interface NavigationStepLinkedEvolutionsProps {
+  patientId: string;
+  navigationStepId: string;
+  /** Quando false, não busca (ex.: etapa ainda não persistida) */
+  enabled?: boolean;
+  compact?: boolean;
+}
+
+/**
+ * Lista evoluções do prontuário (ClinicalNote) vinculadas à etapa via navigationStepId.
+ * Substitui o modelo SOAP duplicado em metadata da etapa para consultas especializada / navegação.
+ */
+export function NavigationStepLinkedEvolutions({
+  patientId,
+  navigationStepId,
+  enabled = true,
+  compact = false,
+}: NavigationStepLinkedEvolutionsProps): React.ReactElement {
+  const { data, isLoading, isError, refetch } =
+    useClinicalNotesForNavigationStep(patientId, navigationStepId, enabled);
+
+  const items = data?.data ?? [];
+
+  return (
+    <section
+      className="space-y-3 rounded-md border border-primary/25 bg-primary/5 p-3"
+      aria-labelledby="nav-step-prontuario-heading"
+    >
+      <div className="flex items-start gap-2">
+        <FileText className="h-4 w-4 shrink-0 text-primary mt-0.5" aria-hidden />
+        <div className="min-w-0 flex-1 space-y-1">
+          <h4
+            id="nav-step-prontuario-heading"
+            className="text-sm font-semibold text-foreground"
+          >
+            Evoluções do prontuário
+          </h4>
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            O registro clínico estruturado desta consulta fica no{' '}
+            <strong>Prontuário</strong> do paciente (mesmo modelo das evoluções
+            médica / enfermagem). Use os botões de evolução na aba Prontuário
+            vinculando esta etapa.
+          </p>
+        </div>
+      </div>
+
+      {isLoading && (
+        <p className="text-xs text-muted-foreground">Carregando evoluções…</p>
+      )}
+      {isError && (
+        <p className="text-xs text-destructive">
+          Não foi possível carregar as evoluções.{' '}
+          <button
+            type="button"
+            className="underline font-medium"
+            onClick={() => void refetch()}
+          >
+            Tentar novamente
+          </button>
+        </p>
+      )}
+      {!isLoading && !isError && items.length === 0 && (
+        <p className="text-xs text-muted-foreground rounded border border-dashed border-border bg-background/80 px-2 py-2">
+          Nenhuma evolução vinculada a esta etapa ainda. Abra o{' '}
+          <Link
+            href={`/patients/${patientId}?tab=chart`}
+            className="font-medium text-primary underline underline-offset-2"
+          >
+            Prontuário do paciente
+          </Link>{' '}
+          e crie a evolução (médica ou enfermagem) escolhendo esta consulta.
+        </p>
+      )}
+      {items.length > 0 && (
+        <ul className="space-y-2" aria-label="Evoluções vinculadas">
+          {items.map((n) => (
+            <li
+              key={n.id}
+              className="flex flex-wrap items-center gap-2 rounded-md border border-border bg-background px-2 py-1.5 text-sm"
+            >
+              <span className="font-medium text-foreground">
+                {clinicalNoteTypeLabel(n.noteType)}
+              </span>
+              <Badge variant="secondary" className="text-xs font-normal">
+                {statusLabel(n.status)}
+              </Badge>
+              <span className="text-xs text-muted-foreground">
+                {format(new Date(n.createdAt), 'dd/MM/yyyy HH:mm', {
+                  locale: ptBR,
+                })}
+              </span>
+              {!compact && (
+                <Link
+                  href={`/patients/${patientId}?tab=chart`}
+                  className="ml-auto text-xs font-medium text-primary underline underline-offset-2"
+                >
+                  Abrir prontuário
+                </Link>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/patients/patient-detail-page.tsx
+++ b/frontend/src/components/patients/patient-detail-page.tsx
@@ -4,16 +4,31 @@ import { usePatientDetail } from '@/hooks/use-patient-detail';
 import { PatientDetailTabs } from './patient-detail-tabs';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, Edit } from 'lucide-react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { Card, CardContent } from '@/components/ui/card';
 
 interface PatientDetailPageProps {
   patientId: string;
 }
 
+const TAB_QUERY_VALUES = [
+  'overview',
+  'clinical',
+  'oncology',
+  'treatment',
+  'navigation',
+  'chart',
+] as const;
+
 export function PatientDetailPage({ patientId }: PatientDetailPageProps) {
   const { data: patient, isLoading, error } = usePatientDetail(patientId);
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const tabParam = searchParams.get('tab');
+  const defaultTab =
+    tabParam && TAB_QUERY_VALUES.includes(tabParam as (typeof TAB_QUERY_VALUES)[number])
+      ? (tabParam as (typeof TAB_QUERY_VALUES)[number])
+      : undefined;
 
   if (isLoading) {
     return (
@@ -75,7 +90,7 @@ export function PatientDetailPage({ patientId }: PatientDetailPageProps) {
       {/* Tabs */}
       <Card>
         <CardContent className="p-6">
-          <PatientDetailTabs patient={patient} />
+          <PatientDetailTabs patient={patient} defaultTab={defaultTab} />
         </CardContent>
       </Card>
     </div>

--- a/frontend/src/components/patients/patient-detail-tabs.tsx
+++ b/frontend/src/components/patients/patient-detail-tabs.tsx
@@ -10,15 +10,29 @@ import { PatientTreatmentTab } from './patient-treatment-tab';
 import { PatientNavigationTab } from './patient-navigation-tab';
 import { PatientProntuarioTab } from './patient-prontuario-tab';
 
+const TAB_VALUES = [
+  'overview',
+  'clinical',
+  'oncology',
+  'treatment',
+  'navigation',
+  'chart',
+] as const;
+
 interface PatientDetailTabsProps {
   patient: PatientDetail;
+  /** Ex.: `chart` quando a URL traz `?tab=chart` (link da navegação oncológica → prontuário). */
+  defaultTab?: (typeof TAB_VALUES)[number];
 }
 
 export function PatientDetailTabs({
   patient,
+  defaultTab = 'overview',
 }: PatientDetailTabsProps): React.ReactElement {
+  const initial =
+    defaultTab && TAB_VALUES.includes(defaultTab) ? defaultTab : 'overview';
   return (
-    <Tabs defaultValue="overview" className="w-full">
+    <Tabs defaultValue={initial} className="w-full">
       <TabsList className="grid w-full grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-1 h-auto">
         <TabsTrigger value="overview">Visão Geral</TabsTrigger>
         <TabsTrigger value="clinical">Dados Clínicos</TabsTrigger>

--- a/frontend/src/hooks/__tests__/use-clinical-notes.test.ts
+++ b/frontend/src/hooks/__tests__/use-clinical-notes.test.ts
@@ -1,0 +1,179 @@
+import { vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+
+vi.mock('@/lib/api/clinical-notes', () => ({
+  clinicalNotesApi: {
+    list: vi.fn(),
+    getById: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    sign: vi.fn(),
+    addendum: vi.fn(),
+    void: vi.fn(),
+    getSectionSuggestions: vi.fn(),
+  },
+}));
+
+import {
+  useClinicalNoteDetail,
+  useClinicalNoteMutations,
+  useClinicalNotesForNavigationStep,
+  useClinicalNotesList,
+} from '../use-clinical-notes';
+import { clinicalNotesApi } from '@/lib/api/clinical-notes';
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return Wrapper;
+}
+
+describe('useClinicalNotesList', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('não executa query sem patientId', () => {
+    const { result } = renderHook(
+      () => useClinicalNotesList(undefined),
+      { wrapper: makeWrapper() }
+    );
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(clinicalNotesApi.list).not.toHaveBeenCalled();
+  });
+
+  it('chama clinicalNotesApi.list com paginação padrão quando patientId existe', async () => {
+    vi.mocked(clinicalNotesApi.list).mockResolvedValue({
+      data: [],
+      total: 0,
+      page: 1,
+      limit: 50,
+    } as never);
+
+    const { result } = renderHook(
+      () => useClinicalNotesList('patient-1'),
+      { wrapper: makeWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(clinicalNotesApi.list).toHaveBeenCalledWith('patient-1', {
+      page: 1,
+      limit: 50,
+    });
+  });
+});
+
+describe('useClinicalNotesForNavigationStep', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('não executa query quando enabled=false', () => {
+    const { result } = renderHook(
+      () => useClinicalNotesForNavigationStep('p1', 'ns1', false),
+      { wrapper: makeWrapper() }
+    );
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(clinicalNotesApi.list).not.toHaveBeenCalled();
+  });
+
+  it('não executa query quando patientId está ausente', () => {
+    const { result } = renderHook(
+      () => useClinicalNotesForNavigationStep(undefined, 'ns1', true),
+      { wrapper: makeWrapper() }
+    );
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(clinicalNotesApi.list).not.toHaveBeenCalled();
+  });
+
+  it('não executa query quando navigationStepId está ausente', () => {
+    const { result } = renderHook(
+      () => useClinicalNotesForNavigationStep('p1', undefined, true),
+      { wrapper: makeWrapper() }
+    );
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(clinicalNotesApi.list).not.toHaveBeenCalled();
+  });
+
+  it('chama clinicalNotesApi.list com navigationStepId quando habilitado', async () => {
+    vi.mocked(clinicalNotesApi.list).mockResolvedValue({
+      data: [],
+      total: 0,
+      page: 1,
+      limit: 50,
+    } as never);
+
+    const { result } = renderHook(
+      () => useClinicalNotesForNavigationStep('p1', 'ns1', true),
+      { wrapper: makeWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(clinicalNotesApi.list).toHaveBeenCalledWith('p1', {
+      page: 1,
+      limit: 50,
+      navigationStepId: 'ns1',
+    });
+  });
+});
+
+describe('useClinicalNoteDetail', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('não executa query sem id', () => {
+    const { result } = renderHook(
+      () => useClinicalNoteDetail(undefined),
+      { wrapper: makeWrapper() }
+    );
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(clinicalNotesApi.getById).not.toHaveBeenCalled();
+  });
+
+  it('chama clinicalNotesApi.getById quando id existe', async () => {
+    vi.mocked(clinicalNotesApi.getById).mockResolvedValue({ id: 'n1' } as never);
+
+    const { result } = renderHook(
+      () => useClinicalNoteDetail('n1'),
+      { wrapper: makeWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(clinicalNotesApi.getById).toHaveBeenCalledWith('n1');
+  });
+});
+
+describe('useClinicalNoteMutations', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('create chama clinicalNotesApi.create com payload normalizado', async () => {
+    vi.mocked(clinicalNotesApi.create).mockResolvedValue({ id: 'n1' } as never);
+
+    const { result } = renderHook(
+      () => useClinicalNoteMutations('patient-1'),
+      { wrapper: makeWrapper() }
+    );
+
+    result.current.create.mutate({
+      noteType: 'MEDICAL',
+      navigationStepId: 'ns-1',
+      sections: { hda: 'teste' },
+    } as never);
+
+    await waitFor(() => expect(result.current.create.isSuccess).toBe(true));
+    expect(clinicalNotesApi.create).toHaveBeenCalledWith('patient-1', {
+      noteType: 'MEDICAL',
+      navigationStepId: 'ns-1',
+      sections: { hda: 'teste' },
+    });
+  });
+});
+

--- a/frontend/src/hooks/use-clinical-notes.ts
+++ b/frontend/src/hooks/use-clinical-notes.ts
@@ -13,6 +13,25 @@ export function useClinicalNotesList(patientId: string | undefined) {
   });
 }
 
+/** Evoluções do prontuário vinculadas a uma etapa de navegação (consulta especializada / navegação). */
+export function useClinicalNotesForNavigationStep(
+  patientId: string | undefined,
+  navigationStepId: string | undefined,
+  enabled: boolean
+) {
+  return useQuery({
+    queryKey: ['clinical-notes', patientId, 'navigation-step', navigationStepId],
+    queryFn: () =>
+      clinicalNotesApi.list(patientId!, {
+        page: 1,
+        limit: 50,
+        navigationStepId,
+      }),
+    enabled: Boolean(patientId && navigationStepId && enabled),
+    staleTime: 15_000,
+  });
+}
+
 export function useClinicalNoteDetail(id: string | undefined) {
   return useQuery({
     queryKey: ['clinical-notes', 'detail', id],

--- a/frontend/src/lib/api/clinical-notes.ts
+++ b/frontend/src/lib/api/clinical-notes.ts
@@ -195,7 +195,7 @@ export interface PaginatedClinicalNotes {
 export const clinicalNotesApi = {
   list(
     patientId: string,
-    params?: { page?: number; limit?: number }
+    params?: { page?: number; limit?: number; navigationStepId?: string }
   ): Promise<PaginatedClinicalNotes> {
     return apiClient.get<PaginatedClinicalNotes>(
       `/patients/${patientId}/clinical-notes`,

--- a/frontend/src/lib/utils/nav-step-form-variants.ts
+++ b/frontend/src/lib/utils/nav-step-form-variants.ts
@@ -190,6 +190,15 @@ export function baseStepKey(stepKey: string): string {
   return stepKey.replace(/-\d+$/, '').toLowerCase();
 }
 
+/**
+ * Etapas cuja evolução clínica oficial é o prontuário (ClinicalNote), não o SOAP em metadata da etapa.
+ * Evita modelo duplicado na edição do card de navegação.
+ */
+export function usesProntuarioEvolutionModel(stepKeyRaw: string): boolean {
+  const k = baseStepKey(stepKeyRaw);
+  return k === 'specialist_consultation' || k === 'navigation_consultation';
+}
+
 export function getNavStepFormVariant(stepKeyRaw: string): NavStepFormVariant {
   const k = baseStepKey(stepKeyRaw);
 

--- a/frontend/src/middleware.test.ts
+++ b/frontend/src/middleware.test.ts
@@ -1,7 +1,7 @@
 import { middleware } from './middleware';
 
-function buildRequest(pathname: string, cookie?: string) {
-  const url = `https://onconav.local${pathname}`;
+function buildRequest(pathname: string, cookie?: string, protocol: 'http' | 'https' = 'https') {
+  const url = `${protocol}://onconav.local${pathname}`;
   const headers = new Headers(cookie ? { cookie } : {});
 
   const request = {
@@ -49,9 +49,17 @@ describe('middleware auth gating (probe no backend)', () => {
     const [calledUrl, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     // Probe usa URL interna (loopback) — não o hostname externo da requisição original.
     // Isso evita roundtrip HTTPS externo no Docker de produção.
-    expect(calledUrl).toBe('http://localhost:3000/api/v1/auth/profile');
+    expect(calledUrl).toBe('https://localhost:3000/api/v1/auth/profile');
     expect(init?.method).toBe('GET');
     expect((init?.headers as Record<string, string>)?.cookie).toContain('access_token=token');
+  });
+
+  it('usa o protocolo da requisição (http) ao montar URL interna padrão', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ id: 'u1' }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    await middleware(buildRequest('/dashboard', 'access_token=token', 'http'));
+    const [calledUrl] = fetchMock.mock.calls[0] as unknown as [string];
+    expect(calledUrl).toBe('http://localhost:3000/api/v1/auth/profile');
   });
 
   it('usa INTERNAL_APP_URL quando hostname é .internal (permitido)', async () => {

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -25,15 +25,18 @@ const SESSION_PROBE_TIMEOUT_MS = 2000;
  * Quando INTERNAL_APP_URL está definido, o hostname é validado para prevenir
  * SSRF interno: somente loopback e sufixo `.internal` são permitidos.
  */
-function internalProbeUrl(): string {
+function internalProbeUrl(request: NextRequest): string {
   const raw =
     process.env.INTERNAL_APP_URL ??
-    `http://localhost:${process.env.PORT ?? 3000}`;
+    `${request.nextUrl.protocol}//localhost:${process.env.PORT ?? 3000}`;
   const parsed = new URL(raw); // lança se malformada
   const ALLOWED = new Set(['localhost', '127.0.0.1', '::1']);
   if (!ALLOWED.has(parsed.hostname) && !parsed.hostname.endsWith('.internal')) {
     // Falha segura: hostname não permitido → usa loopback padrão.
-    return new URL(SESSION_PROBE_PATH, `http://localhost:${process.env.PORT ?? 3000}`).toString();
+    return new URL(
+      SESSION_PROBE_PATH,
+      `${request.nextUrl.protocol}//localhost:${process.env.PORT ?? 3000}`
+    ).toString();
   }
   return new URL(SESSION_PROBE_PATH, raw).toString();
 }
@@ -43,7 +46,7 @@ async function hasActiveSession(request: NextRequest): Promise<boolean> {
   const timeout = setTimeout(() => controller.abort(), SESSION_PROBE_TIMEOUT_MS);
 
   try {
-    const url = internalProbeUrl();
+    const url = internalProbeUrl(request);
     const res = await fetch(url, {
       method: 'GET',
       headers: {


### PR DESCRIPTION
## Summary
- Endurece a sessão no backend e restringe/filtra evoluções por etapa.
- Frontend passa a vincular evoluções à etapa e melhora o fluxo do paciente.
- Adiciona cobertura de testes no backend (sessão/validação) e no frontend (middleware/hook).

## Test plan
- [x] Backend: Jest (auth + clinical-notes)
- [x] Frontend: Vitest (middleware + hook de evoluções)
- [ ] Validar manualmente: criar/editar evolução em etapa correta e confirmar que etapas indevidas não aparecem