### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,63 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Services overview
+
+| Service | Port | Command | Health check |
+|---------|------|---------|--------------|
+| Backend (NestJS) | 3002 | `cd backend && npm run start:dev` | `curl http://localhost:3002/api/v1/health` |
+| Frontend (Next.js) | 3000 | `cd frontend && npm run dev` | `curl http://localhost:3000` |
+| AI Service (FastAPI) | 8001 | `cd ai-service && uvicorn main:app --reload --host 0.0.0.0 --port 8001` | `curl http://localhost:8001/health` |
+| PostgreSQL | 5432 | via Docker (`compose.infra.yml`) | `docker exec pg-database pg_isready` |
+| Redis | 6379 | via Docker (`compose.infra.yml`) | `docker exec redis-cache redis-cli ping` |
+| RabbitMQ | 5672/15672 | via Docker (`compose.infra.yml`) | `docker exec msg-service rabbitmq-diagnostics ping` |
+
+### Starting infrastructure
+
+```bash
+# Docker daemon must be running first
+sudo dockerd &>/tmp/dockerd.log &
+sleep 3
+docker compose -f compose.infra.yml up -d
+```
+
+Wait for containers to be healthy before running migrations or starting services.
+
+### Database setup
+
+After infrastructure is up (PostgreSQL healthy):
+
+```bash
+cd backend && npx prisma migrate deploy && npx prisma db seed
+```
+
+### Non-obvious caveats
+
+- **Python PATH**: `pip install` installs binaries to `~/.local/bin`. Ensure `export PATH="$HOME/.local/bin:$PATH"` is set before running `uvicorn` or `pytest`.
+- **Docker in this VM**: The environment runs Docker-in-Docker with `fuse-overlayfs` storage driver and `iptables-legacy`. Docker daemon needs to be started manually with `sudo dockerd`.
+- **AI Service without LLM keys**: The service works without `OPENAI_API_KEY`/`ANTHROPIC_API_KEY`—it falls back to mocked responses. Clinical rules and ML model still function.
+- **Backend service token**: The AI service requires `Authorization: Bearer <BACKEND_SERVICE_TOKEN>` for internal endpoints. In dev, this is `change-me-internal-service-token` (matching `backend/.env` and `ai-service/.env`).
+- **Cookie-based auth**: Login returns JWT in HttpOnly cookies (not in response body). Use `curl -c cookies.txt` / `curl -b cookies.txt` for testing.
+- **Each service has its own `.env`**: `backend/.env`, `frontend/.env`, `ai-service/.env`. The root `.env` is NOT used.
+
+### Test credentials (seeded)
+
+| Role | Email | Password |
+|------|-------|----------|
+| ADMIN | admin@hospitalteste.com | senha123 |
+| ONCOLOGIST | oncologista@hospitalteste.com | senha123 |
+| NURSE | enfermeira@hospitalteste.com | senha123 |
+
+### Running tests
+
+See `CLAUDE.md` and `README.md` for full command reference. Quick summary:
+- Backend: `cd backend && npm test`
+- Frontend: `cd frontend && npm test`
+- AI Service: `cd ai-service && pytest`
+
+### Running lint
+
+- Backend: `cd backend && npm run lint`
+- Frontend: `cd frontend && npm run lint`
+- AI Service: `cd ai-service && ruff check .`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions for future agents, including:

- Services overview table (ports, commands, health checks)
- Infrastructure startup instructions (Docker-in-Docker caveats)
- Database setup steps
- Non-obvious caveats (Python PATH, cookie auth, service tokens, env files)
- Test credentials and commands reference

## Environment Verification

All services verified working:

[services_health_check.log](https://cursor.com/agents/bc-21ad53ef-616a-4280-9d48-3219e184168c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fservices_health_check.log)

## What was tested

- ✅ Backend lint (0 errors, warnings only)
- ✅ Frontend lint (0 errors, 2 warnings)
- ✅ AI Service lint (ruff - all passed)
- ✅ Backend tests (42 suites, 669 tests passed)
- ✅ Frontend tests (25 files, 237 tests passed)
- ✅ AI Service tests (97 passed, 2 skipped)
- ✅ All 3 services running in dev mode with health checks passing
- ✅ Login + authenticated API call (fetched patients list)
- ✅ AI Service prioritization endpoint tested


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21ad53ef-616a-4280-9d48-3219e184168c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21ad53ef-616a-4280-9d48-3219e184168c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

