### PR TITLE
fix(backend): scan Trivy no deploy — imagem e dependências

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # ---- deps ----
-FROM node:24.14.0-alpine3.23 AS deps
+FROM node:24.14.1-alpine3.23 AS deps
 WORKDIR /app
 
 COPY package*.json ./
@@ -14,7 +14,7 @@ RUN mkdir -p /certs && \
       -o /certs/rds-global-bundle.pem
 
 # ---- dev ----
-FROM node:24.14.0-alpine3.23 AS dev
+FROM node:24.14.1-alpine3.23 AS dev
 WORKDIR /app
 
 ENV NODE_ENV=development
@@ -28,7 +28,7 @@ EXPOSE 3002
 CMD ["npm", "run", "start:dev"]
 
 # ---- builder ----
-FROM node:24.14.0-alpine3.23 AS builder
+FROM node:24.14.1-alpine3.23 AS builder
 WORKDIR /app
 
 COPY --from=deps /app/node_modules ./node_modules
@@ -40,7 +40,7 @@ RUN npx prisma generate && \
 RUN npm prune --omit=dev
 
 # ---- production ----
-FROM node:24.14.0-alpine3.23 AS production
+FROM node:24.14.1-alpine3.23 AS production
 WORKDIR /app
 
 ENV NODE_ENV=production
@@ -51,7 +51,7 @@ COPY --from=builder /app/prisma ./prisma
 COPY --from=builder /app/prisma.config.mjs ./prisma.config.mjs
 COPY --from=rds-ca /certs/rds-global-bundle.pem /app/certs/rds-global-bundle.pem
 
-RUN chown -R node:node /app
+RUN apk update && apk upgrade --no-cache && chown -R node:node /app
 
 USER node
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -3875,11 +3875,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -6631,9 +6632,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Contexto

O job **Scan** do workflow de deploy (`.github/workflows/deploy.yml`) executa o **Trivy** na imagem `oncosaas-backend` com `--severity CRITICAL` e `--ignore-unfixed`, falhando o deploy quando há CVEs críticas com correção disponível na imagem final.

## O que mudou

1. **Base Docker**: `node:24.14.0-alpine3.23` → `node:24.14.1-alpine3.23` em todos os estágios do `backend/Dockerfile` (patch de segurança do runtime Node/Alpine publicado na imagem oficial).
2. **Alpine na imagem de produção**: `apk update && apk upgrade --no-cache` antes do `chown`, para aplicar correções de pacotes do SO presentes nos repositórios Alpine no momento do build (alinhado ao gate Trivy).
3. **Dependências npm**: `npm audit fix` — atualiza **axios** e **hono** para versões sem as vulnerabilidades reportadas pelo `npm audit` (HIGH/moderate), reduzindo também a superfície na camada `node_modules` da imagem.

## Verificação local

- `npm ci`, `npm run lint` e `npm test` no `backend/` após as mudanças.

## Notas

O daemon Docker não estava disponível neste ambiente para reproduzir o Trivy exatamente como no CI; as alterações seguem o padrão já usado no `ai-service` (upgrade de pacotes do SO na imagem) e as tags oficiais do Docker Hub para Node Alpine.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e3eaf8b-f860-4cbd-b190-33ff80d12fab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e3eaf8b-f860-4cbd-b190-33ff80d12fab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

