### PR TITLE
feat(frontend): agenda de consultas na navegação oncológica

### DIFF
--- a/backend/src/oncology-navigation/dto/consultation-agenda-query.dto.ts
+++ b/backend/src/oncology-navigation/dto/consultation-agenda-query.dto.ts
@@ -1,0 +1,37 @@
+import { Type } from 'class-transformer';
+import {
+  IsDateString,
+  IsIn,
+  IsInt,
+  IsOptional,
+  Max,
+  Min,
+} from 'class-validator';
+
+export type ConsultationAgendaScope = 'consultations' | 'all';
+
+/** Query params para GET /oncology-navigation/consultation-agenda */
+export class ConsultationAgendaQueryDto {
+  @IsDateString()
+  from!: string;
+
+  @IsDateString()
+  to!: string;
+
+  @IsOptional()
+  @IsIn(['consultations', 'all'])
+  scope?: ConsultationAgendaScope = 'consultations';
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 50;
+}

--- a/backend/src/oncology-navigation/oncology-navigation.controller.ts
+++ b/backend/src/oncology-navigation/oncology-navigation.controller.ts
@@ -18,6 +18,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { diskStorage } from 'multer';
 import { extname } from 'path';
 import { OncologyNavigationService } from './oncology-navigation.service';
+import { ConsultationAgendaQueryDto } from './dto/consultation-agenda-query.dto';
 import { CreateNavigationStepDto } from './dto/create-navigation-step.dto';
 import { UpdateNavigationStepDto } from './dto/update-navigation-step.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -43,6 +44,20 @@ interface MulterFile {
 @UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
 export class OncologyNavigationController {
   constructor(private readonly navigationService: OncologyNavigationService) {}
+
+  @Get('consultation-agenda')
+  async getConsultationAgenda(
+    @Query() query: ConsultationAgendaQueryDto,
+    @Request() req: any
+  ) {
+    return this.navigationService.getConsultationAgenda(req.user.tenantId, {
+      from: query.from,
+      to: query.to,
+      scope: query.scope,
+      page: query.page,
+      limit: query.limit,
+    });
+  }
 
   @Get('patients/:patientId/steps')
   async getPatientSteps(

--- a/backend/src/oncology-navigation/oncology-navigation.service.spec.ts
+++ b/backend/src/oncology-navigation/oncology-navigation.service.spec.ts
@@ -8,6 +8,7 @@ import {
 } from './oncology-navigation.service';
 
 type MockPrisma = {
+  $transaction: jest.Mock;
   patient: {
     findFirst: jest.Mock;
     findMany: jest.Mock;
@@ -21,6 +22,7 @@ type MockPrisma = {
     create: jest.Mock;
     update: jest.Mock;
     aggregate: jest.Mock;
+    count: jest.Mock;
   };
   alert: {
     findFirst: jest.Mock;
@@ -46,6 +48,7 @@ describe('OncologyNavigationService', () => {
 
   beforeEach((): void => {
     mockPrisma = {
+      $transaction: jest.fn(),
       patient: {
         findFirst: jest.fn(),
         findMany: jest.fn(),
@@ -59,6 +62,7 @@ describe('OncologyNavigationService', () => {
         create: jest.fn(),
         update: jest.fn(),
         aggregate: jest.fn(),
+        count: jest.fn(),
       },
       alert: {
         findFirst: jest.fn(),
@@ -815,6 +819,140 @@ describe('OncologyNavigationService', () => {
         'breast',
         JourneyStage.SCREENING
       );
+    });
+  });
+
+  // ─── getConsultationAgenda ───────────────────────────────────────────────────
+
+  describe('getConsultationAgenda', () => {
+    const agendaRow = {
+      id: 'step-agenda-1',
+      patientId: PATIENT_ID,
+      stepKey: 'specialist_consultation',
+      stepName: 'Consulta especialista',
+      journeyStage: JourneyStage.TREATMENT,
+      status: NavigationStepStatus.PENDING,
+      isCompleted: false,
+      expectedDate: new Date('2026-05-10T00:00:00.000Z'),
+      dueDate: new Date('2026-05-12T00:00:00.000Z'),
+      actualDate: null,
+      patient: { id: PATIENT_ID, name: 'Paciente Teste' },
+    };
+
+    it('throws BadRequestException when from is after to', async () => {
+      await expect(
+        service.getConsultationAgenda(TENANT, {
+          from: '2026-05-10',
+          to: '2026-05-01',
+        })
+      ).rejects.toThrow(BadRequestException);
+      expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when dates are invalid', async () => {
+      await expect(
+        service.getConsultationAgenda(TENANT, {
+          from: 'not-a-date',
+          to: '2026-05-01',
+        })
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('scopes Prisma where to tenantId and excludes CANCELLED', async () => {
+      mockPrisma.$transaction.mockResolvedValue([1, [agendaRow]]);
+
+      await service.getConsultationAgenda(TENANT, {
+        from: '2026-05-01',
+        to: '2026-05-31',
+        scope: 'consultations',
+      });
+
+      expect(mockPrisma.$transaction).toHaveBeenCalled();
+      expect(mockPrisma.navigationStep.count).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            tenantId: TENANT,
+            status: { not: NavigationStepStatus.CANCELLED },
+            stepKey: {
+              in: ['specialist_consultation', 'navigation_consultation'],
+            },
+          }),
+        })
+      );
+    });
+
+    it('omits stepKey filter when scope is all', async () => {
+      mockPrisma.$transaction.mockResolvedValue([0, []]);
+
+      await service.getConsultationAgenda(TENANT, {
+        from: '2026-05-01',
+        to: '2026-05-31',
+        scope: 'all',
+      });
+
+      const countArg = mockPrisma.navigationStep.count.mock.calls[0][0];
+      expect(countArg.where).not.toHaveProperty('stepKey');
+      expect(countArg.where.tenantId).toBe(TENANT);
+    });
+
+    it('applies pagination (skip/take) for page 2', async () => {
+      mockPrisma.$transaction.mockResolvedValue([0, []]);
+
+      await service.getConsultationAgenda(TENANT, {
+        from: '2026-05-01',
+        to: '2026-05-31',
+        page: 2,
+        limit: 25,
+      });
+
+      expect(mockPrisma.navigationStep.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skip: 25,
+          take: 25,
+        })
+      );
+    });
+
+    it('caps limit at 100', async () => {
+      mockPrisma.$transaction.mockResolvedValue([0, []]);
+
+      await service.getConsultationAgenda(TENANT, {
+        from: '2026-05-01',
+        to: '2026-05-31',
+        limit: 500,
+      });
+
+      expect(mockPrisma.navigationStep.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 100 })
+      );
+    });
+
+    it('maps agendaDate from expectedDate when present', async () => {
+      mockPrisma.$transaction.mockResolvedValue([1, [agendaRow]]);
+
+      const page = await service.getConsultationAgenda(TENANT, {
+        from: '2026-05-01',
+        to: '2026-05-31',
+      });
+
+      expect(page.items).toHaveLength(1);
+      expect(page.items[0].agendaDate).toEqual(agendaRow.expectedDate);
+      expect(page.total).toBe(1);
+      expect(page.page).toBe(1);
+      expect(page.limit).toBe(50);
+      expect(page.totalPages).toBe(1);
+    });
+
+    it('returns totalPages 0 when total is 0', async () => {
+      mockPrisma.$transaction.mockResolvedValue([0, []]);
+
+      const page = await service.getConsultationAgenda(TENANT, {
+        from: '2026-05-01',
+        to: '2026-05-31',
+      });
+
+      expect(page.totalPages).toBe(0);
+      expect(page.items).toEqual([]);
     });
   });
 

--- a/backend/src/oncology-navigation/oncology-navigation.service.ts
+++ b/backend/src/oncology-navigation/oncology-navigation.service.ts
@@ -4,6 +4,7 @@ import {
   BadRequestException,
   Logger,
 } from '@nestjs/common';
+import type { ConsultationAgendaScope } from './dto/consultation-agenda-query.dto';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateNavigationStepDto } from './dto/create-navigation-step.dto';
 import { UpdateNavigationStepDto } from './dto/update-navigation-step.dto';
@@ -38,6 +39,39 @@ const JOURNEY_STAGE_ORDER: Record<JourneyStage, number> = {
   [JourneyStage.FOLLOW_UP]: 3,
   [JourneyStage.PALLIATIVE]: 4,
 };
+
+/** Etapas de consulta (alinha a clinical-notes.constants e nav-step-form-variants) */
+export const CONSULTATION_STEP_KEYS = [
+  'specialist_consultation',
+  'navigation_consultation',
+] as const;
+
+export interface ConsultationAgendaItem {
+  id: string;
+  patientId: string;
+  stepKey: string;
+  stepName: string;
+  journeyStage: JourneyStage;
+  status: NavigationStepStatus;
+  isCompleted: boolean;
+  expectedDate: Date | null;
+  dueDate: Date | null;
+  actualDate: Date | null;
+  /** Data de referência na agenda (esperada ou limite) */
+  agendaDate: Date;
+  patient: {
+    id: string;
+    name: string;
+  };
+}
+
+export interface ConsultationAgendaPage {
+  items: ConsultationAgendaItem[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
 
 @Injectable()
 export class OncologyNavigationService {
@@ -91,6 +125,125 @@ export class OncologyNavigationService {
         { createdAt: 'asc' },
       ],
     });
+  }
+
+  /**
+   * Lista etapas de navegação com data no intervalo [from, to] para a agenda de consultas.
+   * Leitura em lote (PHI): escopo limitado a tenantId do JWT no controller.
+   */
+  async getConsultationAgenda(
+    tenantId: string,
+    params: {
+      from: string;
+      to: string;
+      scope?: ConsultationAgendaScope;
+      page?: number;
+      limit?: number;
+    }
+  ): Promise<ConsultationAgendaPage> {
+    const fromStart = new Date(params.from);
+    const toEnd = new Date(params.to);
+    if (Number.isNaN(fromStart.getTime()) || Number.isNaN(toEnd.getTime())) {
+      throw new BadRequestException('Datas from/to inválidas');
+    }
+    fromStart.setUTCHours(0, 0, 0, 0);
+    toEnd.setUTCHours(23, 59, 59, 999);
+    if (fromStart > toEnd) {
+      throw new BadRequestException('from deve ser anterior ou igual a to');
+    }
+
+    const page = params.page ?? 1;
+    const limit = Math.min(params.limit ?? 50, 100);
+    const skip = (page - 1) * limit;
+    const scope = params.scope ?? 'consultations';
+
+    const stepKeyFilter =
+      scope === 'consultations'
+        ? { stepKey: { in: [...CONSULTATION_STEP_KEYS] } }
+        : {};
+
+    const dateOverlap: Prisma.NavigationStepWhereInput = {
+      OR: [
+        {
+          AND: [
+            { expectedDate: { not: null } },
+            { expectedDate: { gte: fromStart, lte: toEnd } },
+          ],
+        },
+        {
+          AND: [
+            { dueDate: { not: null } },
+            { dueDate: { gte: fromStart, lte: toEnd } },
+          ],
+        },
+        {
+          AND: [
+            { expectedDate: { not: null } },
+            { dueDate: { not: null } },
+            { expectedDate: { lte: toEnd } },
+            { dueDate: { gte: fromStart } },
+          ],
+        },
+      ],
+    };
+
+    const where: Prisma.NavigationStepWhereInput = {
+      tenantId,
+      status: { not: NavigationStepStatus.CANCELLED },
+      ...stepKeyFilter,
+      ...dateOverlap,
+    };
+
+    const [total, rows] = await this.prisma.$transaction([
+      this.prisma.navigationStep.count({ where }),
+      this.prisma.navigationStep.findMany({
+        where,
+        select: {
+          id: true,
+          patientId: true,
+          stepKey: true,
+          stepName: true,
+          journeyStage: true,
+          status: true,
+          isCompleted: true,
+          expectedDate: true,
+          dueDate: true,
+          actualDate: true,
+          patient: { select: { id: true, name: true } },
+        },
+        orderBy: [{ expectedDate: 'asc' }, { dueDate: 'asc' }, { stepName: 'asc' }],
+        take: limit,
+        skip,
+      }),
+    ]);
+
+    const items: ConsultationAgendaItem[] = rows.map((row) => {
+      const agendaDate = row.expectedDate ?? row.dueDate ?? fromStart;
+      return {
+        id: row.id,
+        patientId: row.patientId,
+        stepKey: row.stepKey,
+        stepName: row.stepName,
+        journeyStage: row.journeyStage,
+        status: row.status,
+        isCompleted: row.isCompleted,
+        expectedDate: row.expectedDate,
+        dueDate: row.dueDate,
+        actualDate: row.actualDate,
+        agendaDate,
+        patient: row.patient,
+      };
+    });
+
+    const totalPages = total === 0 ? 0 : Math.ceil(total / limit);
+
+    return {
+      items,
+      total,
+      page,
+      limit,
+      totalPages,
+    };
   }
 
   /**

--- a/frontend/src/app/oncology-navigation/agenda/page.tsx
+++ b/frontend/src/app/oncology-navigation/agenda/page.tsx
@@ -21,6 +21,7 @@ import { Button, buttonVariants } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { EmptyState } from '@/components/ui/empty-state';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
   Select,
@@ -269,15 +270,12 @@ export default function ConsultationAgendaPage() {
         </Card>
 
         {isError && (
-          <div
-            role="alert"
-            className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive"
-          >
-            <p className="font-semibold">Não foi possível carregar a agenda</p>
-            <p className="mt-1 text-sm">
+          <Alert variant="destructive">
+            <AlertTitle>Não foi possível carregar a agenda</AlertTitle>
+            <AlertDescription>
               {error instanceof Error ? error.message : 'Erro desconhecido.'}
-            </p>
-          </div>
+            </AlertDescription>
+          </Alert>
         )}
 
         {isLoading && (

--- a/frontend/src/app/oncology-navigation/agenda/page.tsx
+++ b/frontend/src/app/oncology-navigation/agenda/page.tsx
@@ -2,101 +2,25 @@
 
 import React, { useCallback, useMemo, useState } from 'react';
 import Link from 'next/link';
-import {
-  endOfWeek,
-  format,
-  parseISO,
-  startOfWeek,
-} from 'date-fns';
+import { endOfWeek, parseISO, startOfWeek } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
-import {
-  CalendarDays,
-  ChevronLeft,
-  ChevronRight,
-  ExternalLink,
-  RefreshCw,
-} from 'lucide-react';
+import { CalendarDays, RefreshCw } from 'lucide-react';
 import { NavigationBar } from '@/components/shared/navigation-bar';
+import { ConsultationAgendaDaySection } from '@/components/oncology-navigation/consultation-agenda-day-section';
+import { ConsultationAgendaFilters } from '@/components/oncology-navigation/consultation-agenda-filters';
+import { ConsultationAgendaPagination } from '@/components/oncology-navigation/consultation-agenda-pagination';
 import { Button, buttonVariants } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Skeleton } from '@/components/ui/skeleton';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { cn } from '@/lib/utils';
-import { JOURNEY_STAGE_LABELS, type JourneyStage } from '@/lib/utils/journey-stage';
+import {
+  groupConsultationAgendaByDay,
+  toYmd,
+} from '@/lib/utils/consultationAgenda';
 import { useConsultationAgenda } from '@/hooks/useOncologyNavigation';
-import type { ConsultationAgendaItem, ConsultationAgendaScope } from '@/lib/api/oncology-navigation';
-
-function toYmd(d: Date): string {
-  return format(d, 'yyyy-MM-dd');
-}
-
-const STATUS_LABEL: Record<string, string> = {
-  PENDING: 'Pendente',
-  IN_PROGRESS: 'Em andamento',
-  COMPLETED: 'Concluída',
-  OVERDUE: 'Atrasada',
-  CANCELLED: 'Cancelada',
-  NOT_APPLICABLE: 'Não aplicável',
-};
-
-function statusBadgeVariant(
-  status: string
-): 'default' | 'secondary' | 'destructive' | 'outline' | 'success' {
-  switch (status) {
-    case 'COMPLETED':
-      return 'success';
-    case 'OVERDUE':
-      return 'destructive';
-    case 'IN_PROGRESS':
-      return 'default';
-    case 'PENDING':
-      return 'secondary';
-    default:
-      return 'outline';
-  }
-}
-
-function formatAgendaDayLabel(iso: string): string {
-  try {
-    return format(parseISO(iso), "EEEE, d 'de' MMMM", { locale: ptBR });
-  } catch {
-    return iso;
-  }
-}
-
-function formatShortDate(iso: string | null): string {
-  if (!iso) return '—';
-  try {
-    return format(parseISO(iso), 'dd/MM/yyyy', { locale: ptBR });
-  } catch {
-    return '—';
-  }
-}
-
-function groupByAgendaDay(items: ConsultationAgendaItem[]): Map<string, ConsultationAgendaItem[]> {
-  const map = new Map<string, ConsultationAgendaItem[]>();
-  for (const item of items) {
-    let key: string;
-    try {
-      key = format(parseISO(item.agendaDate), 'yyyy-MM-dd');
-    } catch {
-      key = item.agendaDate.slice(0, 10);
-    }
-    const list = map.get(key) ?? [];
-    list.push(item);
-    map.set(key, list);
-  }
-  return map;
-}
+import type { ConsultationAgendaScope } from '@/lib/api/oncology-navigation';
 
 export default function ConsultationAgendaPage() {
   const now = useMemo(() => new Date(), []);
@@ -125,7 +49,8 @@ export default function ConsultationAgendaPage() {
     useConsultationAgenda(queryParams);
 
   const grouped = useMemo(
-    () => (data?.items ? groupByAgendaDay(data.items) : new Map()),
+    () =>
+      data?.items ? groupConsultationAgendaByDay(data.items) : new Map(),
     [data?.items]
   );
   const sortedDayKeys = useMemo(
@@ -133,14 +58,17 @@ export default function ConsultationAgendaPage() {
     [grouped]
   );
 
-  const shiftWeek = useCallback((delta: -1 | 1) => {
-    const anchor = parseISO(from);
-    const next = new Date(anchor);
-    next.setDate(next.getDate() + delta * 7);
-    setFrom(toYmd(startOfWeek(next, { locale: ptBR })));
-    setTo(toYmd(endOfWeek(next, { locale: ptBR })));
-    setPage(1);
-  }, [from]);
+  const shiftWeek = useCallback(
+    (delta: -1 | 1) => {
+      const anchor = parseISO(from);
+      const next = new Date(anchor);
+      next.setDate(next.getDate() + delta * 7);
+      setFrom(toYmd(startOfWeek(next, { locale: ptBR })));
+      setTo(toYmd(endOfWeek(next, { locale: ptBR })));
+      setPage(1);
+    },
+    [from]
+  );
 
   const totalPages = data?.totalPages ?? 0;
 
@@ -157,7 +85,8 @@ export default function ConsultationAgendaPage() {
               Agenda de consultas
             </h1>
             <p className="mt-1 text-sm text-muted-foreground">
-              Etapas de consulta com data prevista ou limite no período selecionado.
+              Etapas de consulta com data prevista ou limite no período
+              selecionado.
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
@@ -184,90 +113,24 @@ export default function ConsultationAgendaPage() {
           </div>
         </header>
 
-        <Card>
-          <CardHeader className="pb-4">
-            <CardTitle className="text-base font-medium">Filtros</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="flex flex-wrap items-end gap-4">
-              <div className="flex flex-col gap-1.5">
-                <label htmlFor="agenda-from" className="text-sm font-medium">
-                  De
-                </label>
-                <input
-                  id="agenda-from"
-                  type="date"
-                  value={from}
-                  onChange={(e) => {
-                    setFrom(e.target.value);
-                    setPage(1);
-                  }}
-                  className="flex h-10 w-full min-w-[10rem] rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                />
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <label htmlFor="agenda-to" className="text-sm font-medium">
-                  Até
-                </label>
-                <input
-                  id="agenda-to"
-                  type="date"
-                  value={to}
-                  onChange={(e) => {
-                    setTo(e.target.value);
-                    setPage(1);
-                  }}
-                  className="flex h-10 w-full min-w-[10rem] rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                />
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <span id="agenda-scope-label" className="text-sm font-medium">
-                  Escopo
-                </span>
-                <Select
-                  value={scope}
-                  onValueChange={(v) => {
-                    setScope(v as ConsultationAgendaScope);
-                    setPage(1);
-                  }}
-                >
-                  <SelectTrigger
-                    className="w-[220px]"
-                    aria-labelledby="agenda-scope-label"
-                  >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="consultations">
-                      Somente consultas
-                    </SelectItem>
-                    <SelectItem value="all">Todas as etapas com data</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => shiftWeek(-1)}
-              >
-                <ChevronLeft className="mr-1 h-4 w-4" aria-hidden />
-                Semana anterior
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => shiftWeek(1)}
-              >
-                Próxima semana
-                <ChevronRight className="ml-1 h-4 w-4" aria-hidden />
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
+        <ConsultationAgendaFilters
+          from={from}
+          to={to}
+          scope={scope}
+          onFromChange={(v) => {
+            setFrom(v);
+            setPage(1);
+          }}
+          onToChange={(v) => {
+            setTo(v);
+            setPage(1);
+          }}
+          onScopeChange={(v) => {
+            setScope(v);
+            setPage(1);
+          }}
+          onShiftWeek={shiftWeek}
+        />
 
         {isError && (
           <Alert variant="destructive">
@@ -309,127 +172,20 @@ export default function ConsultationAgendaPage() {
             </p>
 
             <div className="space-y-8">
-              {sortedDayKeys.map((dayKey) => {
-                const dayItems = grouped.get(dayKey) ?? [];
-                const headerIso = `${dayKey}T12:00:00.000Z`;
-                return (
-                  <section
-                    key={dayKey}
-                    aria-labelledby={`agenda-day-${dayKey}`}
-                    className="space-y-3"
-                  >
-                    <h2
-                      id={`agenda-day-${dayKey}`}
-                      className="text-lg font-semibold capitalize text-foreground"
-                    >
-                      {formatAgendaDayLabel(headerIso)}
-                    </h2>
-                    <ul className="space-y-3" role="list">
-                      {dayItems.map((item: ConsultationAgendaItem) => (
-                        <li key={item.id}>
-                          <Card
-                            className={cn(
-                              'border-l-4',
-                              item.status === 'OVERDUE' && 'border-l-destructive',
-                              item.status === 'COMPLETED' && 'border-l-emerald-600',
-                              item.status === 'IN_PROGRESS' && 'border-l-primary',
-                              item.status === 'PENDING' && 'border-l-muted-foreground'
-                            )}
-                          >
-                            <CardContent className="flex flex-col gap-3 p-4 md:flex-row md:items-start md:justify-between">
-                              <div className="min-w-0 flex-1 space-y-2">
-                                <div className="flex flex-wrap items-center gap-2">
-                                  <span className="font-medium text-foreground">
-                                    {item.stepName}
-                                  </span>
-                                  <Badge variant={statusBadgeVariant(item.status)}>
-                                    {STATUS_LABEL[item.status] ?? item.status}
-                                  </Badge>
-                                </div>
-                                <p className="text-sm text-muted-foreground">
-                                  <span className="font-medium text-foreground">
-                                    {item.patient.name}
-                                  </span>
-                                  {' · '}
-                                  {JOURNEY_STAGE_LABELS[
-                                    item.journeyStage as JourneyStage
-                                  ] ?? item.journeyStage}
-                                </p>
-                                <dl className="grid grid-cols-1 gap-1 text-xs text-muted-foreground sm:grid-cols-3">
-                                  <div>
-                                    <dt className="inline font-medium text-foreground">
-                                      Prevista:{' '}
-                                    </dt>
-                                    <dd className="inline">
-                                      {formatShortDate(item.expectedDate)}
-                                    </dd>
-                                  </div>
-                                  <div>
-                                    <dt className="inline font-medium text-foreground">
-                                      Limite:{' '}
-                                    </dt>
-                                    <dd className="inline">
-                                      {formatShortDate(item.dueDate)}
-                                    </dd>
-                                  </div>
-                                  <div>
-                                    <dt className="inline font-medium text-foreground">
-                                      Realizada:{' '}
-                                    </dt>
-                                    <dd className="inline">
-                                      {formatShortDate(item.actualDate)}
-                                    </dd>
-                                  </div>
-                                </dl>
-                              </div>
-                              <Link
-                                href={`/patients/${item.patientId}`}
-                                className={cn(
-                                  buttonVariants({ variant: 'outline', size: 'sm' }),
-                                  'inline-flex shrink-0 items-center gap-1'
-                                )}
-                              >
-                                Ficha do paciente
-                                <ExternalLink className="h-3.5 w-3.5" aria-hidden />
-                              </Link>
-                            </CardContent>
-                          </Card>
-                        </li>
-                      ))}
-                    </ul>
-                  </section>
-                );
-              })}
+              {sortedDayKeys.map((dayKey) => (
+                <ConsultationAgendaDaySection
+                  key={dayKey}
+                  dayKey={dayKey}
+                  items={grouped.get(dayKey) ?? []}
+                />
+              ))}
             </div>
 
-            {totalPages > 1 && (
-              <nav
-                className="flex flex-wrap items-center justify-center gap-2 pt-4"
-                aria-label="Paginação da agenda"
-              >
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  disabled={page <= 1}
-                  onClick={() => setPage((p) => Math.max(1, p - 1))}
-                >
-                  Anterior
-                </Button>
-                <span className="text-sm text-muted-foreground">
-                  Página {page} de {totalPages}
-                </span>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  disabled={page >= totalPages}
-                  onClick={() => setPage((p) => p + 1)}
-                >
-                  Próxima
-                </Button>
-              </nav>
-            )}
+            <ConsultationAgendaPagination
+              page={page}
+              totalPages={totalPages}
+              onPageChange={setPage}
+            />
           </>
         )}
       </main>

--- a/frontend/src/app/oncology-navigation/agenda/page.tsx
+++ b/frontend/src/app/oncology-navigation/agenda/page.tsx
@@ -1,0 +1,440 @@
+'use client';
+
+import React, { useCallback, useMemo, useState } from 'react';
+import Link from 'next/link';
+import {
+  endOfWeek,
+  format,
+  parseISO,
+  startOfWeek,
+} from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import {
+  CalendarDays,
+  ChevronLeft,
+  ChevronRight,
+  ExternalLink,
+  RefreshCw,
+} from 'lucide-react';
+import { NavigationBar } from '@/components/shared/navigation-bar';
+import { Button, buttonVariants } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { EmptyState } from '@/components/ui/empty-state';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { cn } from '@/lib/utils';
+import { JOURNEY_STAGE_LABELS, type JourneyStage } from '@/lib/utils/journey-stage';
+import { useConsultationAgenda } from '@/hooks/useOncologyNavigation';
+import type { ConsultationAgendaItem, ConsultationAgendaScope } from '@/lib/api/oncology-navigation';
+
+function toYmd(d: Date): string {
+  return format(d, 'yyyy-MM-dd');
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  PENDING: 'Pendente',
+  IN_PROGRESS: 'Em andamento',
+  COMPLETED: 'Concluída',
+  OVERDUE: 'Atrasada',
+  CANCELLED: 'Cancelada',
+  NOT_APPLICABLE: 'Não aplicável',
+};
+
+function statusBadgeVariant(
+  status: string
+): 'default' | 'secondary' | 'destructive' | 'outline' | 'success' {
+  switch (status) {
+    case 'COMPLETED':
+      return 'success';
+    case 'OVERDUE':
+      return 'destructive';
+    case 'IN_PROGRESS':
+      return 'default';
+    case 'PENDING':
+      return 'secondary';
+    default:
+      return 'outline';
+  }
+}
+
+function formatAgendaDayLabel(iso: string): string {
+  try {
+    return format(parseISO(iso), "EEEE, d 'de' MMMM", { locale: ptBR });
+  } catch {
+    return iso;
+  }
+}
+
+function formatShortDate(iso: string | null): string {
+  if (!iso) return '—';
+  try {
+    return format(parseISO(iso), 'dd/MM/yyyy', { locale: ptBR });
+  } catch {
+    return '—';
+  }
+}
+
+function groupByAgendaDay(items: ConsultationAgendaItem[]): Map<string, ConsultationAgendaItem[]> {
+  const map = new Map<string, ConsultationAgendaItem[]>();
+  for (const item of items) {
+    let key: string;
+    try {
+      key = format(parseISO(item.agendaDate), 'yyyy-MM-dd');
+    } catch {
+      key = item.agendaDate.slice(0, 10);
+    }
+    const list = map.get(key) ?? [];
+    list.push(item);
+    map.set(key, list);
+  }
+  return map;
+}
+
+export default function ConsultationAgendaPage() {
+  const now = useMemo(() => new Date(), []);
+  const [from, setFrom] = useState(() =>
+    toYmd(startOfWeek(now, { locale: ptBR }))
+  );
+  const [to, setTo] = useState(() =>
+    toYmd(endOfWeek(now, { locale: ptBR }))
+  );
+  const [scope, setScope] = useState<ConsultationAgendaScope>('consultations');
+  const [page, setPage] = useState(1);
+  const limit = 50;
+
+  const queryParams = useMemo(
+    () => ({
+      from,
+      to,
+      scope,
+      page,
+      limit,
+    }),
+    [from, to, scope, page, limit]
+  );
+
+  const { data, isLoading, isFetching, isError, error, refetch } =
+    useConsultationAgenda(queryParams);
+
+  const grouped = useMemo(
+    () => (data?.items ? groupByAgendaDay(data.items) : new Map()),
+    [data?.items]
+  );
+  const sortedDayKeys = useMemo(
+    () => Array.from(grouped.keys()).sort(),
+    [grouped]
+  );
+
+  const shiftWeek = useCallback((delta: -1 | 1) => {
+    const anchor = parseISO(from);
+    const next = new Date(anchor);
+    next.setDate(next.getDate() + delta * 7);
+    setFrom(toYmd(startOfWeek(next, { locale: ptBR })));
+    setTo(toYmd(endOfWeek(next, { locale: ptBR })));
+    setPage(1);
+  }, [from]);
+
+  const totalPages = data?.totalPages ?? 0;
+
+  return (
+    <div className="flex min-h-screen flex-col bg-muted/30">
+      <NavigationBar />
+      <main
+        className="mx-auto w-full max-w-6xl flex-1 space-y-6 p-4 md:p-6"
+        id="main-content"
+      >
+        <header className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight text-foreground md:text-3xl">
+              Agenda de consultas
+            </h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Etapas de consulta com data prevista ou limite no período selecionado.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Link
+              href="/oncology-navigation"
+              className={cn(buttonVariants({ variant: 'outline', size: 'sm' }))}
+            >
+              Board de navegação
+            </Link>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => refetch()}
+              disabled={isFetching}
+              aria-label="Atualizar agenda"
+            >
+              <RefreshCw
+                className={cn('mr-2 h-4 w-4', isFetching && 'animate-spin')}
+                aria-hidden
+              />
+              Atualizar
+            </Button>
+          </div>
+        </header>
+
+        <Card>
+          <CardHeader className="pb-4">
+            <CardTitle className="text-base font-medium">Filtros</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex flex-wrap items-end gap-4">
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor="agenda-from" className="text-sm font-medium">
+                  De
+                </label>
+                <input
+                  id="agenda-from"
+                  type="date"
+                  value={from}
+                  onChange={(e) => {
+                    setFrom(e.target.value);
+                    setPage(1);
+                  }}
+                  className="flex h-10 w-full min-w-[10rem] rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor="agenda-to" className="text-sm font-medium">
+                  Até
+                </label>
+                <input
+                  id="agenda-to"
+                  type="date"
+                  value={to}
+                  onChange={(e) => {
+                    setTo(e.target.value);
+                    setPage(1);
+                  }}
+                  className="flex h-10 w-full min-w-[10rem] rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <span id="agenda-scope-label" className="text-sm font-medium">
+                  Escopo
+                </span>
+                <Select
+                  value={scope}
+                  onValueChange={(v) => {
+                    setScope(v as ConsultationAgendaScope);
+                    setPage(1);
+                  }}
+                >
+                  <SelectTrigger
+                    className="w-[220px]"
+                    aria-labelledby="agenda-scope-label"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="consultations">
+                      Somente consultas
+                    </SelectItem>
+                    <SelectItem value="all">Todas as etapas com data</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => shiftWeek(-1)}
+              >
+                <ChevronLeft className="mr-1 h-4 w-4" aria-hidden />
+                Semana anterior
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => shiftWeek(1)}
+              >
+                Próxima semana
+                <ChevronRight className="ml-1 h-4 w-4" aria-hidden />
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        {isError && (
+          <div
+            role="alert"
+            className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive"
+          >
+            <p className="font-semibold">Não foi possível carregar a agenda</p>
+            <p className="mt-1 text-sm">
+              {error instanceof Error ? error.message : 'Erro desconhecido.'}
+            </p>
+          </div>
+        )}
+
+        {isLoading && (
+          <div className="space-y-4" aria-busy="true" aria-label="Carregando agenda">
+            <Skeleton className="h-10 w-full max-w-md" />
+            <Skeleton className="h-32 w-full" />
+            <Skeleton className="h-32 w-full" />
+          </div>
+        )}
+
+        {!isLoading && data && data.total === 0 && (
+          <Card>
+            <CardContent className="pt-6">
+              <EmptyState
+                icon={<CalendarDays className="h-12 w-12" aria-hidden />}
+                title="Nenhum item no período"
+                description="Ajuste as datas, o escopo ou verifique se as etapas têm data prevista ou limite preenchidos."
+              />
+            </CardContent>
+          </Card>
+        )}
+
+        {!isLoading && data && data.total > 0 && (
+          <>
+            <p className="text-sm text-muted-foreground" role="status">
+              Exibindo {data.items.length} de {data.total} registro
+              {data.total === 1 ? '' : 's'}
+              {totalPages > 1
+                ? ` · Página ${data.page} de ${totalPages}`
+                : ''}
+            </p>
+
+            <div className="space-y-8">
+              {sortedDayKeys.map((dayKey) => {
+                const dayItems = grouped.get(dayKey) ?? [];
+                const headerIso = `${dayKey}T12:00:00.000Z`;
+                return (
+                  <section
+                    key={dayKey}
+                    aria-labelledby={`agenda-day-${dayKey}`}
+                    className="space-y-3"
+                  >
+                    <h2
+                      id={`agenda-day-${dayKey}`}
+                      className="text-lg font-semibold capitalize text-foreground"
+                    >
+                      {formatAgendaDayLabel(headerIso)}
+                    </h2>
+                    <ul className="space-y-3" role="list">
+                      {dayItems.map((item: ConsultationAgendaItem) => (
+                        <li key={item.id}>
+                          <Card
+                            className={cn(
+                              'border-l-4',
+                              item.status === 'OVERDUE' && 'border-l-destructive',
+                              item.status === 'COMPLETED' && 'border-l-emerald-600',
+                              item.status === 'IN_PROGRESS' && 'border-l-primary',
+                              item.status === 'PENDING' && 'border-l-muted-foreground'
+                            )}
+                          >
+                            <CardContent className="flex flex-col gap-3 p-4 md:flex-row md:items-start md:justify-between">
+                              <div className="min-w-0 flex-1 space-y-2">
+                                <div className="flex flex-wrap items-center gap-2">
+                                  <span className="font-medium text-foreground">
+                                    {item.stepName}
+                                  </span>
+                                  <Badge variant={statusBadgeVariant(item.status)}>
+                                    {STATUS_LABEL[item.status] ?? item.status}
+                                  </Badge>
+                                </div>
+                                <p className="text-sm text-muted-foreground">
+                                  <span className="font-medium text-foreground">
+                                    {item.patient.name}
+                                  </span>
+                                  {' · '}
+                                  {JOURNEY_STAGE_LABELS[
+                                    item.journeyStage as JourneyStage
+                                  ] ?? item.journeyStage}
+                                </p>
+                                <dl className="grid grid-cols-1 gap-1 text-xs text-muted-foreground sm:grid-cols-3">
+                                  <div>
+                                    <dt className="inline font-medium text-foreground">
+                                      Prevista:{' '}
+                                    </dt>
+                                    <dd className="inline">
+                                      {formatShortDate(item.expectedDate)}
+                                    </dd>
+                                  </div>
+                                  <div>
+                                    <dt className="inline font-medium text-foreground">
+                                      Limite:{' '}
+                                    </dt>
+                                    <dd className="inline">
+                                      {formatShortDate(item.dueDate)}
+                                    </dd>
+                                  </div>
+                                  <div>
+                                    <dt className="inline font-medium text-foreground">
+                                      Realizada:{' '}
+                                    </dt>
+                                    <dd className="inline">
+                                      {formatShortDate(item.actualDate)}
+                                    </dd>
+                                  </div>
+                                </dl>
+                              </div>
+                              <Link
+                                href={`/patients/${item.patientId}`}
+                                className={cn(
+                                  buttonVariants({ variant: 'outline', size: 'sm' }),
+                                  'inline-flex shrink-0 items-center gap-1'
+                                )}
+                              >
+                                Ficha do paciente
+                                <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+                              </Link>
+                            </CardContent>
+                          </Card>
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+                );
+              })}
+            </div>
+
+            {totalPages > 1 && (
+              <nav
+                className="flex flex-wrap items-center justify-center gap-2 pt-4"
+                aria-label="Paginação da agenda"
+              >
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                >
+                  Anterior
+                </Button>
+                <span className="text-sm text-muted-foreground">
+                  Página {page} de {totalPages}
+                </span>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={page >= totalPages}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  Próxima
+                </Button>
+              </nav>
+            )}
+          </>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/components/oncology-navigation/consultation-agenda-day-section.tsx
+++ b/frontend/src/components/oncology-navigation/consultation-agenda-day-section.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import type { ConsultationAgendaItem } from '@/lib/api/oncology-navigation';
+import { formatAgendaDayLabel } from '@/lib/utils/consultationAgenda';
+import { ConsultationAgendaItemCard } from './consultation-agenda-item-card';
+
+export interface ConsultationAgendaDaySectionProps {
+  dayKey: string;
+  items: ConsultationAgendaItem[];
+}
+
+export function ConsultationAgendaDaySection({
+  dayKey,
+  items,
+}: ConsultationAgendaDaySectionProps) {
+  const headerIso = `${dayKey}T12:00:00.000Z`;
+
+  return (
+    <section
+      aria-labelledby={`agenda-day-${dayKey}`}
+      className="space-y-3"
+    >
+      <h2
+        id={`agenda-day-${dayKey}`}
+        className="text-lg font-semibold capitalize text-foreground"
+      >
+        {formatAgendaDayLabel(headerIso)}
+      </h2>
+      <ul className="space-y-3" role="list">
+        {items.map((item) => (
+          <li key={item.id}>
+            <ConsultationAgendaItemCard item={item} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/components/oncology-navigation/consultation-agenda-filters.tsx
+++ b/frontend/src/components/oncology-navigation/consultation-agenda-filters.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import type { ConsultationAgendaScope } from '@/lib/api/oncology-navigation';
+
+const dateInputClass =
+  'flex h-10 w-full min-w-[10rem] rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
+
+export interface ConsultationAgendaFiltersProps {
+  from: string;
+  to: string;
+  scope: ConsultationAgendaScope;
+  onFromChange: (value: string) => void;
+  onToChange: (value: string) => void;
+  onScopeChange: (value: ConsultationAgendaScope) => void;
+  onShiftWeek: (delta: -1 | 1) => void;
+}
+
+export function ConsultationAgendaFilters({
+  from,
+  to,
+  scope,
+  onFromChange,
+  onToChange,
+  onScopeChange,
+  onShiftWeek,
+}: ConsultationAgendaFiltersProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-4">
+        <CardTitle className="text-base font-medium">Filtros</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-wrap items-end gap-4">
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="agenda-from" className="text-sm font-medium">
+              De
+            </label>
+            <input
+              id="agenda-from"
+              type="date"
+              value={from}
+              onChange={(e) => onFromChange(e.target.value)}
+              className={dateInputClass}
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="agenda-to" className="text-sm font-medium">
+              Até
+            </label>
+            <input
+              id="agenda-to"
+              type="date"
+              value={to}
+              onChange={(e) => onToChange(e.target.value)}
+              className={dateInputClass}
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <span id="agenda-scope-label" className="text-sm font-medium">
+              Escopo
+            </span>
+            <Select
+              value={scope}
+              onValueChange={(v) => onScopeChange(v as ConsultationAgendaScope)}
+            >
+              <SelectTrigger
+                className="w-[220px]"
+                aria-labelledby="agenda-scope-label"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="consultations">Somente consultas</SelectItem>
+                <SelectItem value="all">Todas as etapas com data</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => onShiftWeek(-1)}
+          >
+            <ChevronLeft className="mr-1 h-4 w-4" aria-hidden />
+            Semana anterior
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => onShiftWeek(1)}
+          >
+            Próxima semana
+            <ChevronRight className="ml-1 h-4 w-4" aria-hidden />
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/oncology-navigation/consultation-agenda-item-card.tsx
+++ b/frontend/src/components/oncology-navigation/consultation-agenda-item-card.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import Link from 'next/link';
+import { ExternalLink } from 'lucide-react';
+import { buttonVariants } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import { JOURNEY_STAGE_LABELS, type JourneyStage } from '@/lib/utils/journey-stage';
+import type { ConsultationAgendaItem } from '@/lib/api/oncology-navigation';
+import {
+  CONSULTATION_AGENDA_STATUS_LABEL,
+  consultationAgendaItemBorderClass,
+  consultationAgendaStatusBadgeVariant,
+  formatShortAgendaDate,
+} from '@/lib/utils/consultationAgenda';
+
+export interface ConsultationAgendaItemCardProps {
+  item: ConsultationAgendaItem;
+}
+
+export function ConsultationAgendaItemCard({ item }: ConsultationAgendaItemCardProps) {
+  return (
+    <Card
+      className={cn(
+        'border-l-4',
+        consultationAgendaItemBorderClass(item.status)
+      )}
+    >
+      <CardContent className="flex flex-col gap-3 p-4 md:flex-row md:items-start md:justify-between">
+        <div className="min-w-0 flex-1 space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-medium text-foreground">{item.stepName}</span>
+            <Badge variant={consultationAgendaStatusBadgeVariant(item.status)}>
+              {CONSULTATION_AGENDA_STATUS_LABEL[item.status] ?? item.status}
+            </Badge>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">{item.patient.name}</span>
+            {' · '}
+            {JOURNEY_STAGE_LABELS[item.journeyStage as JourneyStage] ??
+              item.journeyStage}
+          </p>
+          <dl className="grid grid-cols-1 gap-1 text-xs text-muted-foreground sm:grid-cols-3">
+            <div>
+              <dt className="inline font-medium text-foreground">Prevista: </dt>
+              <dd className="inline">{formatShortAgendaDate(item.expectedDate)}</dd>
+            </div>
+            <div>
+              <dt className="inline font-medium text-foreground">Limite: </dt>
+              <dd className="inline">{formatShortAgendaDate(item.dueDate)}</dd>
+            </div>
+            <div>
+              <dt className="inline font-medium text-foreground">Realizada: </dt>
+              <dd className="inline">{formatShortAgendaDate(item.actualDate)}</dd>
+            </div>
+          </dl>
+        </div>
+        <Link
+          href={`/patients/${item.patientId}`}
+          className={cn(
+            buttonVariants({ variant: 'outline', size: 'sm' }),
+            'inline-flex shrink-0 items-center gap-1'
+          )}
+        >
+          Ficha do paciente
+          <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/oncology-navigation/consultation-agenda-pagination.tsx
+++ b/frontend/src/components/oncology-navigation/consultation-agenda-pagination.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+
+export interface ConsultationAgendaPaginationProps {
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+export function ConsultationAgendaPagination({
+  page,
+  totalPages,
+  onPageChange,
+}: ConsultationAgendaPaginationProps) {
+  if (totalPages <= 1) return null;
+
+  return (
+    <nav
+      className="flex flex-wrap items-center justify-center gap-2 pt-4"
+      aria-label="Paginação da agenda"
+    >
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={page <= 1}
+        onClick={() => onPageChange(Math.max(1, page - 1))}
+      >
+        Anterior
+      </Button>
+      <span className="text-sm text-muted-foreground">
+        Página {page} de {totalPages}
+      </span>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={page >= totalPages}
+        onClick={() => onPageChange(page + 1)}
+      >
+        Próxima
+      </Button>
+    </nav>
+  );
+}

--- a/frontend/src/components/shared/navigation-bar.tsx
+++ b/frontend/src/components/shared/navigation-bar.tsx
@@ -7,6 +7,7 @@ import {
   MessageSquare,
   LayoutDashboard,
   Navigation,
+  CalendarDays,
   Calculator,
   LogOut,
   Settings,
@@ -59,6 +60,11 @@ const baseNavItems: NavItem[] = [
     path: '/oncology-navigation',
     label: 'Navegação Oncológica',
     icon: Navigation,
+  },
+  {
+    path: '/oncology-navigation/agenda',
+    label: 'Agenda de consultas',
+    icon: CalendarDays,
   },
   {
     path: '/chat',
@@ -164,6 +170,15 @@ export function NavigationBar() {
     // Caso especial: /patients deve ser ativo para /patients e subrotas
     if (itemPath === '/patients') {
       return pathname === '/patients' || pathname.startsWith('/patients/');
+    }
+
+    // Board de navegação: não marcar como ativo na rota dedicada da agenda
+    if (itemPath === '/oncology-navigation') {
+      if (pathname === '/oncology-navigation') return true;
+      if (pathname.startsWith('/oncology-navigation/')) {
+        return !pathname.startsWith('/oncology-navigation/agenda');
+      }
+      return false;
     }
 
     // Para outras rotas, verificar se começa com o path

--- a/frontend/src/components/ui/alert.tsx
+++ b/frontend/src/components/ui/alert.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const alertVariants = cva(
+  'relative w-full rounded-lg border p-4 text-foreground [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4',
+  {
+    variants: {
+      variant: {
+        default: 'bg-background',
+        destructive:
+          'border-destructive/50 bg-destructive/10 text-destructive [&>svg]:text-destructive',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+));
+Alert.displayName = 'Alert';
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn('mb-1 font-medium leading-none tracking-tight', className)}
+    {...props}
+  />
+));
+AlertTitle.displayName = 'AlertTitle';
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('text-sm [&_p]:leading-relaxed', className)}
+    {...props}
+  />
+));
+AlertDescription.displayName = 'AlertDescription';
+
+export { Alert, AlertTitle, AlertDescription };

--- a/frontend/src/hooks/__tests__/useConsultationAgenda.test.ts
+++ b/frontend/src/hooks/__tests__/useConsultationAgenda.test.ts
@@ -1,0 +1,107 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+
+vi.mock('@/lib/api/oncology-navigation', () => ({
+  oncologyNavigationApi: {
+    getConsultationAgenda: vi.fn(),
+  },
+}));
+
+import { useConsultationAgenda } from '../useOncologyNavigation';
+import { oncologyNavigationApi } from '@/lib/api/oncology-navigation';
+
+const baseParams = {
+  from: '2024-05-06',
+  to: '2024-05-12',
+  scope: 'consultations' as const,
+  page: 1,
+  limit: 50,
+};
+
+const emptyPage = {
+  items: [],
+  total: 0,
+  page: 1,
+  limit: 50,
+  totalPages: 0,
+};
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { Wrapper, queryClient };
+}
+
+describe('useConsultationAgenda', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('não dispara fetch quando from ou to estão vazios', () => {
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () =>
+        useConsultationAgenda({
+          ...baseParams,
+          from: '',
+        }),
+      { wrapper: Wrapper }
+    );
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(oncologyNavigationApi.getConsultationAgenda).not.toHaveBeenCalled();
+  });
+
+  it('busca a agenda e usa a queryKey com os parâmetros', async () => {
+    vi.mocked(oncologyNavigationApi.getConsultationAgenda).mockResolvedValue(
+      emptyPage
+    );
+
+    const { Wrapper, queryClient } = makeWrapper();
+    const { result } = renderHook(() => useConsultationAgenda(baseParams), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(oncologyNavigationApi.getConsultationAgenda).toHaveBeenCalledWith(
+      baseParams
+    );
+    expect(
+      queryClient.getQueryData(['consultation-agenda', baseParams])
+    ).toEqual(emptyPage);
+  });
+
+  it('respeita enabled: false sem chamar a API', () => {
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useConsultationAgenda(baseParams, { enabled: false }),
+      { wrapper: Wrapper }
+    );
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(oncologyNavigationApi.getConsultationAgenda).not.toHaveBeenCalled();
+  });
+
+  it('expõe isError quando a API falha', async () => {
+    vi.mocked(oncologyNavigationApi.getConsultationAgenda).mockRejectedValue(
+      new Error('falha de rede')
+    );
+
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useConsultationAgenda(baseParams), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect((result.current.error as Error).message).toBe('falha de rede');
+  });
+});

--- a/frontend/src/hooks/useOncologyNavigation.ts
+++ b/frontend/src/hooks/useOncologyNavigation.ts
@@ -1,6 +1,24 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { oncologyNavigationApi } from '@/lib/api/oncology-navigation';
+import {
+  oncologyNavigationApi,
+  type ConsultationAgendaQuery,
+} from '@/lib/api/oncology-navigation';
+
+export const useConsultationAgenda = (
+  params: ConsultationAgendaQuery,
+  options?: { enabled?: boolean }
+) => {
+  return useQuery({
+    queryKey: ['consultation-agenda', params],
+    queryFn: () => oncologyNavigationApi.getConsultationAgenda(params),
+    enabled:
+      (options?.enabled ?? true) &&
+      Boolean(params.from) &&
+      Boolean(params.to),
+    staleTime: 30 * 1000,
+  });
+};
 
 export const usePatientNavigationSteps = (patientId: string | null) => {
   return useQuery({
@@ -56,6 +74,7 @@ export const useInitializeNavigationSteps = () => {
         queryKey: ['navigation-steps', variables.patientId],
       });
       queryClient.invalidateQueries({ queryKey: ['patient', variables.patientId] });
+      queryClient.invalidateQueries({ queryKey: ['consultation-agenda'] });
       toast.success('Etapas de navegação inicializadas!');
     },
     onError: (error: Error) => {
@@ -81,6 +100,7 @@ export const useUpdateNavigationStep = () => {
     onSuccess: (updatedStep) => {
       queryClient.invalidateQueries({ queryKey: ['navigation-steps'] });
       queryClient.invalidateQueries({ queryKey: ['patient', updatedStep.patientId] });
+      queryClient.invalidateQueries({ queryKey: ['consultation-agenda'] });
     },
     onError: (error: Error) => {
       console.error('Erro ao atualizar etapa:', error);
@@ -100,6 +120,7 @@ export const useInitializeAllPatients = () => {
       queryClient.invalidateQueries({ queryKey: ['patients'] });
       queryClient.invalidateQueries({ queryKey: ['patient'] });
       queryClient.invalidateQueries({ queryKey: ['navigation-steps'] });
+      queryClient.invalidateQueries({ queryKey: ['consultation-agenda'] });
       toast.success('Etapas inicializadas para todos os pacientes!');
       return result;
     },
@@ -121,6 +142,7 @@ export const useDeleteNavigationStep = () => {
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ['navigation-steps'] });
       queryClient.invalidateQueries({ queryKey: ['patient', variables.patientId] });
+      queryClient.invalidateQueries({ queryKey: ['consultation-agenda'] });
     },
     onError: (error: Error) => {
       toast.error('Falha ao excluir etapa.', {
@@ -139,6 +161,7 @@ export const useUploadStepFile = () => {
     onSuccess: (updatedStep) => {
       queryClient.invalidateQueries({ queryKey: ['navigation-steps'] });
       queryClient.invalidateQueries({ queryKey: ['patient', updatedStep.patientId] });
+      queryClient.invalidateQueries({ queryKey: ['consultation-agenda'] });
       toast.success('Arquivo enviado com sucesso!');
     },
     onError: (error: Error) => {

--- a/frontend/src/lib/api/oncology-navigation.ts
+++ b/frontend/src/lib/api/oncology-navigation.ts
@@ -62,6 +62,39 @@ export interface CreateNavigationStepDto {
   notes?: string;
 }
 
+export type ConsultationAgendaScope = 'consultations' | 'all';
+
+export interface ConsultationAgendaItem {
+  id: string;
+  patientId: string;
+  stepKey: string;
+  stepName: string;
+  journeyStage: NavigationStep['journeyStage'];
+  status: NavigationStep['status'];
+  isCompleted: boolean;
+  expectedDate: string | null;
+  dueDate: string | null;
+  actualDate: string | null;
+  agendaDate: string;
+  patient: { id: string; name: string };
+}
+
+export interface ConsultationAgendaPage {
+  items: ConsultationAgendaItem[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface ConsultationAgendaQuery {
+  from: string;
+  to: string;
+  scope?: ConsultationAgendaScope;
+  page?: number;
+  limit?: number;
+}
+
 export interface UpdateNavigationStepDto {
   status?:
     | 'PENDING'
@@ -90,6 +123,26 @@ export interface UpdateNavigationStepDto {
 }
 
 export const oncologyNavigationApi = {
+  /**
+   * Agenda de consultas (etapas com data no intervalo, por padrão só consultas clínicas).
+   */
+  getConsultationAgenda: async (
+    params: ConsultationAgendaQuery
+  ): Promise<ConsultationAgendaPage> => {
+    return apiClient.get<ConsultationAgendaPage>(
+      '/oncology-navigation/consultation-agenda',
+      {
+        params: {
+          from: params.from,
+          to: params.to,
+          scope: params.scope,
+          page: params.page,
+          limit: params.limit,
+        },
+      }
+    );
+  },
+
   /**
    * Obtém todas as etapas de navegação de um paciente
    */

--- a/frontend/src/lib/utils/__tests__/consultationAgenda.test.ts
+++ b/frontend/src/lib/utils/__tests__/consultationAgenda.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import type { ConsultationAgendaItem } from '@/lib/api/oncology-navigation';
+import {
+  consultationAgendaItemBorderClass,
+  consultationAgendaStatusBadgeVariant,
+  formatShortAgendaDate,
+  groupConsultationAgendaByDay,
+} from '../consultationAgenda';
+
+function makeItem(
+  overrides: Partial<ConsultationAgendaItem> = {}
+): ConsultationAgendaItem {
+  return {
+    id: 's1',
+    patientId: 'p1',
+    stepKey: 'specialist_consultation',
+    stepName: 'Consulta',
+    status: 'PENDING',
+    journeyStage: 'DIAGNOSIS',
+    isCompleted: false,
+    agendaDate: '2024-05-07',
+    expectedDate: null,
+    dueDate: null,
+    actualDate: null,
+    patient: { id: 'p1', name: 'Paciente' },
+    ...overrides,
+  };
+}
+
+describe('consultationAgenda utils', () => {
+  it('groupConsultationAgendaByDay agrupa por yyyy-MM-dd', () => {
+    const items = [
+      makeItem({ id: 'a', agendaDate: '2024-05-07' }),
+      makeItem({ id: 'b', agendaDate: '2024-05-07' }),
+      makeItem({ id: 'c', agendaDate: '2024-05-08' }),
+    ];
+    const map = groupConsultationAgendaByDay(items);
+    expect(map.get('2024-05-07')?.map((i) => i.id).sort()).toEqual(['a', 'b']);
+    expect(map.get('2024-05-08')?.map((i) => i.id)).toEqual(['c']);
+  });
+
+  it('formatShortAgendaDate retorna — para null e data válida em pt-BR', () => {
+    expect(formatShortAgendaDate(null)).toBe('—');
+    expect(formatShortAgendaDate('2024-05-07')).toMatch(/07\/05\/2024/);
+  });
+
+  it('consultationAgendaStatusBadgeVariant mapeia status conhecidos', () => {
+    expect(consultationAgendaStatusBadgeVariant('COMPLETED')).toBe('success');
+    expect(consultationAgendaStatusBadgeVariant('OVERDUE')).toBe('destructive');
+    expect(consultationAgendaStatusBadgeVariant('UNKNOWN')).toBe('outline');
+  });
+
+  it('consultationAgendaItemBorderClass usa tokens priority', () => {
+    expect(consultationAgendaItemBorderClass('OVERDUE')).toBe(
+      'border-l-priority-critical'
+    );
+    expect(consultationAgendaItemBorderClass('COMPLETED')).toBe(
+      'border-l-priority-medium'
+    );
+    expect(consultationAgendaItemBorderClass('PENDING')).toBe(
+      'border-l-priority-low'
+    );
+  });
+});

--- a/frontend/src/lib/utils/consultationAgenda.ts
+++ b/frontend/src/lib/utils/consultationAgenda.ts
@@ -1,0 +1,84 @@
+import { format, parseISO } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import type { ConsultationAgendaItem } from '@/lib/api/oncology-navigation';
+
+export function toYmd(d: Date): string {
+  return format(d, 'yyyy-MM-dd');
+}
+
+export const CONSULTATION_AGENDA_STATUS_LABEL: Record<string, string> = {
+  PENDING: 'Pendente',
+  IN_PROGRESS: 'Em andamento',
+  COMPLETED: 'Concluída',
+  OVERDUE: 'Atrasada',
+  CANCELLED: 'Cancelada',
+  NOT_APPLICABLE: 'Não aplicável',
+};
+
+export function consultationAgendaStatusBadgeVariant(
+  status: string
+): 'default' | 'secondary' | 'destructive' | 'outline' | 'success' {
+  switch (status) {
+    case 'COMPLETED':
+      return 'success';
+    case 'OVERDUE':
+      return 'destructive';
+    case 'IN_PROGRESS':
+      return 'default';
+    case 'PENDING':
+      return 'secondary';
+    default:
+      return 'outline';
+  }
+}
+
+/** Borda esquerda por status da etapa (tokens priority.* + primary/muted). */
+export function consultationAgendaItemBorderClass(status: string): string {
+  switch (status) {
+    case 'OVERDUE':
+      return 'border-l-priority-critical';
+    case 'COMPLETED':
+      return 'border-l-priority-medium';
+    case 'IN_PROGRESS':
+      return 'border-l-primary';
+    case 'PENDING':
+      return 'border-l-priority-low';
+    default:
+      return 'border-l-muted-foreground';
+  }
+}
+
+export function formatAgendaDayLabel(iso: string): string {
+  try {
+    return format(parseISO(iso), "EEEE, d 'de' MMMM", { locale: ptBR });
+  } catch {
+    return iso;
+  }
+}
+
+export function formatShortAgendaDate(iso: string | null): string {
+  if (!iso) return '—';
+  try {
+    return format(parseISO(iso), 'dd/MM/yyyy', { locale: ptBR });
+  } catch {
+    return '—';
+  }
+}
+
+export function groupConsultationAgendaByDay(
+  items: ConsultationAgendaItem[]
+): Map<string, ConsultationAgendaItem[]> {
+  const map = new Map<string, ConsultationAgendaItem[]>();
+  for (const item of items) {
+    let key: string;
+    try {
+      key = format(parseISO(item.agendaDate), 'yyyy-MM-dd');
+    } catch {
+      key = item.agendaDate.slice(0, 10);
+    }
+    const list = map.get(key) ?? [];
+    list.push(item);
+    map.set(key, list);
+  }
+  return map;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objetivo
Interface de **agenda de consultas** a partir de `NavigationStep` (`specialist_consultation` / `navigation_consultation`), com API paginada no backend e UI no App Router.

## Alterações nesta revisão
- **Refactor da página** `/oncology-navigation/agenda`: componentes dedicados em `components/oncology-navigation/` (filtros, seção por dia, card de item, paginação).
- **Utilitários** em `lib/utils/consultationAgenda.ts`: agrupamento por dia, labels de status, variantes de badge, bordas com tokens **`priority.*`** (sem `emerald-600` hardcoded).
- **Testes** Vitest para os utilitários da agenda.

## Verificação
- `npm run type-check` e `npm run lint` no frontend
- `vitest` em `consultationAgenda.test.ts` e `useConsultationAgenda.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d591c2c1-1d8e-4083-b839-628504f57b4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d591c2c1-1d8e-4083-b839-628504f57b4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

