### PR TITLE
chore: ignorar artefatos locais do graphify

### DIFF
--- a/.cursor/rules/graphify.mdc
+++ b/.cursor/rules/graphify.mdc
@@ -1,0 +1,10 @@
+---
+description: graphify knowledge graph context
+alwaysApply: true
+---
+
+This project has a graphify knowledge graph at graphify-out/.
+
+- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
+- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
+- After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)

--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,22 @@ backend/data/ans/exam-catalog-import.json
 # Playwright / MCP artefatos locais
 .playwright-mcp/
 
+# Graphify (artefatos gerados localmente)
+graphify-out/
+**/graphify-out/
+
+# Obsidian (vault local)
+obsidian-vault/
+
+# Headers/capturas locais de requests
+headers-*.txt
+
+# Scripts utilitários locais (não versionar)
+build_frontend.py
+gen_frontend.py
+label_frontend.py
+merge_frontend.py
+
 # Other
 # Relatório HTML gerado localmente (não versionar / não enviar ao remoto)
 report.html

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,8 @@
+# Vault e cache do Graphify (muitos ficheiros; não são fonte do produto)
+graphify-out/obsidian/**
+graphify-out/cache/**
+ai-service/graphify-out/cache/**
+backend/graphify-out/cache/**
+
+# Cliente Prisma gerado — AST enorme e pouco útil para o mapa da app
+backend/generated/**


### PR DESCRIPTION
## O quê
- Adiciona regra do graphify no Cursor e `.graphifyignore`
- Atualiza `.gitignore` para evitar versionar saídas geradas (graphify/obsidian/headers/scripts locais)

## Por quê
- Evita ruído em PRs e commits com artefatos gerados/local-only.

## Como testar
- [ ] Rodar `graphify` localmente e confirmar que `graphify-out/` não aparece no `git status`

## Checklist
- [ ] Sem arquivos gerados/locais no diff

Made with [Cursor](https://cursor.com)