### PR TITLE
feat: expectedDate nas etapas de navegação

### DIFF
--- a/backend/src/oncology-navigation/dto/update-navigation-step.dto.ts
+++ b/backend/src/oncology-navigation/dto/update-navigation-step.dto.ts
@@ -11,6 +11,14 @@ import { JourneyStage, NavigationStepStatus } from '@generated/prisma/client';
 import { IsPlainText } from '../../common/validators/is-plain-text.decorator';
 
 export class UpdateNavigationStepDto {
+  /**
+   * Datas da etapa (Prisma → JSON):
+   * - expectedDate: data agendada / planejada
+   * - dueDate: data limite (alertas de atraso)
+   * - actualDate: data em que o evento foi realizado
+   * completedAt marca conclusão no fluxo do sistema e pode coexistir com actualDate.
+   */
+
   @IsEnum(NavigationStepStatus)
   @IsOptional()
   status?: NavigationStepStatus;
@@ -30,6 +38,10 @@ export class UpdateNavigationStepDto {
   @IsDateString()
   @IsOptional()
   actualDate?: string;
+
+  @IsDateString()
+  @IsOptional()
+  expectedDate?: string;
 
   @IsDateString()
   @IsOptional()

--- a/backend/src/oncology-navigation/oncology-navigation.service.spec.ts
+++ b/backend/src/oncology-navigation/oncology-navigation.service.spec.ts
@@ -822,6 +822,49 @@ describe('OncologyNavigationService', () => {
     });
   });
 
+  // ─── updateStep — expectedDate ────────────────────────────────────────────────
+
+  describe('updateStep — expectedDate', () => {
+    const stepId = 'step-test-1';
+    const tenantScopedExisting = {
+      id: stepId,
+      tenantId: TENANT,
+      patientId: PATIENT_ID,
+      isCompleted: false,
+      status: NavigationStepStatus.PENDING,
+      journeyStage: JourneyStage.TREATMENT,
+      expectedDate: null,
+      dueDate: null,
+      actualDate: null,
+      completedAt: null,
+    };
+
+    beforeEach(() => {
+      mockPrisma.navigationStep.findFirst.mockResolvedValue(tenantScopedExisting as never);
+      mockPrisma.navigationStep.update.mockResolvedValue({
+        ...tenantScopedExisting,
+        expectedDate: new Date('2026-06-15T12:00:00.000Z'),
+      } as never);
+    });
+
+    it('persiste expectedDate quando enviado no DTO', async () => {
+      await service.updateStep(
+        stepId,
+        { expectedDate: '2026-06-15' },
+        TENANT
+      );
+
+      expect(mockPrisma.navigationStep.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: stepId, tenantId: TENANT },
+          data: expect.objectContaining({
+            expectedDate: expect.any(Date),
+          }),
+        })
+      );
+    });
+  });
+
   // ─── getConsultationAgenda ───────────────────────────────────────────────────
 
   describe('getConsultationAgenda', () => {

--- a/backend/src/oncology-navigation/oncology-navigation.service.ts
+++ b/backend/src/oncology-navigation/oncology-navigation.service.ts
@@ -387,6 +387,12 @@ export class OncologyNavigationService {
         : null;
     }
 
+    if (updateDto.expectedDate !== undefined) {
+      updateData.expectedDate = updateDto.expectedDate
+        ? new Date(updateDto.expectedDate)
+        : null;
+    }
+
     // Se mudando status para OVERDUE (apenas se não estiver marcando/desmarcando como completa)
     if (
       updateDto.status === NavigationStepStatus.OVERDUE &&

--- a/frontend/src/app/oncology-navigation/agenda/page.tsx
+++ b/frontend/src/app/oncology-navigation/agenda/page.tsx
@@ -82,7 +82,7 @@ export default function ConsultationAgendaPage() {
         <header className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
           <div>
             <h1 className="text-2xl font-semibold tracking-tight text-foreground md:text-3xl">
-              Agenda de consultas
+              Agenda
             </h1>
             <p className="mt-1 text-sm text-muted-foreground">
               Etapas de consulta com data prevista ou limite no período

--- a/frontend/src/app/oncology-navigation/page.tsx
+++ b/frontend/src/app/oncology-navigation/page.tsx
@@ -70,6 +70,10 @@ import { NavigationStepEditPanel } from '@/components/oncology-navigation/naviga
 import { NavigationStepLinkedEvolutions } from '@/components/oncology-navigation/navigation-step-linked-evolutions';
 import { cn } from '@/lib/utils';
 import {
+  formatNavigationStepDateBr,
+  NAVIGATION_STEP_UI_DATE_LABEL,
+} from '@/lib/utils/navigation-step-dates';
+import {
   getFilledStepDetailEntries,
   getNavStepFormVariant,
   parseStepDetailFromMetadata,
@@ -892,6 +896,9 @@ function StepCard({ step, apiUrl, dragHandle }: StepCardProps) {
   const [dueDate, setDueDate] = useState(
     step.dueDate ? new Date(step.dueDate).toISOString().split('T')[0] : ''
   );
+  const [expectedDate, setExpectedDate] = useState(
+    step.expectedDate ? new Date(step.expectedDate).toISOString().split('T')[0] : ''
+  );
 
   const [stepDetail, setStepDetail] = useState<Record<string, string>>(() =>
     parseStepDetailFromMetadata(step.metadata, variant)
@@ -926,6 +933,11 @@ function StepCard({ step, apiUrl, dragHandle }: StepCardProps) {
       );
       setDueDate(
         step.dueDate ? new Date(step.dueDate).toISOString().split('T')[0] : ''
+      );
+      setExpectedDate(
+        step.expectedDate
+          ? new Date(step.expectedDate).toISOString().split('T')[0]
+          : ''
       );
       setStepDetail(parseStepDetailFromMetadata(step.metadata, variant));
     });
@@ -967,6 +979,9 @@ function StepCard({ step, apiUrl, dragHandle }: StepCardProps) {
             variant === 'generic' && findings.length > 0 ? findings : undefined,
           actualDate: actualDate
             ? new Date(actualDate).toISOString()
+            : undefined,
+          expectedDate: expectedDate
+            ? new Date(expectedDate).toISOString()
             : undefined,
           dueDate: dueDate ? new Date(dueDate).toISOString() : undefined,
           metadata: nextMetadata,
@@ -1148,6 +1163,8 @@ function StepCard({ step, apiUrl, dragHandle }: StepCardProps) {
             }
             dueDate={dueDate}
             onDueDateChange={setDueDate}
+            expectedDate={expectedDate}
+            onExpectedDateChange={setExpectedDate}
             actualDate={actualDate}
             onActualDateChange={setActualDate}
             isCompleted={isCompleted}
@@ -1186,6 +1203,11 @@ function StepCard({ step, apiUrl, dragHandle }: StepCardProps) {
               setActualDate(
                 step.actualDate
                   ? new Date(step.actualDate).toISOString().split('T')[0]
+                  : ''
+              );
+              setExpectedDate(
+                step.expectedDate
+                  ? new Date(step.expectedDate).toISOString().split('T')[0]
                   : ''
               );
               setDueDate(
@@ -1311,31 +1333,43 @@ function StepCard({ step, apiUrl, dragHandle }: StepCardProps) {
               </div>
             )}
 
-            {/* Informações de datas */}
-            <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs mt-2 opacity-70">
-              {step.expectedDate && (
-                <span>
-                  Esperado:{' '}
-                  {new Date(step.expectedDate).toLocaleDateString('pt-BR')}
-                </span>
-              )}
-              {step.dueDate && (
-                <span
-                  className={
-                    step.status === 'OVERDUE' ? 'text-red-600 font-medium' : ''
-                  }
+            {/* Datas da etapa: sempre as três dimensões */}
+            <dl className="mt-3 grid gap-2 rounded-md border border-border/60 bg-muted/20 px-3 py-2 text-xs sm:grid-cols-3">
+              <div className="min-w-0">
+                <dt className="font-medium text-muted-foreground">
+                  {NAVIGATION_STEP_UI_DATE_LABEL.agendada}
+                </dt>
+                <dd className="font-mono text-foreground tabular-nums">
+                  {formatNavigationStepDateBr(step.expectedDate)}
+                </dd>
+              </div>
+              <div className="min-w-0">
+                <dt className="font-medium text-muted-foreground">
+                  {NAVIGATION_STEP_UI_DATE_LABEL.limite}
+                </dt>
+                <dd
+                  className={cn(
+                    'font-mono tabular-nums',
+                    step.status === 'OVERDUE'
+                      ? 'font-medium text-destructive'
+                      : 'text-foreground'
+                  )}
                 >
-                  Prazo: {new Date(step.dueDate).toLocaleDateString('pt-BR')}
-                  {step.status === 'OVERDUE' && ' (ATRASADO)'}
-                </span>
-              )}
-              {step.actualDate && (
-                <span>
-                  Realizado:{' '}
-                  {new Date(step.actualDate).toLocaleDateString('pt-BR')}
-                </span>
-              )}
-            </div>
+                  {formatNavigationStepDateBr(step.dueDate)}
+                  {step.status === 'OVERDUE' && step.dueDate ? (
+                    <span className="ml-1 text-destructive">(atrasado)</span>
+                  ) : null}
+                </dd>
+              </div>
+              <div className="min-w-0">
+                <dt className="font-medium text-muted-foreground">
+                  {NAVIGATION_STEP_UI_DATE_LABEL.realizada}
+                </dt>
+                <dd className="font-mono text-foreground tabular-nums">
+                  {formatNavigationStepDateBr(step.actualDate)}
+                </dd>
+              </div>
+            </dl>
           </div>
         )}
       </div>

--- a/frontend/src/components/dashboard/oncology-navigation-panel.tsx
+++ b/frontend/src/components/dashboard/oncology-navigation-panel.tsx
@@ -10,7 +10,6 @@ import {
   XCircle,
   ChevronRight,
   ChevronDown,
-  Calendar,
   FileText,
   ClipboardList,
   Pencil,
@@ -30,6 +29,10 @@ import {
 import { Button } from '@/components/ui/button';
 import { NavigationStepForm } from '@/components/patients/navigation-step-form';
 import type { UpdateNavigationStepFormData } from '@/lib/validations/navigation-step';
+import {
+  formatNavigationStepDateBr,
+  NAVIGATION_STEP_UI_DATE_LABEL,
+} from '@/lib/utils/navigation-step-dates';
 
 interface OncologyNavigationPanelProps {
   patientId: string;
@@ -158,6 +161,7 @@ export function OncologyNavigationPanel({
         status: data.status,
         isCompleted: data.isCompleted,
         completedAt: data.completedAt,
+        expectedDate: data.expectedDate,
         actualDate: data.actualDate,
         dueDate: data.dueDate,
         institutionName: data.institutionName,
@@ -311,35 +315,39 @@ export function OncologyNavigationPanel({
                             </p>
                           )}
 
-                          {/* Prazo */}
-                          {step.dueDate && (
-                            <div className="flex items-center gap-1.5 text-sm text-orange-700">
-                              <Clock className="h-4 w-4" />
-                              <span>
-                                Prazo:{' '}
-                                {format(new Date(step.dueDate), 'dd/MM/yyyy', {
-                                  locale: ptBR,
-                                })}
-                              </span>
+                          {/* Datas planejamento / limite / realização */}
+                          <dl className="mt-2 grid gap-2 text-sm text-orange-800 sm:grid-cols-3">
+                            <div>
+                              <dt className="text-xs font-medium text-orange-900/90">
+                                {NAVIGATION_STEP_UI_DATE_LABEL.agendada}
+                              </dt>
+                              <dd className="font-mono tabular-nums">
+                                {formatNavigationStepDateBr(step.expectedDate)}
+                              </dd>
                             </div>
-                          )}
-
-                          {/* Data esperada (se não houver prazo) */}
-                          {!step.dueDate && step.expectedDate && (
-                            <div className="flex items-center gap-1.5 text-sm text-orange-700">
-                              <Clock className="h-4 w-4" />
-                              <span>
-                                Esperado:{' '}
-                                {format(
-                                  new Date(step.expectedDate),
-                                  'dd/MM/yyyy',
-                                  {
-                                    locale: ptBR,
-                                  }
-                                )}
-                              </span>
+                            <div>
+                              <dt className="text-xs font-medium text-orange-900/90">
+                                {NAVIGATION_STEP_UI_DATE_LABEL.limite}
+                              </dt>
+                              <dd
+                                className={
+                                  step.status === 'OVERDUE'
+                                    ? 'font-mono tabular-nums font-semibold text-red-700'
+                                    : 'font-mono tabular-nums'
+                                }
+                              >
+                                {formatNavigationStepDateBr(step.dueDate)}
+                              </dd>
                             </div>
-                          )}
+                            <div>
+                              <dt className="text-xs font-medium text-orange-900/90">
+                                {NAVIGATION_STEP_UI_DATE_LABEL.realizada}
+                              </dt>
+                              <dd className="font-mono tabular-nums">
+                                {formatNavigationStepDateBr(step.actualDate)}
+                              </dd>
+                            </div>
+                          </dl>
 
                           {/* Status de conclusão */}
                           {step.completedAt && (

--- a/frontend/src/components/oncology-navigation/navigation-step-edit-panel.tsx
+++ b/frontend/src/components/oncology-navigation/navigation-step-edit-panel.tsx
@@ -60,8 +60,13 @@ export interface NavigationStepEditPanelProps {
   variantSectionReplacement?: React.ReactNode;
   stepDetail: Record<string, string>;
   onStepDetailFieldChange: (key: string, value: string) => void;
+  /** Data agendada (planejamento) — `expectedDate`. */
+  expectedDate: string;
+  onExpectedDateChange: (v: string) => void;
+  /** Data limite — `dueDate`; obrigatória para monitoramento de atrasos. */
   dueDate: string;
   onDueDateChange: (v: string) => void;
+  /** Data realizada — `actualDate`. */
   actualDate: string;
   onActualDateChange: (v: string) => void;
   isCompleted: boolean;
@@ -133,6 +138,8 @@ export function NavigationStepEditPanel({
   variantSectionReplacement,
   stepDetail,
   onStepDetailFieldChange,
+  expectedDate,
+  onExpectedDateChange,
   dueDate,
   onDueDateChange,
   actualDate,
@@ -166,6 +173,7 @@ export function NavigationStepEditPanel({
   const hint = getNavigationStepContextHint(stepKey);
   const VariantIcon = variantSectionIcon(variant);
   const idPrefix = useId();
+  const expectedId = `${idPrefix}-expected`;
   const dueId = `${idPrefix}-due`;
   const actualId = `${idPrefix}-actual`;
   const instId = `${idPrefix}-inst`;
@@ -199,10 +207,26 @@ export function NavigationStepEditPanel({
             <SectionTitle icon={CalendarDays}>Prazos e status</SectionTitle>
           </div>
           <p className="text-xs text-muted-foreground">
-            A data limite alimenta alertas de atraso no painel. A data realizada registra quando o
-            evento ocorreu de fato.
+            <span className="font-medium text-foreground">Agendada</span> registra quando o evento
+            está planejado. <span className="font-medium text-foreground">Limite</span> alimenta
+            alertas de atraso.{' '}
+            <span className="font-medium text-foreground">Realizada</span> marca quando de fato
+            ocorreu.
           </p>
-          <div className="grid gap-4 sm:grid-cols-2">
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="space-y-2">
+              <Label htmlFor={expectedId}>Data agendada</Label>
+              <Input
+                id={expectedId}
+                type="date"
+                value={expectedDate}
+                onChange={(e) => onExpectedDateChange(e.target.value)}
+                className="tabular-nums"
+              />
+              <p className="text-xs text-muted-foreground">
+                Opcional; preencha quando houver compromisso previsto.
+              </p>
+            </div>
             <div className="space-y-2">
               <Label htmlFor={dueId}>
                 Data limite <span className="text-destructive">*</span>
@@ -220,7 +244,7 @@ export function NavigationStepEditPanel({
                 Obrigatória para manter o monitoramento de prazos e atrasos.
               </p>
             </div>
-            <div className="space-y-2">
+            <div className="space-y-2 sm:col-span-2 lg:col-span-1">
               <Label htmlFor={actualId}>Data realizada</Label>
               <Input
                 id={actualId}

--- a/frontend/src/components/patients/create-navigation-step-dialog.tsx
+++ b/frontend/src/components/patients/create-navigation-step-dialog.tsx
@@ -205,7 +205,7 @@ export function CreateNavigationStepDialog({
               name="expectedDate"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Data esperada (opcional)</FormLabel>
+                  <FormLabel>Data agendada (opcional)</FormLabel>
                   <Popover>
                     <PopoverTrigger asChild>
                       <FormControl>
@@ -251,7 +251,7 @@ export function CreateNavigationStepDialog({
               name="dueDate"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Prazo final (opcional)</FormLabel>
+                  <FormLabel>Data limite (opcional)</FormLabel>
                   <Popover>
                     <PopoverTrigger asChild>
                       <FormControl>

--- a/frontend/src/components/patients/navigation-step-form.tsx
+++ b/frontend/src/components/patients/navigation-step-form.tsx
@@ -36,6 +36,7 @@ import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { cn } from '@/lib/utils';
 import { NavigationStep } from '@/lib/api/navigation';
+import { NAVIGATION_STEP_UI_DATE_LABEL } from '@/lib/utils/navigation-step-dates';
 
 const STEP_STATUS_LABELS: Record<string, string> = {
   PENDING: 'Pendente',
@@ -85,6 +86,11 @@ export function NavigationStepForm({
         ? typeof step.dueDate === 'string' && step.dueDate.includes('T')
           ? step.dueDate
           : new Date(step.dueDate).toISOString()
+        : undefined,
+      expectedDate: step.expectedDate
+        ? typeof step.expectedDate === 'string' && step.expectedDate.includes('T')
+          ? step.expectedDate
+          : new Date(step.expectedDate).toISOString()
         : undefined,
       institutionName: step.institutionName || undefined,
       professionalName: step.professionalName || undefined,
@@ -153,22 +159,24 @@ export function NavigationStepForm({
             )}
           />
 
-          {/* Data Real */}
+          {/* Data agendada (expectedDate) */}
           <FormField
             control={form.control}
-            name="actualDate"
+            name="expectedDate"
             render={({ field }) => (
               <FormItem className="flex flex-col">
-                <FormLabel>Data Real de Conclusão</FormLabel>
+                <FormLabel>Data agendada</FormLabel>
                 <Popover>
                   <PopoverTrigger asChild>
                     <FormControl>
                       <Button
+                        type="button"
                         variant="outline"
                         className={cn(
                           'w-full pl-3 text-left font-normal',
                           !field.value && 'text-muted-foreground'
                         )}
+                        aria-label={`${NAVIGATION_STEP_UI_DATE_LABEL.agendada}, opcional`}
                       >
                         {field.value ? (
                           format(new Date(field.value), 'dd/MM/yyyy', {
@@ -177,7 +185,7 @@ export function NavigationStepForm({
                         ) : (
                           <span>Selecione a data</span>
                         )}
-                        <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                        <CalendarIcon className="ml-auto h-4 w-4 opacity-50" aria-hidden />
                       </Button>
                     </FormControl>
                   </PopoverTrigger>
@@ -188,6 +196,7 @@ export function NavigationStepForm({
                       onSelect={(date) =>
                         field.onChange(date ? date.toISOString() : undefined)
                       }
+                      locale={ptBR}
                       initialFocus
                     />
                   </PopoverContent>
@@ -197,22 +206,24 @@ export function NavigationStepForm({
             )}
           />
 
-          {/* Prazo Final */}
+          {/* Data limite (dueDate) */}
           <FormField
             control={form.control}
             name="dueDate"
             render={({ field }) => (
               <FormItem className="flex flex-col">
-                <FormLabel>Prazo Final</FormLabel>
+                <FormLabel>Data limite</FormLabel>
                 <Popover>
                   <PopoverTrigger asChild>
                     <FormControl>
                       <Button
+                        type="button"
                         variant="outline"
                         className={cn(
                           'w-full pl-3 text-left font-normal',
                           !field.value && 'text-muted-foreground'
                         )}
+                        aria-label={`${NAVIGATION_STEP_UI_DATE_LABEL.limite}`}
                       >
                         {field.value ? (
                           format(new Date(field.value), 'dd/MM/yyyy', {
@@ -221,7 +232,7 @@ export function NavigationStepForm({
                         ) : (
                           <span>Selecione a data</span>
                         )}
-                        <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                        <CalendarIcon className="ml-auto h-4 w-4 opacity-50" aria-hidden />
                       </Button>
                     </FormControl>
                   </PopoverTrigger>
@@ -232,6 +243,54 @@ export function NavigationStepForm({
                       onSelect={(date) =>
                         field.onChange(date ? date.toISOString() : undefined)
                       }
+                      locale={ptBR}
+                      initialFocus
+                    />
+                  </PopoverContent>
+                </Popover>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* Data realizada (actualDate) */}
+          <FormField
+            control={form.control}
+            name="actualDate"
+            render={({ field }) => (
+              <FormItem className="flex flex-col md:col-span-2">
+                <FormLabel>Data realizada</FormLabel>
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <FormControl>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className={cn(
+                          'w-full pl-3 text-left font-normal',
+                          !field.value && 'text-muted-foreground'
+                        )}
+                        aria-label={`${NAVIGATION_STEP_UI_DATE_LABEL.realizada}, opcional`}
+                      >
+                        {field.value ? (
+                          format(new Date(field.value), 'dd/MM/yyyy', {
+                            locale: ptBR,
+                          })
+                        ) : (
+                          <span>Selecione a data</span>
+                        )}
+                        <CalendarIcon className="ml-auto h-4 w-4 opacity-50" aria-hidden />
+                      </Button>
+                    </FormControl>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-auto p-0" align="start">
+                    <Calendar
+                      mode="single"
+                      selected={field.value ? new Date(field.value) : undefined}
+                      onSelect={(date) =>
+                        field.onChange(date ? date.toISOString() : undefined)
+                      }
+                      locale={ptBR}
                       initialFocus
                     />
                   </PopoverContent>

--- a/frontend/src/components/patients/patient-navigation-tab.tsx
+++ b/frontend/src/components/patients/patient-navigation-tab.tsx
@@ -53,6 +53,10 @@ import {
   StageDroppableColumn,
 } from '@/components/patients/navigation-step-dnd';
 import { NavigationStep, navigationApi } from '@/lib/api/navigation';
+import {
+  formatNavigationStepDateBr,
+  NAVIGATION_STEP_UI_DATE_LABEL,
+} from '@/lib/utils/navigation-step-dates';
 import { NavigationStepDialog } from './navigation-step-dialog';
 import { CreateNavigationStepDialog } from './create-navigation-step-dialog';
 import { toast } from 'sonner';
@@ -723,64 +727,49 @@ export function PatientNavigationTab({
                                 {step.stepDescription}
                               </p>
                             )}
-                            <div className="flex items-center gap-4 text-sm flex-wrap">
-                              {step.expectedDate && (
-                                <div>
-                                  <span className="font-medium">
-                                    Prazo esperado:
-                                  </span>{' '}
-                                  {format(
-                                    new Date(step.expectedDate),
-                                    'dd/MM/yyyy',
-                                    {
-                                      locale: ptBR,
-                                    }
-                                  )}
-                                </div>
-                              )}
-                              {step.completedAt && (
-                                <div>
-                                  <span className="font-medium">
-                                    Concluído em:
-                                  </span>{' '}
-                                  {format(
-                                    new Date(step.completedAt),
-                                    'dd/MM/yyyy',
-                                    {
-                                      locale: ptBR,
-                                    }
-                                  )}
-                                </div>
-                              )}
-                              {step.dueDate && (
-                                <div>
-                                  <span className="font-medium">
-                                    Prazo final:
-                                  </span>{' '}
-                                  {format(
-                                    new Date(step.dueDate),
-                                    'dd/MM/yyyy',
-                                    {
-                                      locale: ptBR,
-                                    }
-                                  )}
-                                </div>
-                              )}
-                              {step.actualDate && (
-                                <div>
-                                  <span className="font-medium">
-                                    Data real:
-                                  </span>{' '}
-                                  {format(
-                                    new Date(step.actualDate),
-                                    'dd/MM/yyyy',
-                                    {
-                                      locale: ptBR,
-                                    }
-                                  )}
-                                </div>
-                              )}
-                            </div>
+                            <dl className="grid gap-2 rounded-md border border-border/70 bg-muted/15 px-2 py-2 text-sm sm:grid-cols-3">
+                              <div className="min-w-0">
+                                <dt className="text-xs font-medium text-muted-foreground">
+                                  {NAVIGATION_STEP_UI_DATE_LABEL.agendada}
+                                </dt>
+                                <dd className="font-mono text-foreground tabular-nums">
+                                  {formatNavigationStepDateBr(step.expectedDate)}
+                                </dd>
+                              </div>
+                              <div className="min-w-0">
+                                <dt className="text-xs font-medium text-muted-foreground">
+                                  {NAVIGATION_STEP_UI_DATE_LABEL.limite}
+                                </dt>
+                                <dd
+                                  className={
+                                    step.status === 'OVERDUE'
+                                      ? 'font-mono font-semibold text-destructive tabular-nums'
+                                      : 'font-mono text-foreground tabular-nums'
+                                  }
+                                >
+                                  {formatNavigationStepDateBr(step.dueDate)}
+                                </dd>
+                              </div>
+                              <div className="min-w-0">
+                                <dt className="text-xs font-medium text-muted-foreground">
+                                  {NAVIGATION_STEP_UI_DATE_LABEL.realizada}
+                                </dt>
+                                <dd className="font-mono text-foreground tabular-nums">
+                                  {formatNavigationStepDateBr(step.actualDate)}
+                                </dd>
+                              </div>
+                            </dl>
+                            {step.completedAt ? (
+                              <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                                <Clock className="h-3.5 w-3.5 shrink-0" aria-hidden />
+                                <span>
+                                  Registro no sistema (conclusão):{' '}
+                                  {format(new Date(step.completedAt), 'dd/MM/yyyy', {
+                                    locale: ptBR,
+                                  })}
+                                </span>
+                              </div>
+                            ) : null}
                             {step.institutionName && (
                               <div className="text-sm">
                                 <span className="font-medium">

--- a/frontend/src/components/shared/navigation-bar.tsx
+++ b/frontend/src/components/shared/navigation-bar.tsx
@@ -58,12 +58,12 @@ const baseNavItems: NavItem[] = [
   },
   {
     path: '/oncology-navigation',
-    label: 'Navegação Oncológica',
+    label: 'Navegação',
     icon: Navigation,
   },
   {
     path: '/oncology-navigation/agenda',
-    label: 'Agenda de consultas',
+    label: 'Agenda',
     icon: CalendarDays,
   },
   {

--- a/frontend/src/lib/api/oncology-navigation.ts
+++ b/frontend/src/lib/api/oncology-navigation.ts
@@ -1,6 +1,11 @@
 import { apiClient } from './client';
 import type { JourneyStage } from '@/lib/utils/journey-stage';
 
+/**
+ * Datas por etapa (documentação produto ↔ JSON):
+ * @see frontend/src/lib/utils/navigation-step-dates.ts NAVIGATION_STEP_UI_DATE_LABEL —
+ * «Agendada» → expectedDate; «Limite» → dueDate; «Realizada» → actualDate.
+ */
 /** Parâmetro de estágio da jornada (API oncology-navigation) — alinhado ao Prisma. */
 export type JourneyStageParam = JourneyStage;
 
@@ -29,9 +34,12 @@ export interface NavigationStep {
   isRequired: boolean;
   isCompleted: boolean;
   completedAt?: string;
+  /** «Agendada» na UI — data-alvo planejada. */
   expectedDate?: string;
-  dueDate?: string; // Data limite para gerar alarmes de atraso
-  actualDate?: string; // Data real de conclusão
+  /** «Limite» na UI — vigência para alertas de atraso. */
+  dueDate?: string;
+  /** «Realizada» na UI — quando o evento ocorreu. */
+  actualDate?: string;
   institutionName?: string; // Instituição de saúde onde foi realizada
   professionalName?: string; // Profissional que realizou a etapa
   result?: string; // Resultado da etapa
@@ -106,8 +114,9 @@ export interface UpdateNavigationStepDto {
   isCompleted?: boolean;
   completedAt?: string;
   completedBy?: string;
-  actualDate?: string; // Data realizada
-  dueDate?: string; // Data limite para gerar alarmes de atraso
+  expectedDate?: string;
+  actualDate?: string;
+  dueDate?: string;
   institutionName?: string; // Instituição de saúde onde foi realizada
   professionalName?: string; // Profissional que realizou
   result?: string; // Resultado da etapa

--- a/frontend/src/lib/utils/__tests__/navigation-step-dates.test.ts
+++ b/frontend/src/lib/utils/__tests__/navigation-step-dates.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatNavigationStepDateBr,
+  NAVIGATION_STEP_UI_DATE_LABEL,
+} from '@/lib/utils/navigation-step-dates';
+
+describe('navigation-step-dates', () => {
+  it('expõe rótulos de UI estáveis para as três dimensões de data', () => {
+    expect(NAVIGATION_STEP_UI_DATE_LABEL.agendada).toBe('Agendada');
+    expect(NAVIGATION_STEP_UI_DATE_LABEL.limite).toBe('Limite');
+    expect(NAVIGATION_STEP_UI_DATE_LABEL.realizada).toBe('Realizada');
+  });
+
+  it('formatNavigationStepDateBr retorna placeholder para ausente', () => {
+    expect(formatNavigationStepDateBr(undefined)).toBe('—');
+    expect(formatNavigationStepDateBr(null)).toBe('—');
+    expect(formatNavigationStepDateBr('')).toBe('—');
+  });
+
+  it('formatNavigationStepDateBr formata ISO completo ou só data', () => {
+    expect(formatNavigationStepDateBr('2026-07-08T12:00:00.000Z')).toMatch(
+      /^\d{2}\/\d{2}\/2026$/
+    );
+    expect(formatNavigationStepDateBr('2026-07-08')).toMatch(/\/07\/2026$/);
+  });
+});

--- a/frontend/src/lib/utils/navigation-step-dates.ts
+++ b/frontend/src/lib/utils/navigation-step-dates.ts
@@ -1,0 +1,34 @@
+import { format, parseISO } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+
+/**
+ * Contrato produto ↔ API JSON (`NavigationStep` no backend Nest/Prisma):
+ *
+ * | Rótulo na UI (usuário) | Campo JSON (camelCase) | Observação |
+ * | ---------------------- | ---------------------- | ----------- |
+ * | Agendada | `expectedDate` | Planejamento / data-alvo planejada. |
+ * | Limite | `dueDate` | Alimenta alertas de atraso. |
+ * | Realizada | `actualDate` | Momento em que o evento ocorreu. |
+ *
+ * `completedAt` marca quando a etapa foi registrada como concluída no sistema;
+ * o backend pode preencher `actualDate` a partir dela quando a realizada não é informada.
+ */
+export const NAVIGATION_STEP_UI_DATE_LABEL = {
+  agendada: 'Agendada',
+  limite: 'Limite',
+  realizada: 'Realizada',
+} as const;
+
+/** Formato curto pt-BR para listagens; valores ausentes mostram placeholder acessível. */
+export function formatNavigationStepDateBr(
+  value?: string | null,
+  emptyPlaceholder = '—'
+): string {
+  if (value == null || value === '') return emptyPlaceholder;
+  try {
+    const raw = value.includes('T') ? value : `${value.slice(0, 10)}T12:00:00`;
+    return format(parseISO(raw), 'dd/MM/yyyy', { locale: ptBR });
+  } catch {
+    return emptyPlaceholder;
+  }
+}

--- a/frontend/src/lib/validations/navigation-step.ts
+++ b/frontend/src/lib/validations/navigation-step.ts
@@ -13,6 +13,7 @@ export const updateNavigationStepSchema = z.object({
   status: navigationStepStatusSchema.optional(),
   isCompleted: z.boolean().optional(),
   completedAt: z.string().optional(),
+  expectedDate: z.string().optional(),
   actualDate: z.string().optional(),
   dueDate: z.string().optional(),
   institutionName: z.string().optional(),


### PR DESCRIPTION
## O quê
- Backend: aceita `expectedDate` no update de etapa e adiciona testes
- Frontend: UI/validações para editar/exibir `expectedDate`
- Utilitário + testes para lidar com datas de etapas

## Por quê
- Permite planejar e acompanhar datas previstas das etapas de navegação oncológica.

## Como testar
- [ ] Backend: rodar `cd backend && npm test` (módulo oncology-navigation)
- [ ] Frontend: abrir tela de navegação e editar/visualizar `expectedDate`

## Checklist
- [ ] Sem quebra de contrato entre frontend/backend
- [ ] Testes adicionados para utilitário de datas

Made with [Cursor](https://cursor.com)