### PR TITLE
feat: pedidos (exames/receita) na evolução

### DIFF
--- a/backend/prisma/migrations/20260508005311_add_clinical_note_orders/migration.sql
+++ b/backend/prisma/migrations/20260508005311_add_clinical_note_orders/migration.sql
@@ -1,0 +1,85 @@
+-- CreateTable
+CREATE TABLE "clinical_exam_requests" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "patientId" TEXT NOT NULL,
+    "clinicalNoteId" TEXT NOT NULL,
+    "clinicalNoteVersionNumber" INTEGER NOT NULL,
+    "requestedById" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "code" TEXT,
+    "loincCode" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "clinical_exam_requests_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "clinical_prescription_lines" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "patientId" TEXT NOT NULL,
+    "clinicalNoteId" TEXT NOT NULL,
+    "clinicalNoteVersionNumber" INTEGER NOT NULL,
+    "prescribedById" TEXT NOT NULL,
+    "medicationName" TEXT NOT NULL,
+    "catalogKey" TEXT,
+    "dosage" TEXT,
+    "frequency" TEXT,
+    "route" TEXT,
+    "duration" TEXT,
+    "indication" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "clinical_prescription_lines_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "clinical_exam_requests_tenantId_idx" ON "clinical_exam_requests"("tenantId");
+
+-- CreateIndex
+CREATE INDEX "clinical_exam_requests_patientId_idx" ON "clinical_exam_requests"("patientId");
+
+-- CreateIndex
+CREATE INDEX "clinical_exam_requests_clinicalNoteId_idx" ON "clinical_exam_requests"("clinicalNoteId");
+
+-- CreateIndex
+CREATE INDEX "clinical_exam_requests_tenantId_clinicalNoteId_idx" ON "clinical_exam_requests"("tenantId", "clinicalNoteId");
+
+-- CreateIndex
+CREATE INDEX "clinical_prescription_lines_tenantId_idx" ON "clinical_prescription_lines"("tenantId");
+
+-- CreateIndex
+CREATE INDEX "clinical_prescription_lines_patientId_idx" ON "clinical_prescription_lines"("patientId");
+
+-- CreateIndex
+CREATE INDEX "clinical_prescription_lines_clinicalNoteId_idx" ON "clinical_prescription_lines"("clinicalNoteId");
+
+-- CreateIndex
+CREATE INDEX "clinical_prescription_lines_tenantId_clinicalNoteId_idx" ON "clinical_prescription_lines"("tenantId", "clinicalNoteId");
+
+-- AddForeignKey
+ALTER TABLE "clinical_exam_requests" ADD CONSTRAINT "clinical_exam_requests_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "tenants"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "clinical_exam_requests" ADD CONSTRAINT "clinical_exam_requests_patientId_fkey" FOREIGN KEY ("patientId") REFERENCES "patients"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "clinical_exam_requests" ADD CONSTRAINT "clinical_exam_requests_clinicalNoteId_fkey" FOREIGN KEY ("clinicalNoteId") REFERENCES "clinical_notes"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "clinical_exam_requests" ADD CONSTRAINT "clinical_exam_requests_requestedById_fkey" FOREIGN KEY ("requestedById") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "clinical_prescription_lines" ADD CONSTRAINT "clinical_prescription_lines_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "tenants"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "clinical_prescription_lines" ADD CONSTRAINT "clinical_prescription_lines_patientId_fkey" FOREIGN KEY ("patientId") REFERENCES "patients"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "clinical_prescription_lines" ADD CONSTRAINT "clinical_prescription_lines_clinicalNoteId_fkey" FOREIGN KEY ("clinicalNoteId") REFERENCES "clinical_notes"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "clinical_prescription_lines" ADD CONSTRAINT "clinical_prescription_lines_prescribedById_fkey" FOREIGN KEY ("prescribedById") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -33,6 +33,10 @@ model User {
   clinicalNotesSigned          ClinicalNote[]        @relation("ClinicalNoteSignedBy")
   clinicalNotesVoided          ClinicalNote[]        @relation("ClinicalNoteVoidedBy")
   clinicalNoteVersionsAuthored ClinicalNoteVersion[] @relation("ClinicalNoteVersionAuthor")
+  /// Pedidos de exame registrados na evolução
+  clinicalExamRequestsRequested ClinicalExamRequest[] @relation("ClinicalExamRequestRequestedBy")
+  /// Linhas de prescrição registradas na evolução médica
+  clinicalPrescriptionLinesPrescribed ClinicalPrescriptionLine[] @relation("ClinicalPrescriptionLinePrescribedBy")
   productFeedbacks             ProductFeedback[]
 
   @@unique([tenantId, email])
@@ -152,6 +156,10 @@ model Patient {
   performanceStatusHistory PerformanceStatusHistory[] // Histórico ECOG para cálculo de delta
   dispositionFeedback      ClinicalDispositionFeedback[] // Correções de disposição para retraining
   clinicalNotes            ClinicalNote[] // Prontuário estruturado (evoluções versionadas)
+  /// Pedidos de exame vinculados a uma evolução (ServiceRequest clínico; não é o cadastro ComplementaryExam)
+  clinicalExamRequests     ClinicalExamRequest[]
+  /// Prescrição na evolução (evento prescritivo; não substitui Medication "em uso")
+  clinicalPrescriptionLines ClinicalPrescriptionLine[]
   consents                 PatientConsent[] // Termos de Consentimento Livre e Esclarecido (TCLE)
 
   createdAt DateTime @default(now())
@@ -199,6 +207,8 @@ model ClinicalNote {
   amendsClinicalNote ClinicalNote?         @relation("ClinicalNoteAmendment", fields: [amendsClinicalNoteId], references: [id])
   amendedNotes       ClinicalNote[]        @relation("ClinicalNoteAmendment")
   versions           ClinicalNoteVersion[]
+  clinicalExamRequests      ClinicalExamRequest[]
+  clinicalPrescriptionLines ClinicalPrescriptionLine[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -208,6 +218,67 @@ model ClinicalNote {
   @@index([tenantId, patientId, createdAt])
   @@index([navigationStepId])
   @@map("clinical_notes")
+}
+
+/// Pedido de exame na evolução — rastreável por `clinicalNoteId` + `clinicalNoteVersionNumber`
+model ClinicalExamRequest {
+  id                        String @id @default(uuid())
+  tenantId                  String
+  patientId                 String
+  clinicalNoteId            String
+  /// Versão da evolução no momento do registro (`ClinicalNoteVersion.versionNumber`)
+  clinicalNoteVersionNumber Int
+
+  requestedById String
+  displayName   String
+  code          String?
+  loincCode     String?
+
+  tenant         Tenant       @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  patient        Patient      @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  clinicalNote   ClinicalNote @relation(fields: [clinicalNoteId], references: [id], onDelete: Cascade)
+  requestedBy    User         @relation("ClinicalExamRequestRequestedBy", fields: [requestedById], references: [id])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([tenantId])
+  @@index([patientId])
+  @@index([clinicalNoteId])
+  @@index([tenantId, clinicalNoteId])
+  @@map("clinical_exam_requests")
+}
+
+/// Linha de medicamento prescrita no contexto da evolução médica — não atualiza automaticamente `Medication` (em uso / ML)
+model ClinicalPrescriptionLine {
+  id                        String @id @default(uuid())
+  tenantId                  String
+  patientId                 String
+  clinicalNoteId            String
+  clinicalNoteVersionNumber Int
+
+  prescribedById String
+  medicationName String
+  catalogKey     String?
+  dosage         String?
+  frequency      String?
+  route          String?
+  duration       String?
+  indication     String?
+
+  tenant       Tenant       @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  patient      Patient      @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  clinicalNote ClinicalNote @relation(fields: [clinicalNoteId], references: [id], onDelete: Cascade)
+  prescribedBy User         @relation("ClinicalPrescriptionLinePrescribedBy", fields: [prescribedById], references: [id])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([tenantId])
+  @@index([patientId])
+  @@index([clinicalNoteId])
+  @@index([tenantId, clinicalNoteId])
+  @@map("clinical_prescription_lines")
 }
 
 enum ClinicalNoteType {
@@ -1506,6 +1577,8 @@ model Tenant {
   dispositionFeedback      ClinicalDispositionFeedback[]
   clinicalNotes            ClinicalNote[]
   clinicalNoteVersions     ClinicalNoteVersion[]
+  clinicalExamRequests     ClinicalExamRequest[]
+  clinicalPrescriptionLines ClinicalPrescriptionLine[]
   patientConsents          PatientConsent[]
   productFeedbacks         ProductFeedback[]
 

--- a/backend/src/clinical-notes/clinical-note-orders.service.spec.ts
+++ b/backend/src/clinical-notes/clinical-note-orders.service.spec.ts
@@ -1,0 +1,120 @@
+import { BadRequestException } from '@nestjs/common';
+import { ClinicalNoteStatus, ClinicalNoteType, UserRole } from '@generated/prisma/client';
+import { ClinicalNoteOrdersService } from './clinical-note-orders.service';
+import { ClinicalNotesService } from './clinical-notes.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+describe('ClinicalNoteOrdersService', () => {
+  let service: ClinicalNoteOrdersService;
+  const mockPrisma = {
+    clinicalNote: { findFirst: jest.fn() },
+    clinicalNoteVersion: { findFirst: jest.fn() },
+    clinicalExamRequest: {
+      findMany: jest.fn(),
+      create: jest.fn(),
+      findFirst: jest.fn(),
+      delete: jest.fn(),
+    },
+    clinicalPrescriptionLine: {
+      findMany: jest.fn(),
+      create: jest.fn(),
+      findFirst: jest.fn(),
+      delete: jest.fn(),
+    },
+  };
+  const mockClinicalNotes = {
+    canCreateOrSignNoteType: jest.fn(),
+  };
+
+  const actor = {
+    id: 'user-1',
+    role: UserRole.ONCOLOGIST,
+    clinicalSubrole: null,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ClinicalNoteOrdersService(
+      mockPrisma as unknown as PrismaService,
+      mockClinicalNotes as unknown as ClinicalNotesService
+    );
+  });
+
+  describe('createExamRequest', () => {
+    it('scopes note to patient and tenant', async () => {
+      mockPrisma.clinicalNote.findFirst.mockResolvedValue({
+        id: 'note-1',
+        status: ClinicalNoteStatus.DRAFT,
+        noteType: ClinicalNoteType.MEDICAL,
+        patientId: 'pat-1',
+      });
+      mockPrisma.clinicalNoteVersion.findFirst.mockResolvedValue({
+        versionNumber: 2,
+      });
+      mockClinicalNotes.canCreateOrSignNoteType.mockReturnValue(true);
+      mockPrisma.clinicalExamRequest.create.mockResolvedValue({
+        id: 'ex-1',
+        clinicalNoteVersionNumber: 2,
+        displayName: 'Hemograma',
+        code: null,
+        loincCode: null,
+        requestedBy: { id: actor.id, name: 'Dra.' },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      await service.createExamRequest(
+        'pat-1',
+        'note-1',
+        'tenant-1',
+        actor,
+        { displayName: 'Hemograma' }
+      );
+
+      expect(mockPrisma.clinicalNote.findFirst).toHaveBeenCalledWith({
+        where: { id: 'note-1', tenantId: 'tenant-1', patientId: 'pat-1' },
+        select: expect.any(Object),
+      });
+    });
+
+    it('throws when note not in draft', async () => {
+      mockPrisma.clinicalNote.findFirst.mockResolvedValue({
+        id: 'note-1',
+        status: ClinicalNoteStatus.SIGNED,
+        noteType: ClinicalNoteType.MEDICAL,
+        patientId: 'pat-1',
+      });
+
+      await expect(
+        service.createExamRequest(
+          'pat-1',
+          'note-1',
+          'tenant-1',
+          actor,
+          { displayName: 'X' }
+        )
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('createPrescriptionLine', () => {
+    it('rejects nursing evolution', async () => {
+      mockPrisma.clinicalNote.findFirst.mockResolvedValue({
+        id: 'note-1',
+        status: ClinicalNoteStatus.DRAFT,
+        noteType: ClinicalNoteType.NURSING,
+        patientId: 'pat-1',
+      });
+
+      await expect(
+        service.createPrescriptionLine(
+          'pat-1',
+          'note-1',
+          'tenant-1',
+          actor,
+          { medicationName: 'X' }
+        )
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+});

--- a/backend/src/clinical-notes/clinical-note-orders.service.ts
+++ b/backend/src/clinical-notes/clinical-note-orders.service.ts
@@ -1,0 +1,284 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  ClinicalNoteStatus,
+  ClinicalNoteType,
+} from '@generated/prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { ClinicalNotesService, type ClinicalNoteActor } from './clinical-notes.service';
+import { CreateClinicalExamRequestDto } from './dto/create-clinical-exam-request.dto';
+import { CreateClinicalPrescriptionLineDto } from './dto/create-clinical-prescription-line.dto';
+
+@Injectable()
+export class ClinicalNoteOrdersService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly clinicalNotesService: ClinicalNotesService
+  ) {}
+
+  private async resolveNoteForOrders(
+    clinicalNoteId: string,
+    patientId: string,
+    tenantId: string
+  ) {
+    const note = await this.prisma.clinicalNote.findFirst({
+      where: { id: clinicalNoteId, tenantId, patientId },
+      select: {
+        id: true,
+        status: true,
+        noteType: true,
+        patientId: true,
+      },
+    });
+    if (!note) {
+      throw new NotFoundException('Evolução não encontrada para este paciente');
+    }
+    if (note.status === ClinicalNoteStatus.VOIDED) {
+      throw new BadRequestException('Não é possível alterar pedidos em evolução anulada');
+    }
+    if (note.status !== ClinicalNoteStatus.DRAFT) {
+      throw new BadRequestException(
+        'Pedidos só podem ser incluídos ou removidos enquanto a evolução estiver em rascunho'
+      );
+    }
+    return note;
+  }
+
+  private async latestVersionNumber(
+    clinicalNoteId: string,
+    tenantId: string
+  ): Promise<number> {
+    const v = await this.prisma.clinicalNoteVersion.findFirst({
+      where: { clinicalNoteId, tenantId },
+      orderBy: { versionNumber: 'desc' },
+      select: { versionNumber: true },
+    });
+    if (!v) {
+      throw new BadRequestException('Evolução sem versão de conteúdo');
+    }
+    return v.versionNumber;
+  }
+
+  private assertCanManageOrdersForNoteType(
+    actor: ClinicalNoteActor,
+    noteType: ClinicalNoteType
+  ) {
+    if (
+      !this.clinicalNotesService.canCreateOrSignNoteType(
+        actor.role,
+        actor.clinicalSubrole,
+        noteType
+      )
+    ) {
+      throw new ForbiddenException('Sem permissão para gerir pedidos nesta evolução');
+    }
+  }
+
+  async listExamRequests(
+    patientId: string,
+    clinicalNoteId: string,
+    tenantId: string
+  ) {
+    const note = await this.prisma.clinicalNote.findFirst({
+      where: { id: clinicalNoteId, tenantId, patientId },
+      select: { id: true },
+    });
+    if (!note) {
+      throw new NotFoundException('Evolução não encontrada para este paciente');
+    }
+    return this.prisma.clinicalExamRequest.findMany({
+      where: { tenantId, clinicalNoteId },
+      orderBy: { createdAt: 'asc' },
+      select: {
+        id: true,
+        clinicalNoteVersionNumber: true,
+        displayName: true,
+        code: true,
+        loincCode: true,
+        requestedBy: { select: { id: true, name: true } },
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+  }
+
+  async createExamRequest(
+    patientId: string,
+    clinicalNoteId: string,
+    tenantId: string,
+    actor: ClinicalNoteActor,
+    dto: CreateClinicalExamRequestDto
+  ) {
+    const note = await this.resolveNoteForOrders(
+      clinicalNoteId,
+      patientId,
+      tenantId
+    );
+    this.assertCanManageOrdersForNoteType(actor, note.noteType);
+    const versionNumber = await this.latestVersionNumber(clinicalNoteId, tenantId);
+    return this.prisma.clinicalExamRequest.create({
+      data: {
+        tenantId,
+        patientId,
+        clinicalNoteId,
+        clinicalNoteVersionNumber: versionNumber,
+        requestedById: actor.id,
+        displayName: dto.displayName.trim(),
+        code: dto.code?.trim() || null,
+        loincCode: dto.loincCode?.trim() || null,
+      },
+      select: {
+        id: true,
+        clinicalNoteVersionNumber: true,
+        displayName: true,
+        code: true,
+        loincCode: true,
+        requestedBy: { select: { id: true, name: true } },
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+  }
+
+  async deleteExamRequest(
+    patientId: string,
+    clinicalNoteId: string,
+    requestId: string,
+    tenantId: string,
+    actor: ClinicalNoteActor
+  ) {
+    const note = await this.resolveNoteForOrders(
+      clinicalNoteId,
+      patientId,
+      tenantId
+    );
+    this.assertCanManageOrdersForNoteType(actor, note.noteType);
+    const row = await this.prisma.clinicalExamRequest.findFirst({
+      where: { id: requestId, tenantId, clinicalNoteId, patientId },
+      select: { id: true },
+    });
+    if (!row) {
+      throw new NotFoundException('Pedido de exame não encontrado');
+    }
+    await this.prisma.clinicalExamRequest.delete({
+      where: { id: requestId, tenantId },
+    });
+  }
+
+  async listPrescriptionLines(
+    patientId: string,
+    clinicalNoteId: string,
+    tenantId: string
+  ) {
+    const note = await this.prisma.clinicalNote.findFirst({
+      where: { id: clinicalNoteId, tenantId, patientId },
+      select: { id: true },
+    });
+    if (!note) {
+      throw new NotFoundException('Evolução não encontrada para este paciente');
+    }
+    return this.prisma.clinicalPrescriptionLine.findMany({
+      where: { tenantId, clinicalNoteId },
+      orderBy: { createdAt: 'asc' },
+      select: {
+        id: true,
+        clinicalNoteVersionNumber: true,
+        medicationName: true,
+        catalogKey: true,
+        dosage: true,
+        frequency: true,
+        route: true,
+        duration: true,
+        indication: true,
+        prescribedBy: { select: { id: true, name: true } },
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+  }
+
+  async createPrescriptionLine(
+    patientId: string,
+    clinicalNoteId: string,
+    tenantId: string,
+    actor: ClinicalNoteActor,
+    dto: CreateClinicalPrescriptionLineDto
+  ) {
+    const note = await this.resolveNoteForOrders(
+      clinicalNoteId,
+      patientId,
+      tenantId
+    );
+    if (note.noteType !== ClinicalNoteType.MEDICAL) {
+      throw new BadRequestException(
+        'Prescrições estruturadas só se aplicam à evolução médica'
+      );
+    }
+    this.assertCanManageOrdersForNoteType(actor, ClinicalNoteType.MEDICAL);
+    const versionNumber = await this.latestVersionNumber(clinicalNoteId, tenantId);
+    return this.prisma.clinicalPrescriptionLine.create({
+      data: {
+        tenantId,
+        patientId,
+        clinicalNoteId,
+        clinicalNoteVersionNumber: versionNumber,
+        prescribedById: actor.id,
+        medicationName: dto.medicationName.trim(),
+        catalogKey: dto.catalogKey?.trim() || null,
+        dosage: dto.dosage?.trim() || null,
+        frequency: dto.frequency?.trim() || null,
+        route: dto.route?.trim() || null,
+        duration: dto.duration?.trim() || null,
+        indication: dto.indication?.trim() || null,
+      },
+      select: {
+        id: true,
+        clinicalNoteVersionNumber: true,
+        medicationName: true,
+        catalogKey: true,
+        dosage: true,
+        frequency: true,
+        route: true,
+        duration: true,
+        indication: true,
+        prescribedBy: { select: { id: true, name: true } },
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+  }
+
+  async deletePrescriptionLine(
+    patientId: string,
+    clinicalNoteId: string,
+    lineId: string,
+    tenantId: string,
+    actor: ClinicalNoteActor
+  ) {
+    const note = await this.resolveNoteForOrders(
+      clinicalNoteId,
+      patientId,
+      tenantId
+    );
+    if (note.noteType !== ClinicalNoteType.MEDICAL) {
+      throw new BadRequestException(
+        'Prescrições estruturadas só se aplicam à evolução médica'
+      );
+    }
+    this.assertCanManageOrdersForNoteType(actor, ClinicalNoteType.MEDICAL);
+    const row = await this.prisma.clinicalPrescriptionLine.findFirst({
+      where: { id: lineId, tenantId, clinicalNoteId, patientId },
+      select: { id: true },
+    });
+    if (!row) {
+      throw new NotFoundException('Linha de prescrição não encontrada');
+    }
+    await this.prisma.clinicalPrescriptionLine.delete({
+      where: { id: lineId, tenantId },
+    });
+  }
+}

--- a/backend/src/clinical-notes/clinical-notes.constants.ts
+++ b/backend/src/clinical-notes/clinical-notes.constants.ts
@@ -21,9 +21,6 @@ export type ClinicalNoteSectionKey = (typeof CLINICAL_NOTE_SECTION_KEYS)[number]
 /** Limite por campo (caracteres) — legado V1 por seção */
 export const CLINICAL_NOTE_SECTION_MAX_LENGTH = 32_000;
 
-/** Limite do corpo Markdown da evolução (V2, texto único cifrado). */
-export const CLINICAL_NOTE_CONTENT_MARKDOWN_MAX_LENGTH = 400_000;
-
 /**
  * Chave da etapa de navegação universal correspondente a cada tipo de evolução.
  * Alinhado a `mergeUniversalStepConfigs` em oncology-navigation.service.ts.

--- a/backend/src/clinical-notes/clinical-notes.module.ts
+++ b/backend/src/clinical-notes/clinical-notes.module.ts
@@ -2,14 +2,24 @@ import { Module } from '@nestjs/common';
 import { PrismaModule } from '../prisma/prisma.module';
 import { AuditLogModule } from '../audit-log/audit-log.module';
 import { ClinicalNotesService } from './clinical-notes.service';
+import { ClinicalNoteOrdersService } from './clinical-note-orders.service';
 import { ClinicalNoteSectionSuggestionService } from './clinical-note-section-suggestion.service';
 import { ClinicalNotesController } from './clinical-notes.controller';
 import { PatientClinicalNotesController } from './patient-clinical-notes.controller';
+import { PatientClinicalNoteOrdersController } from './patient-clinical-note-orders.controller';
 
 @Module({
   imports: [PrismaModule, AuditLogModule],
-  controllers: [ClinicalNotesController, PatientClinicalNotesController],
-  providers: [ClinicalNotesService, ClinicalNoteSectionSuggestionService],
+  controllers: [
+    ClinicalNotesController,
+    PatientClinicalNotesController,
+    PatientClinicalNoteOrdersController,
+  ],
+  providers: [
+    ClinicalNotesService,
+    ClinicalNoteOrdersService,
+    ClinicalNoteSectionSuggestionService,
+  ],
   exports: [ClinicalNotesService, ClinicalNoteSectionSuggestionService],
 })
 export class ClinicalNotesModule {}

--- a/backend/src/clinical-notes/clinical-notes.service.spec.ts
+++ b/backend/src/clinical-notes/clinical-notes.service.spec.ts
@@ -10,7 +10,6 @@ import {
 import { ClinicalNotesService } from './clinical-notes.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditLogService } from '../audit-log/audit-log.service';
-import { CLINICAL_NOTE_CONTENT_MARKDOWN_MAX_LENGTH } from './clinical-notes.constants';
 
 describe('ClinicalNotesService', () => {
   let service: ClinicalNotesService;
@@ -55,10 +54,10 @@ describe('ClinicalNotesService', () => {
       expect(service.normalizeAndValidateContentMarkdown('')).toBe('');
     });
 
-    it('rejects content exceeding max length', () => {
-      const huge = 'x'.repeat(CLINICAL_NOTE_CONTENT_MARKDOWN_MAX_LENGTH + 1);
-      expect(() => service.normalizeAndValidateContentMarkdown(huge)).toThrow(
-        BadRequestException
+    it('accepts conteúdo muito longo (sem limite artificial)', () => {
+      const longContent = 'x'.repeat(450_000);
+      expect(service.normalizeAndValidateContentMarkdown(longContent)).toBe(
+        longContent
       );
     });
   });

--- a/backend/src/clinical-notes/clinical-notes.service.ts
+++ b/backend/src/clinical-notes/clinical-notes.service.ts
@@ -20,10 +20,7 @@ import {
   encryptSensitiveData,
   decryptSensitiveData,
 } from '../whatsapp-connections/utils/encryption.util';
-import {
-  CLINICAL_NOTE_NAVIGATION_STEP_KEY,
-  CLINICAL_NOTE_CONTENT_MARKDOWN_MAX_LENGTH,
-} from './clinical-notes.constants';
+import { CLINICAL_NOTE_NAVIGATION_STEP_KEY } from './clinical-notes.constants';
 import { decodeDecryptedClinicalNoteToMarkdown } from './clinical-note-legacy-content.util';
 import {
   CreateClinicalNoteDto,
@@ -59,13 +56,7 @@ export class ClinicalNotesService {
   }
 
   normalizeAndValidateContentMarkdown(raw: string | null | undefined): string {
-    const s = raw === undefined || raw === null ? '' : String(raw);
-    if (s.length > CLINICAL_NOTE_CONTENT_MARKDOWN_MAX_LENGTH) {
-      throw new BadRequestException(
-        `Conteúdo da evolução excede ${CLINICAL_NOTE_CONTENT_MARKDOWN_MAX_LENGTH} caracteres`
-      );
-    }
-    return s;
+    return raw === undefined || raw === null ? '' : String(raw);
   }
 
   private encryptClinicalNotePayload(plaintext: string): {

--- a/backend/src/clinical-notes/dto/clinical-note-sections.dto.ts
+++ b/backend/src/clinical-notes/dto/clinical-note-sections.dto.ts
@@ -6,7 +6,6 @@ import {
   MaxLength,
 } from 'class-validator';
 import { ClinicalNoteType } from '@generated/prisma/client';
-import { CLINICAL_NOTE_CONTENT_MARKDOWN_MAX_LENGTH } from '../clinical-notes.constants';
 
 export class CreateClinicalNoteDto {
   @IsEnum(ClinicalNoteType)
@@ -18,13 +17,11 @@ export class CreateClinicalNoteDto {
 
   /** Evolução em Markdown (texto livre). */
   @IsString()
-  @MaxLength(CLINICAL_NOTE_CONTENT_MARKDOWN_MAX_LENGTH)
   contentMarkdown!: string;
 }
 
 export class UpdateClinicalNoteDto {
   @IsString()
-  @MaxLength(CLINICAL_NOTE_CONTENT_MARKDOWN_MAX_LENGTH)
   contentMarkdown!: string;
 
   @IsOptional()
@@ -40,7 +37,6 @@ export class UpdateClinicalNoteDto {
 export class AddendumClinicalNoteDto {
   @IsOptional()
   @IsString()
-  @MaxLength(CLINICAL_NOTE_CONTENT_MARKDOWN_MAX_LENGTH)
   contentMarkdown?: string;
 }
 

--- a/backend/src/clinical-notes/dto/create-clinical-exam-request.dto.ts
+++ b/backend/src/clinical-notes/dto/create-clinical-exam-request.dto.ts
@@ -1,0 +1,18 @@
+import { IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class CreateClinicalExamRequestDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(500)
+  displayName: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  code?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(32)
+  loincCode?: string;
+}

--- a/backend/src/clinical-notes/dto/create-clinical-prescription-line.dto.ts
+++ b/backend/src/clinical-notes/dto/create-clinical-prescription-line.dto.ts
@@ -1,0 +1,38 @@
+import { IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class CreateClinicalPrescriptionLineDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(500)
+  medicationName: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(128)
+  catalogKey?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(128)
+  dosage?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(128)
+  frequency?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  route?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(128)
+  duration?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  indication?: string;
+}

--- a/backend/src/clinical-notes/patient-clinical-note-orders.controller.ts
+++ b/backend/src/clinical-notes/patient-clinical-note-orders.controller.ts
@@ -1,0 +1,145 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { TenantGuard } from '../auth/guards/tenant.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import type { CurrentUser as CurrentUserType } from '../auth/decorators/current-user.decorator';
+import { ClinicalSubrole, UserRole } from '@generated/prisma/client';
+import { ClinicalNoteOrdersService } from './clinical-note-orders.service';
+import { CreateClinicalExamRequestDto } from './dto/create-clinical-exam-request.dto';
+import { CreateClinicalPrescriptionLineDto } from './dto/create-clinical-prescription-line.dto';
+
+const ORDERS_ROLES = [
+  UserRole.NURSE,
+  UserRole.NURSE_CHIEF,
+  UserRole.DOCTOR,
+  UserRole.ONCOLOGIST,
+  UserRole.COORDINATOR,
+  UserRole.ADMIN,
+] as const;
+
+@Controller(
+  'patients/:patientId/clinical-notes/:clinicalNoteId/clinical-orders'
+)
+@UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
+export class PatientClinicalNoteOrdersController {
+  constructor(private readonly ordersService: ClinicalNoteOrdersService) {}
+
+  private actor(user: CurrentUserType) {
+    return {
+      id: user.id,
+      role: user.role as UserRole,
+      clinicalSubrole: user.clinicalSubrole as ClinicalSubrole | null | undefined,
+    };
+  }
+
+  @Get('exam-requests')
+  @Roles(...ORDERS_ROLES)
+  listExamRequests(
+    @Param('patientId', ParseUUIDPipe) patientId: string,
+    @Param('clinicalNoteId', ParseUUIDPipe) clinicalNoteId: string,
+    @CurrentUser() user: CurrentUserType
+  ) {
+    return this.ordersService.listExamRequests(
+      patientId,
+      clinicalNoteId,
+      user.tenantId
+    );
+  }
+
+  @Post('exam-requests')
+  @Roles(...ORDERS_ROLES)
+  createExamRequest(
+    @Param('patientId', ParseUUIDPipe) patientId: string,
+    @Param('clinicalNoteId', ParseUUIDPipe) clinicalNoteId: string,
+    @Body() dto: CreateClinicalExamRequestDto,
+    @CurrentUser() user: CurrentUserType
+  ) {
+    return this.ordersService.createExamRequest(
+      patientId,
+      clinicalNoteId,
+      user.tenantId,
+      this.actor(user),
+      dto
+    );
+  }
+
+  @Delete('exam-requests/:requestId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @Roles(...ORDERS_ROLES)
+  deleteExamRequest(
+    @Param('patientId', ParseUUIDPipe) patientId: string,
+    @Param('clinicalNoteId', ParseUUIDPipe) clinicalNoteId: string,
+    @Param('requestId', ParseUUIDPipe) requestId: string,
+    @CurrentUser() user: CurrentUserType
+  ) {
+    return this.ordersService.deleteExamRequest(
+      patientId,
+      clinicalNoteId,
+      requestId,
+      user.tenantId,
+      this.actor(user)
+    );
+  }
+
+  @Get('prescription-lines')
+  @Roles(...ORDERS_ROLES)
+  listPrescriptionLines(
+    @Param('patientId', ParseUUIDPipe) patientId: string,
+    @Param('clinicalNoteId', ParseUUIDPipe) clinicalNoteId: string,
+    @CurrentUser() user: CurrentUserType
+  ) {
+    return this.ordersService.listPrescriptionLines(
+      patientId,
+      clinicalNoteId,
+      user.tenantId
+    );
+  }
+
+  @Post('prescription-lines')
+  @Roles(...ORDERS_ROLES)
+  createPrescriptionLine(
+    @Param('patientId', ParseUUIDPipe) patientId: string,
+    @Param('clinicalNoteId', ParseUUIDPipe) clinicalNoteId: string,
+    @Body() dto: CreateClinicalPrescriptionLineDto,
+    @CurrentUser() user: CurrentUserType
+  ) {
+    return this.ordersService.createPrescriptionLine(
+      patientId,
+      clinicalNoteId,
+      user.tenantId,
+      this.actor(user),
+      dto
+    );
+  }
+
+  @Delete('prescription-lines/:lineId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @Roles(...ORDERS_ROLES)
+  deletePrescriptionLine(
+    @Param('patientId', ParseUUIDPipe) patientId: string,
+    @Param('clinicalNoteId', ParseUUIDPipe) clinicalNoteId: string,
+    @Param('lineId', ParseUUIDPipe) lineId: string,
+    @CurrentUser() user: CurrentUserType
+  ) {
+    return this.ordersService.deletePrescriptionLine(
+      patientId,
+      clinicalNoteId,
+      lineId,
+      user.tenantId,
+      this.actor(user)
+    );
+  }
+}

--- a/frontend/src/components/patients/clinical-note-orders-panel.tsx
+++ b/frontend/src/components/patients/clinical-note-orders-panel.tsx
@@ -1,0 +1,510 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  clinicalNoteOrdersApi,
+  type ClinicalExamRequestRow,
+  type ClinicalPrescriptionLineRow,
+} from '@/lib/api/clinical-note-orders';
+import type { ClinicalNoteType } from '@/lib/api/clinical-notes';
+import { toast } from 'sonner';
+import { useState } from 'react';
+
+const qk = ['clinical-note-orders'] as const;
+
+function formatVersionHint(row: {
+  clinicalNoteVersionNumber: number;
+}): string {
+  return `v${row.clinicalNoteVersionNumber}`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}
+
+function openPrintHtml(args: { title: string; htmlBody: string }) {
+  const w = window.open('', '_blank', 'noopener,noreferrer');
+  if (!w) {
+    toast.error('Não foi possível abrir a janela de impressão.');
+    return;
+  }
+  w.document.open();
+  w.document.write(`<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${escapeHtml(args.title)}</title>
+    <style>
+      body { font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; color: #111827; padding: 24px; }
+      h1 { font-size: 16px; margin: 0 0 12px; }
+      h2 { font-size: 14px; margin: 16px 0 8px; }
+      .muted { color: #6b7280; font-size: 12px; }
+      .box { border: 1px solid #e5e7eb; border-radius: 8px; padding: 12px; }
+      table { width: 100%; border-collapse: collapse; }
+      th, td { border-bottom: 1px solid #e5e7eb; text-align: left; padding: 8px 6px; font-size: 12px; vertical-align: top; }
+      th { font-weight: 600; }
+      .page-break { page-break-before: always; }
+      @media print { body { padding: 0; } .no-print { display: none; } }
+    </style>
+  </head>
+  <body>
+    ${args.htmlBody}
+    <script>
+      window.onload = () => { window.focus(); window.print(); };
+    </script>
+  </body>
+</html>`);
+  w.document.close();
+}
+
+export function ClinicalNoteOrdersPanel(props: {
+  patientId: string;
+  patientName?: string;
+  clinicalNoteId: string;
+  noteType: ClinicalNoteType;
+  noteStatus: 'DRAFT' | 'SIGNED' | 'VOIDED';
+  canManageExamRequests: boolean;
+  canManagePrescriptions: boolean;
+  variant: 'exams' | 'prescription';
+  professionalName?: string;
+}) {
+  const {
+    patientId,
+    patientName,
+    clinicalNoteId,
+    noteType,
+    noteStatus,
+    canManageExamRequests,
+    canManagePrescriptions,
+    variant,
+    professionalName,
+  } = props;
+
+  const queryClient = useQueryClient();
+  const enabled =
+    noteStatus !== 'VOIDED' && Boolean(patientId && clinicalNoteId);
+
+  const examsQuery = useQuery({
+    queryKey: [...qk, 'exams', patientId, clinicalNoteId],
+    queryFn: () =>
+      clinicalNoteOrdersApi.listExamRequests(patientId, clinicalNoteId),
+    enabled,
+  });
+
+  const rxQuery = useQuery({
+    queryKey: [...qk, 'rx', patientId, clinicalNoteId],
+    queryFn: () =>
+      clinicalNoteOrdersApi.listPrescriptionLines(patientId, clinicalNoteId),
+    enabled: enabled && noteType === 'MEDICAL',
+  });
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({
+      queryKey: [...qk, 'exams', patientId, clinicalNoteId],
+    });
+    void queryClient.invalidateQueries({
+      queryKey: [...qk, 'rx', patientId, clinicalNoteId],
+    });
+  };
+
+  const [examName, setExamName] = useState('');
+  const addExam = useMutation({
+    mutationFn: () =>
+      clinicalNoteOrdersApi.createExamRequest(patientId, clinicalNoteId, {
+        displayName: examName.trim(),
+      }),
+    onSuccess: () => {
+      setExamName('');
+      invalidate();
+      toast.success('Pedido de exame registrado.');
+    },
+    onError: (e: unknown) => {
+      const msg =
+        e && typeof e === 'object' && 'message' in e
+          ? String((e as { message?: string }).message)
+          : 'Não foi possível registrar o pedido.';
+      toast.error(msg);
+    },
+  });
+
+  const delExam = useMutation({
+    mutationFn: (id: string) =>
+      clinicalNoteOrdersApi.deleteExamRequest(
+        patientId,
+        clinicalNoteId,
+        id
+      ),
+    onSuccess: () => {
+      invalidate();
+      toast.success('Pedido removido.');
+    },
+    onError: () => toast.error('Não foi possível remover o pedido.'),
+  });
+
+  const [medName, setMedName] = useState('');
+  const [medDose, setMedDose] = useState('');
+  const [medFreq, setMedFreq] = useState('');
+  const [medRoute, setMedRoute] = useState('');
+
+  const addRx = useMutation({
+    mutationFn: () =>
+      clinicalNoteOrdersApi.createPrescriptionLine(
+        patientId,
+        clinicalNoteId,
+        {
+          medicationName: medName.trim(),
+          dosage: medDose.trim() || undefined,
+          frequency: medFreq.trim() || undefined,
+          route: medRoute.trim() || undefined,
+        }
+      ),
+    onSuccess: () => {
+      setMedName('');
+      setMedDose('');
+      setMedFreq('');
+      setMedRoute('');
+      invalidate();
+      toast.success('Medicamento adicionado à prescrição.');
+    },
+    onError: (e: unknown) => {
+      const msg =
+        e && typeof e === 'object' && 'message' in e
+          ? String((e as { message?: string }).message)
+          : 'Não foi possível registrar o medicamento.';
+      toast.error(msg);
+    },
+  });
+
+  const delRx = useMutation({
+    mutationFn: (id: string) =>
+      clinicalNoteOrdersApi.deletePrescriptionLine(
+        patientId,
+        clinicalNoteId,
+        id
+      ),
+    onSuccess: () => {
+      invalidate();
+      toast.success('Item removido da prescrição.');
+    },
+    onError: () => toast.error('Não foi possível remover o item.'),
+  });
+
+  const draftLocked = noteStatus !== 'DRAFT';
+  const canEditExams = !draftLocked && canManageExamRequests;
+  const canEditRx = !draftLocked && canManagePrescriptions;
+
+  const safePatientName = patientName?.trim() ? patientName.trim() : 'Paciente';
+  const safeProfessionalName =
+    professionalName?.trim() ? professionalName.trim() : '—';
+
+  const handlePrintExamRequests = () => {
+    const rows = (examsQuery.data as ClinicalExamRequestRow[] | undefined) ?? [];
+    const items = rows
+      .map(
+        (r) =>
+          `<tr>
+            <td>${escapeHtml(r.displayName)}</td>
+            <td class="muted">${escapeHtml(r.code ?? '—')}</td>
+            <td class="muted">${escapeHtml(formatVersionHint(r))}</td>
+          </tr>`
+      )
+      .join('');
+    openPrintHtml({
+      title: `Solicitação de exames — ${safePatientName}`,
+      htmlBody: `
+        <h1>Solicitação de exames</h1>
+        <div class="muted">Paciente: ${escapeHtml(safePatientName)} · Profissional: ${escapeHtml(safeProfessionalName)}</div>
+        <div class="box" style="margin-top: 12px;">
+          <table>
+            <thead>
+              <tr><th>Exame</th><th>Código</th><th>Versão</th></tr>
+            </thead>
+            <tbody>
+              ${items || `<tr><td colspan="3" class="muted">Sem exames solicitados.</td></tr>`}
+            </tbody>
+          </table>
+        </div>
+      `,
+    });
+  };
+
+  const [rxCopiesRaw, setRxCopiesRaw] = useState('2');
+  const rxCopies = Math.min(
+    Math.max(parseInt(rxCopiesRaw || '1', 10) || 1, 1),
+    10
+  );
+  const handlePrintPrescription = () => {
+    const rows =
+      (rxQuery.data as ClinicalPrescriptionLineRow[] | undefined) ?? [];
+    const tableRows = rows
+      .map((r) => {
+        const sig = [r.dosage, r.frequency, r.route].filter(Boolean).join(' · ');
+        return `<tr>
+          <td>${escapeHtml(r.medicationName)}</td>
+          <td class="muted">${escapeHtml(sig || '—')}</td>
+          <td class="muted">${escapeHtml(formatVersionHint(r))}</td>
+        </tr>`;
+      })
+      .join('');
+
+    const single = `
+      <h1>Receita</h1>
+      <div class="muted">Paciente: ${escapeHtml(safePatientName)} · Profissional: ${escapeHtml(safeProfessionalName)}</div>
+      <div class="box" style="margin-top: 12px;">
+        <table>
+          <thead><tr><th>Medicamento</th><th>Posologia</th><th>Versão</th></tr></thead>
+          <tbody>
+            ${tableRows || `<tr><td colspan="3" class="muted">Sem itens prescritos.</td></tr>`}
+          </tbody>
+        </table>
+      </div>
+    `;
+
+    const copiesHtml = Array.from({ length: rxCopies })
+      .map((_, idx) =>
+        idx === 0 ? single : `<div class="page-break"></div>${single}`
+      )
+      .join('');
+
+    openPrintHtml({
+      title: `Receita — ${safePatientName}`,
+      htmlBody: copiesHtml,
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      {variant === 'exams' && (
+        <section
+          className="space-y-2 rounded-md border p-3"
+          aria-label="Pedidos de exame na evolução"
+        >
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h4 className="text-sm font-medium">Solicitações de exames</h4>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={handlePrintExamRequests}
+              disabled={!enabled}
+            >
+              Imprimir solicitação
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {draftLocked
+              ? 'Visível após assinatura; não editável.'
+              : 'Inclua/remova pedidos antes de assinar.'}
+          </p>
+        {examsQuery.isLoading && (
+          <p className="text-xs text-muted-foreground">Carregando…</p>
+        )}
+        {examsQuery.isError && (
+          <p className="text-xs text-destructive" role="alert">
+            Falha ao carregar pedidos.
+          </p>
+        )}
+        <ul className="space-y-2 text-sm">
+          {(examsQuery.data as ClinicalExamRequestRow[] | undefined)?.map(
+            (r) => (
+              <li
+                key={r.id}
+                className="flex flex-wrap gap-2 items-start justify-between border-b border-border/60 pb-2 last:border-0"
+              >
+                <div>
+                  <span className="font-medium">{r.displayName}</span>
+                  <span className="text-xs text-muted-foreground ml-2">
+                    ({formatVersionHint(r)})
+                  </span>
+                  {r.code && (
+                    <span className="text-xs text-muted-foreground block">
+                      Código: {r.code}
+                    </span>
+                  )}
+                </div>
+                {canEditExams && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="shrink-0 text-destructive"
+                    disabled={delExam.isPending}
+                    onClick={() => delExam.mutate(r.id)}
+                  >
+                    Remover
+                  </Button>
+                )}
+              </li>
+            )
+          )}
+        </ul>
+        {canEditExams && (
+          <div className="flex flex-col sm:flex-row gap-2 items-end pt-2">
+            <div className="flex-1 w-full space-y-1">
+              <Label htmlFor="exam-request-name">Nome do exame</Label>
+              <Input
+                id="exam-request-name"
+                value={examName}
+                onChange={(e) => setExamName(e.target.value)}
+                placeholder="Ex.: Hemograma completo"
+                autoComplete="off"
+              />
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              disabled={addExam.isPending || !examName.trim()}
+              onClick={() => addExam.mutate()}
+            >
+              Adicionar
+            </Button>
+          </div>
+        )}
+        </section>
+      )}
+
+      {variant === 'prescription' && noteType === 'MEDICAL' && (
+        <section
+          className="space-y-2 rounded-md border p-3"
+          aria-label="Linhas de prescrição na evolução"
+        >
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h4 className="text-sm font-medium">Receita (linhas)</h4>
+            <div className="flex flex-wrap gap-2 items-end">
+              <div className="space-y-1">
+                <Label htmlFor="rx-copies">Nº de vias</Label>
+                <Input
+                  id="rx-copies"
+                  inputMode="numeric"
+                  value={rxCopiesRaw}
+                  onChange={(e) => setRxCopiesRaw(e.target.value)}
+                  className="w-20"
+                  autoComplete="off"
+                />
+              </div>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={handlePrintPrescription}
+                disabled={!enabled}
+              >
+                Imprimir receita
+              </Button>
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {draftLocked
+              ? 'Visível após assinatura; não editável.'
+              : 'Inclua/remova itens antes de assinar.'}
+          </p>
+          {rxQuery.isLoading && (
+            <p className="text-xs text-muted-foreground">Carregando…</p>
+          )}
+          {rxQuery.isError && (
+            <p className="text-xs text-destructive" role="alert">
+              Falha ao carregar prescrição.
+            </p>
+          )}
+          <ul className="space-y-2 text-sm">
+            {(rxQuery.data as ClinicalPrescriptionLineRow[] | undefined)?.map(
+              (r) => (
+                <li
+                  key={r.id}
+                  className="flex flex-wrap gap-2 items-start justify-between border-b border-border/60 pb-2 last:border-0"
+                >
+                  <div>
+                    <span className="font-medium">{r.medicationName}</span>
+                    <span className="text-xs text-muted-foreground ml-2">
+                      ({formatVersionHint(r)})
+                    </span>
+                    <span className="text-xs text-muted-foreground block">
+                      {[r.dosage, r.frequency, r.route]
+                        .filter(Boolean)
+                        .join(' · ') || '—'}
+                    </span>
+                  </div>
+                  {canEditRx && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="shrink-0 text-destructive"
+                      disabled={delRx.isPending}
+                      onClick={() => delRx.mutate(r.id)}
+                    >
+                      Remover
+                    </Button>
+                  )}
+                </li>
+              )
+            )}
+          </ul>
+          {canEditRx && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 pt-2">
+              <div className="space-y-1 sm:col-span-2">
+                <Label htmlFor="rx-med-name">Medicamento</Label>
+                <Input
+                  id="rx-med-name"
+                  value={medName}
+                  onChange={(e) => setMedName(e.target.value)}
+                  placeholder="Nome ou apresentação"
+                  autoComplete="off"
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="rx-dose">Dose</Label>
+                <Input
+                  id="rx-dose"
+                  value={medDose}
+                  onChange={(e) => setMedDose(e.target.value)}
+                  placeholder="Ex.: 50 mg"
+                  autoComplete="off"
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="rx-freq">Frequência</Label>
+                <Input
+                  id="rx-freq"
+                  value={medFreq}
+                  onChange={(e) => setMedFreq(e.target.value)}
+                  placeholder="Ex.: 12/12 h"
+                  autoComplete="off"
+                />
+              </div>
+              <div className="space-y-1 sm:col-span-2">
+                <Label htmlFor="rx-route">Via</Label>
+                <Input
+                  id="rx-route"
+                  value={medRoute}
+                  onChange={(e) => setMedRoute(e.target.value)}
+                  placeholder="Ex.: VO, IV"
+                  autoComplete="off"
+                />
+              </div>
+              <div className="sm:col-span-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  disabled={addRx.isPending || !medName.trim()}
+                  onClick={() => addRx.mutate()}
+                >
+                  Adicionar à prescrição
+                </Button>
+              </div>
+            </div>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/patients/patient-prontuario-tab.tsx
+++ b/frontend/src/components/patients/patient-prontuario-tab.tsx
@@ -23,7 +23,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
+import { AutoResizeTextarea } from '@/components/ui/auto-resize-textarea';
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -38,6 +38,8 @@ import { ApiClientError } from '@/lib/api/client';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { useAuthStore } from '@/stores/auth-store';
+import { ClinicalNoteOrdersPanel } from '@/components/patients/clinical-note-orders-panel';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   canCreateClinicalNoteType,
   canEditDraftClinicalNote,
@@ -639,31 +641,89 @@ export function PatientProntuarioTab({
                 </div>
               </div>
 
-              <div className="space-y-2">
-                <Label htmlFor="clinical-note-markdown">
-                  {isDraftEditable
-                    ? 'Evolução clínica (Markdown)'
-                    : 'Evolução clínica'}
-                </Label>
-                {isDraftEditable ? (
-                  <Textarea
-                    id="clinical-note-markdown"
-                    value={draftMarkdown}
-                    onChange={(e) => setDraftMarkdown(e.target.value)}
-                    rows={18}
-                    className="font-mono text-sm min-h-[12rem]"
-                    spellCheck
-                  />
-                ) : (
-                  <div
-                    className="rounded-md border bg-muted/30 p-4 max-h-[32rem] overflow-y-auto"
-                    role="region"
-                    aria-label="Conteúdo da evolução"
-                  >
-                    <ClinicalNoteMarkdownBody markdown={draftMarkdown} />
+              <Tabs defaultValue="evolution" className="[overflow-anchor:none]">
+                <TabsList className="w-full justify-start">
+                  <TabsTrigger value="evolution">Evolução</TabsTrigger>
+                  <TabsTrigger value="exams">Exames</TabsTrigger>
+                  {detail.noteType === 'MEDICAL' && (
+                    <TabsTrigger value="prescription">Receita</TabsTrigger>
+                  )}
+                </TabsList>
+
+                <TabsContent value="evolution">
+                  <div className="space-y-2">
+                    <Label htmlFor="clinical-note-markdown">
+                      {isDraftEditable
+                        ? 'Evolução clínica (Markdown)'
+                        : 'Evolução clínica'}
+                    </Label>
+                    {isDraftEditable ? (
+                      <AutoResizeTextarea
+                        id="clinical-note-markdown"
+                        value={draftMarkdown}
+                        onChange={(e) => setDraftMarkdown(e.target.value)}
+                        minRows={10}
+                        className="font-mono text-sm pb-12 md:pb-16"
+                        spellCheck
+                      />
+                    ) : (
+                      <div
+                        className="rounded-md border bg-muted/30 p-4 pb-12 md:pb-16 max-h-[32rem] overflow-y-auto"
+                        role="region"
+                        aria-label="Conteúdo da evolução"
+                      >
+                        <ClinicalNoteMarkdownBody markdown={draftMarkdown} />
+                      </div>
+                    )}
                   </div>
-                )}
-              </div>
+                </TabsContent>
+
+                <TabsContent value="exams">
+                  <ClinicalNoteOrdersPanel
+                    variant="exams"
+                    patientId={patient.id}
+                    patientName={patient.name}
+                    clinicalNoteId={detail.id}
+                    noteType={detail.noteType}
+                    noteStatus={detail.status}
+                    professionalName={
+                      detail.signedBy?.name?.trim() ||
+                      detail.createdBy?.name?.trim() ||
+                      undefined
+                    }
+                    canManageExamRequests={canCreateClinicalNoteType(
+                      role,
+                      clinicalSubrole,
+                      detail.noteType
+                    )}
+                    canManagePrescriptions={false}
+                  />
+                </TabsContent>
+
+                <TabsContent value="prescription">
+                  {detail.noteType === 'MEDICAL' && (
+                    <ClinicalNoteOrdersPanel
+                      variant="prescription"
+                      patientId={patient.id}
+                      patientName={patient.name}
+                      clinicalNoteId={detail.id}
+                      noteType={detail.noteType}
+                      noteStatus={detail.status}
+                      professionalName={
+                        detail.signedBy?.name?.trim() ||
+                        detail.createdBy?.name?.trim() ||
+                        undefined
+                      }
+                      canManageExamRequests={false}
+                      canManagePrescriptions={canCreateClinicalNoteType(
+                        role,
+                        clinicalSubrole,
+                        'MEDICAL'
+                      )}
+                    />
+                  )}
+                </TabsContent>
+              </Tabs>
 
               {detail.status === 'VOIDED' && detail.voidReason && (
                 <p className="text-sm text-destructive">
@@ -736,11 +796,11 @@ export function PatientProntuarioTab({
               Informe o motivo da anulação (registro de auditoria).
             </AlertDialogDescription>
           </AlertDialogHeader>
-          <Textarea
+          <AutoResizeTextarea
             value={voidReason}
             onChange={(e) => setVoidReason(e.target.value)}
             placeholder="Motivo"
-            rows={3}
+            minRows={3}
           />
           <AlertDialogFooter>
             <AlertDialogCancel disabled={voidNote.isPending}>

--- a/frontend/src/hooks/use-clinical-notes.ts
+++ b/frontend/src/hooks/use-clinical-notes.ts
@@ -92,7 +92,10 @@ export function useClinicalNoteMutations(patientId: string) {
   });
 
   const addendum = useMutation({
-    mutationFn: (args: { parentId: string; contentMarkdown?: string }) =>
+    mutationFn: (args: {
+      parentId: string;
+      contentMarkdown?: string;
+    }) =>
       clinicalNotesApi.addendum(args.parentId, {
         contentMarkdown: args.contentMarkdown,
       }),

--- a/frontend/src/lib/api/clinical-note-orders.ts
+++ b/frontend/src/lib/api/clinical-note-orders.ts
@@ -1,0 +1,97 @@
+import { apiClient } from './client';
+
+export type ClinicalExamRequestRow = {
+  id: string;
+  clinicalNoteVersionNumber: number;
+  displayName: string;
+  code: string | null;
+  loincCode: string | null;
+  requestedBy: { id: string; name: string };
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ClinicalPrescriptionLineRow = {
+  id: string;
+  clinicalNoteVersionNumber: number;
+  medicationName: string;
+  catalogKey: string | null;
+  dosage: string | null;
+  frequency: string | null;
+  route: string | null;
+  duration: string | null;
+  indication: string | null;
+  prescribedBy: { id: string; name: string };
+  createdAt: string;
+  updatedAt: string;
+};
+
+export const clinicalNoteOrdersApi = {
+  listExamRequests(
+    patientId: string,
+    clinicalNoteId: string
+  ): Promise<ClinicalExamRequestRow[]> {
+    return apiClient.get<ClinicalExamRequestRow[]>(
+      `/patients/${patientId}/clinical-notes/${clinicalNoteId}/clinical-orders/exam-requests`
+    );
+  },
+
+  createExamRequest(
+    patientId: string,
+    clinicalNoteId: string,
+    body: { displayName: string; code?: string; loincCode?: string }
+  ): Promise<ClinicalExamRequestRow> {
+    return apiClient.post<ClinicalExamRequestRow>(
+      `/patients/${patientId}/clinical-notes/${clinicalNoteId}/clinical-orders/exam-requests`,
+      body
+    );
+  },
+
+  deleteExamRequest(
+    patientId: string,
+    clinicalNoteId: string,
+    requestId: string
+  ): Promise<void> {
+    return apiClient.delete(
+      `/patients/${patientId}/clinical-notes/${clinicalNoteId}/clinical-orders/exam-requests/${requestId}`
+    );
+  },
+
+  listPrescriptionLines(
+    patientId: string,
+    clinicalNoteId: string
+  ): Promise<ClinicalPrescriptionLineRow[]> {
+    return apiClient.get<ClinicalPrescriptionLineRow[]>(
+      `/patients/${patientId}/clinical-notes/${clinicalNoteId}/clinical-orders/prescription-lines`
+    );
+  },
+
+  createPrescriptionLine(
+    patientId: string,
+    clinicalNoteId: string,
+    body: {
+      medicationName: string;
+      catalogKey?: string;
+      dosage?: string;
+      frequency?: string;
+      route?: string;
+      duration?: string;
+      indication?: string;
+    }
+  ): Promise<ClinicalPrescriptionLineRow> {
+    return apiClient.post<ClinicalPrescriptionLineRow>(
+      `/patients/${patientId}/clinical-notes/${clinicalNoteId}/clinical-orders/prescription-lines`,
+      body
+    );
+  },
+
+  deletePrescriptionLine(
+    patientId: string,
+    clinicalNoteId: string,
+    lineId: string
+  ): Promise<void> {
+    return apiClient.delete(
+      `/patients/${patientId}/clinical-notes/${clinicalNoteId}/clinical-orders/prescription-lines/${lineId}`
+    );
+  },
+};


### PR DESCRIPTION
## O quê
- Prisma: adiciona modelos e migration para pedidos vinculados à evolução clínica
- Backend: endpoints/serviços/DTOs para criar e listar pedidos (exames e prescrição)
- Frontend: painel no prontuário + client API para integrar com backend

## Por quê
- Estruturar pedidos derivados da evolução clínica e permitir acompanhamento no prontuário.

## Como testar
- [ ] Subir infra + aplicar migration
- [ ] Backend: criar evolução e adicionar pedidos (exame/receita)
- [ ] Frontend: validar exibição/edição no prontuário

## Checklist
- [ ] Migration aplicada e revertível
- [ ] Sem exposição indevida de dados sensíveis

Made with [Cursor](https://cursor.com)