### PR TITLE
fix(agenda): buscar por data agendada (expectedDate)

### DIFF
--- a/backend/src/oncology-navigation/oncology-navigation.service.spec.ts
+++ b/backend/src/oncology-navigation/oncology-navigation.service.spec.ts
@@ -919,9 +919,44 @@ describe('OncologyNavigationService', () => {
             stepKey: {
               in: ['specialist_consultation', 'navigation_consultation'],
             },
+            AND: expect.arrayContaining([
+              { expectedDate: { not: null } },
+              {
+                expectedDate: expect.objectContaining({
+                  gte: expect.any(Date),
+                  lte: expect.any(Date),
+                }),
+              },
+            ]),
           }),
         })
       );
+    });
+
+    it('filtra agenda somente por expectedDate (não considera dueDate para inclusão)', async () => {
+      mockPrisma.$transaction.mockResolvedValue([0, []]);
+
+      await service.getConsultationAgenda(TENANT, {
+        from: '2026-05-01',
+        to: '2026-05-31',
+      });
+
+      const countArg = mockPrisma.navigationStep.count.mock.calls[0][0];
+      expect(countArg.where).toEqual(
+        expect.objectContaining({
+          tenantId: TENANT,
+          AND: expect.arrayContaining([
+            { expectedDate: { not: null } },
+            {
+              expectedDate: expect.objectContaining({
+                gte: expect.any(Date),
+                lte: expect.any(Date),
+              }),
+            },
+          ]),
+        })
+      );
+      expect(JSON.stringify(countArg.where)).not.toContain('dueDate');
     });
 
     it('omits stepKey filter when scope is all', async () => {

--- a/backend/src/oncology-navigation/oncology-navigation.service.ts
+++ b/backend/src/oncology-navigation/oncology-navigation.service.ts
@@ -162,28 +162,15 @@ export class OncologyNavigationService {
         ? { stepKey: { in: [...CONSULTATION_STEP_KEYS] } }
         : {};
 
-    const dateOverlap: Prisma.NavigationStepWhereInput = {
-      OR: [
-        {
-          AND: [
-            { expectedDate: { not: null } },
-            { expectedDate: { gte: fromStart, lte: toEnd } },
-          ],
-        },
-        {
-          AND: [
-            { dueDate: { not: null } },
-            { dueDate: { gte: fromStart, lte: toEnd } },
-          ],
-        },
-        {
-          AND: [
-            { expectedDate: { not: null } },
-            { dueDate: { not: null } },
-            { expectedDate: { lte: toEnd } },
-            { dueDate: { gte: fromStart } },
-          ],
-        },
+    /**
+     * Agenda deve ser filtrada por data agendada (expectedDate).
+     * dueDate ("Limite") permanece no payload para exibição/monitoramento,
+     * mas não determina inclusão no intervalo da agenda.
+     */
+    const dateFilter: Prisma.NavigationStepWhereInput = {
+      AND: [
+        { expectedDate: { not: null } },
+        { expectedDate: { gte: fromStart, lte: toEnd } },
       ],
     };
 
@@ -191,7 +178,7 @@ export class OncologyNavigationService {
       tenantId,
       status: { not: NavigationStepStatus.CANCELLED },
       ...stepKeyFilter,
-      ...dateOverlap,
+      ...dateFilter,
     };
 
     const [total, rows] = await this.prisma.$transaction([
@@ -218,7 +205,7 @@ export class OncologyNavigationService {
     ]);
 
     const items: ConsultationAgendaItem[] = rows.map((row) => {
-      const agendaDate = row.expectedDate ?? row.dueDate ?? fromStart;
+      const agendaDate = row.expectedDate ?? fromStart;
       return {
         id: row.id,
         patientId: row.patientId,

--- a/frontend/src/app/oncology-navigation/agenda/page.tsx
+++ b/frontend/src/app/oncology-navigation/agenda/page.tsx
@@ -85,8 +85,7 @@ export default function ConsultationAgendaPage() {
               Agenda
             </h1>
             <p className="mt-1 text-sm text-muted-foreground">
-              Etapas de consulta com data prevista ou limite no período
-              selecionado.
+              Etapas de consulta com data agendada no período selecionado.
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
@@ -155,7 +154,7 @@ export default function ConsultationAgendaPage() {
               <EmptyState
                 icon={<CalendarDays className="h-12 w-12" aria-hidden />}
                 title="Nenhum item no período"
-                description="Ajuste as datas, o escopo ou verifique se as etapas têm data prevista ou limite preenchidos."
+                description="Ajuste as datas, o escopo ou verifique se as etapas têm data agendada preenchida."
               />
             </CardContent>
           </Card>

--- a/frontend/src/components/oncology-navigation/consultation-agenda-item-card.tsx
+++ b/frontend/src/components/oncology-navigation/consultation-agenda-item-card.tsx
@@ -43,7 +43,7 @@ export function ConsultationAgendaItemCard({ item }: ConsultationAgendaItemCardP
           </p>
           <dl className="grid grid-cols-1 gap-1 text-xs text-muted-foreground sm:grid-cols-3">
             <div>
-              <dt className="inline font-medium text-foreground">Prevista: </dt>
+              <dt className="inline font-medium text-foreground">Agendada: </dt>
               <dd className="inline">{formatShortAgendaDate(item.expectedDate)}</dd>
             </div>
             <div>


### PR DESCRIPTION
## Summary
- Renomeia o termo para **Agendada** na UI.
- Agenda passa a filtrar as etapas por **expectedDate** (data agendada).
- Testes atualizados para refletir o filtro por expectedDate.

## Test plan
- [ ] Rodar o spec do backend (Jest): `cd backend && npm test -- oncology-navigation.service.spec`
- [ ] Verificar a UI na página **Agenda** e confirmar que os itens aparecem conforme **expectedDate**

Made with [Cursor](https://cursor.com)