### PR TITLE
feat: emitir e imprimir guia TISS SP/SADT

### DIFF
--- a/backend/prisma/migrations/20260508174659_add_tiss_spsadt_guides/migration.sql
+++ b/backend/prisma/migrations/20260508174659_add_tiss_spsadt_guides/migration.sql
@@ -1,0 +1,83 @@
+-- AlterTable
+ALTER TABLE "clinical_exam_requests" ADD COLUMN     "examCatalogCode" TEXT;
+
+-- CreateTable
+CREATE TABLE "tiss_spsadt_guides" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "patientId" TEXT NOT NULL,
+    "clinicalNoteId" TEXT NOT NULL,
+    "guideNumber" TEXT NOT NULL,
+    "operatorName" TEXT NOT NULL,
+    "operatorANSCode" TEXT,
+    "beneficiaryName" TEXT NOT NULL,
+    "beneficiaryCardNumber" TEXT,
+    "requestingProfessionalName" TEXT NOT NULL,
+    "requestingProfessionalCouncil" TEXT,
+    "requestingProfessionalCouncilUf" TEXT,
+    "requestingProfessionalRegistration" TEXT,
+    "requestingFacilityCnes" TEXT,
+    "createdById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "tiss_spsadt_guides_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tiss_spsadt_guide_items" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "guideId" TEXT NOT NULL,
+    "examRequestId" TEXT NOT NULL,
+    "procedureName" TEXT NOT NULL,
+    "procedureCode" TEXT,
+    "quantity" INTEGER NOT NULL DEFAULT 1,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "tiss_spsadt_guide_items_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "tiss_spsadt_guides_tenantId_idx" ON "tiss_spsadt_guides"("tenantId");
+
+-- CreateIndex
+CREATE INDEX "tiss_spsadt_guides_tenantId_patientId_idx" ON "tiss_spsadt_guides"("tenantId", "patientId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tiss_spsadt_guides_tenantId_guideNumber_key" ON "tiss_spsadt_guides"("tenantId", "guideNumber");
+
+-- CreateIndex
+CREATE INDEX "tiss_spsadt_guide_items_tenantId_idx" ON "tiss_spsadt_guide_items"("tenantId");
+
+-- CreateIndex
+CREATE INDEX "tiss_spsadt_guide_items_guideId_idx" ON "tiss_spsadt_guide_items"("guideId");
+
+-- CreateIndex
+CREATE INDEX "tiss_spsadt_guide_items_examRequestId_idx" ON "tiss_spsadt_guide_items"("examRequestId");
+
+-- CreateIndex
+CREATE INDEX "clinical_exam_requests_examCatalogCode_idx" ON "clinical_exam_requests"("examCatalogCode");
+
+-- AddForeignKey
+ALTER TABLE "tiss_spsadt_guides" ADD CONSTRAINT "tiss_spsadt_guides_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "tenants"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tiss_spsadt_guides" ADD CONSTRAINT "tiss_spsadt_guides_patientId_fkey" FOREIGN KEY ("patientId") REFERENCES "patients"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tiss_spsadt_guides" ADD CONSTRAINT "tiss_spsadt_guides_clinicalNoteId_fkey" FOREIGN KEY ("clinicalNoteId") REFERENCES "clinical_notes"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tiss_spsadt_guides" ADD CONSTRAINT "tiss_spsadt_guides_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tiss_spsadt_guide_items" ADD CONSTRAINT "tiss_spsadt_guide_items_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "tenants"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tiss_spsadt_guide_items" ADD CONSTRAINT "tiss_spsadt_guide_items_guideId_fkey" FOREIGN KEY ("guideId") REFERENCES "tiss_spsadt_guides"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tiss_spsadt_guide_items" ADD CONSTRAINT "tiss_spsadt_guide_items_examRequestId_fkey" FOREIGN KEY ("examRequestId") REFERENCES "clinical_exam_requests"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -37,6 +37,8 @@ model User {
   clinicalExamRequestsRequested ClinicalExamRequest[] @relation("ClinicalExamRequestRequestedBy")
   /// Linhas de prescrição registradas na evolução médica
   clinicalPrescriptionLinesPrescribed ClinicalPrescriptionLine[] @relation("ClinicalPrescriptionLinePrescribedBy")
+  /// Guias TISS SP/SADT emitidas
+  tissSpsadtGuidesCreated TissSpsadtGuide[] @relation("TissSpsadtGuideCreatedBy")
   productFeedbacks             ProductFeedback[]
 
   @@unique([tenantId, email])
@@ -160,6 +162,7 @@ model Patient {
   clinicalExamRequests     ClinicalExamRequest[]
   /// Prescrição na evolução (evento prescritivo; não substitui Medication "em uso")
   clinicalPrescriptionLines ClinicalPrescriptionLine[]
+  tissSpsadtGuides         TissSpsadtGuide[]
   consents                 PatientConsent[] // Termos de Consentimento Livre e Esclarecido (TCLE)
 
   createdAt DateTime @default(now())
@@ -209,6 +212,7 @@ model ClinicalNote {
   versions           ClinicalNoteVersion[]
   clinicalExamRequests      ClinicalExamRequest[]
   clinicalPrescriptionLines ClinicalPrescriptionLine[]
+  tissSpsadtGuides          TissSpsadtGuide[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -233,11 +237,14 @@ model ClinicalExamRequest {
   displayName   String
   code          String?
   loincCode     String?
+  /// Referência opcional ao catálogo global (TUSS) para emissão TISS (SP/SADT).
+  examCatalogCode String?
 
   tenant         Tenant       @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   patient        Patient      @relation(fields: [patientId], references: [id], onDelete: Cascade)
   clinicalNote   ClinicalNote @relation(fields: [clinicalNoteId], references: [id], onDelete: Cascade)
   requestedBy    User         @relation("ClinicalExamRequestRequestedBy", fields: [requestedById], references: [id])
+  tissSpsadtGuideItems TissSpsadtGuideItem[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -246,7 +253,72 @@ model ClinicalExamRequest {
   @@index([patientId])
   @@index([clinicalNoteId])
   @@index([tenantId, clinicalNoteId])
+  @@index([examCatalogCode])
   @@map("clinical_exam_requests")
+}
+
+/// Guia TISS SP/SADT (solicitação) — cabeçalho e numeração por tenant.
+model TissSpsadtGuide {
+  id        String @id @default(uuid())
+  tenantId  String
+  patientId String
+  clinicalNoteId String
+
+  /// Número da guia (sequencial por tenant, string para permitir formatação futura).
+  guideNumber String
+
+  operatorName     String
+  operatorANSCode  String?
+  beneficiaryName  String
+  beneficiaryCardNumber String?
+
+  requestingProfessionalName String
+  requestingProfessionalCouncil String?
+  requestingProfessionalCouncilUf String?
+  requestingProfessionalRegistration String?
+  requestingFacilityCnes String?
+
+  createdById String
+
+  tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  patient Patient @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  clinicalNote ClinicalNote @relation(fields: [clinicalNoteId], references: [id], onDelete: Cascade)
+  createdBy User @relation("TissSpsadtGuideCreatedBy", fields: [createdById], references: [id])
+  items TissSpsadtGuideItem[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([tenantId])
+  @@index([tenantId, patientId])
+  @@unique([tenantId, guideNumber])
+  @@map("tiss_spsadt_guides")
+}
+
+/// Snapshot dos procedimentos (exames) emitidos na guia.
+model TissSpsadtGuideItem {
+  id        String @id @default(uuid())
+  tenantId  String
+  guideId   String
+  examRequestId String
+
+  /// Congela o código e nome emitidos (evita mudança retroativa).
+  procedureName String
+  procedureCode String?
+  quantity Int @default(1)
+  notes String?
+
+  tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  guide TissSpsadtGuide @relation(fields: [guideId], references: [id], onDelete: Cascade)
+  examRequest ClinicalExamRequest @relation(fields: [examRequestId], references: [id], onDelete: Restrict)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([tenantId])
+  @@index([guideId])
+  @@index([examRequestId])
+  @@map("tiss_spsadt_guide_items")
 }
 
 /// Linha de medicamento prescrita no contexto da evolução médica — não atualiza automaticamente `Medication` (em uso / ML)
@@ -1579,6 +1651,8 @@ model Tenant {
   clinicalNoteVersions     ClinicalNoteVersion[]
   clinicalExamRequests     ClinicalExamRequest[]
   clinicalPrescriptionLines ClinicalPrescriptionLine[]
+  tissSpsadtGuides         TissSpsadtGuide[]
+  tissSpsadtGuideItems     TissSpsadtGuideItem[]
   patientConsents          PatientConsent[]
   productFeedbacks         ProductFeedback[]
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -38,6 +38,7 @@ import { ConsentModule } from './consent/consent.module';
 import { ProductFeedbackModule } from './product-feedback/product-feedback.module';
 import { JwtAuthGuard } from './auth/guards/jwt-auth.guard';
 import { ThrottleGuard } from './common/guards/throttle.guard';
+import { TissGuidesModule } from './tiss-guides/tiss-guides.module';
 
 @Module({
   imports: [
@@ -76,6 +77,7 @@ import { ThrottleGuard } from './common/guards/throttle.guard';
     EmergencyReferencesModule,
     DispositionFeedbackModule,
     ClinicalNotesModule,
+    TissGuidesModule,
     ConsentModule,
     ProductFeedbackModule,
   ],

--- a/backend/src/clinical-notes/clinical-note-orders.service.spec.ts
+++ b/backend/src/clinical-notes/clinical-note-orders.service.spec.ts
@@ -77,7 +77,7 @@ describe('ClinicalNoteOrdersService', () => {
       });
     });
 
-    it('throws when note not in draft', async () => {
+    it('allows when note is signed', async () => {
       mockPrisma.clinicalNote.findFirst.mockResolvedValue({
         id: 'note-1',
         status: ClinicalNoteStatus.SIGNED,
@@ -85,15 +85,26 @@ describe('ClinicalNoteOrdersService', () => {
         patientId: 'pat-1',
       });
 
+      mockPrisma.clinicalNoteVersion.findFirst.mockResolvedValue({
+        versionNumber: 2,
+      });
+      mockClinicalNotes.canCreateOrSignNoteType.mockReturnValue(true);
+      mockPrisma.clinicalExamRequest.create.mockResolvedValue({
+        id: 'ex-1',
+        clinicalNoteVersionNumber: 2,
+        displayName: 'Hemograma',
+        code: null,
+        loincCode: null,
+        requestedBy: { id: actor.id, name: 'Dra.' },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
       await expect(
-        service.createExamRequest(
-          'pat-1',
-          'note-1',
-          'tenant-1',
-          actor,
-          { displayName: 'X' }
-        )
-      ).rejects.toThrow(BadRequestException);
+        service.createExamRequest('pat-1', 'note-1', 'tenant-1', actor, {
+          displayName: 'Hemograma',
+        })
+      ).resolves.toBeTruthy();
     });
   });
 

--- a/backend/src/clinical-notes/clinical-note-orders.service.ts
+++ b/backend/src/clinical-notes/clinical-note-orders.service.ts
@@ -40,11 +40,6 @@ export class ClinicalNoteOrdersService {
     if (note.status === ClinicalNoteStatus.VOIDED) {
       throw new BadRequestException('Não é possível alterar pedidos em evolução anulada');
     }
-    if (note.status !== ClinicalNoteStatus.DRAFT) {
-      throw new BadRequestException(
-        'Pedidos só podem ser incluídos ou removidos enquanto a evolução estiver em rascunho'
-      );
-    }
     return note;
   }
 
@@ -99,6 +94,7 @@ export class ClinicalNoteOrdersService {
         displayName: true,
         code: true,
         loincCode: true,
+        examCatalogCode: true,
         requestedBy: { select: { id: true, name: true } },
         createdAt: true,
         updatedAt: true,
@@ -130,6 +126,7 @@ export class ClinicalNoteOrdersService {
         displayName: dto.displayName.trim(),
         code: dto.code?.trim() || null,
         loincCode: dto.loincCode?.trim() || null,
+        examCatalogCode: dto.examCatalogCode?.trim() || null,
       },
       select: {
         id: true,
@@ -137,6 +134,7 @@ export class ClinicalNoteOrdersService {
         displayName: true,
         code: true,
         loincCode: true,
+        examCatalogCode: true,
         requestedBy: { select: { id: true, name: true } },
         createdAt: true,
         updatedAt: true,

--- a/backend/src/clinical-notes/dto/create-clinical-exam-request.dto.ts
+++ b/backend/src/clinical-notes/dto/create-clinical-exam-request.dto.ts
@@ -15,4 +15,10 @@ export class CreateClinicalExamRequestDto {
   @IsString()
   @MaxLength(32)
   loincCode?: string;
+
+  /** Código do catálogo global TUSS (ExamCatalogItem.code), quando selecionado por catálogo. */
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  examCatalogCode?: string;
 }

--- a/backend/src/tiss-guides/dto/create-tiss-spsadt-guide.dto.ts
+++ b/backend/src/tiss-guides/dto/create-tiss-spsadt-guide.dto.ts
@@ -1,0 +1,54 @@
+import {
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+
+export class CreateTissSpsadtGuideDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(200)
+  operatorName: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(32)
+  operatorANSCode?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  beneficiaryName?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  beneficiaryCardNumber?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  requestingProfessionalName?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(32)
+  requestingProfessionalCouncil?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2)
+  requestingProfessionalCouncilUf?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(32)
+  requestingProfessionalRegistration?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(16)
+  requestingFacilityCnes?: string;
+}
+

--- a/backend/src/tiss-guides/tiss-guides.controller.ts
+++ b/backend/src/tiss-guides/tiss-guides.controller.ts
@@ -1,0 +1,68 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { TenantGuard } from '../auth/guards/tenant.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import type { CurrentUser as CurrentUserType } from '../auth/decorators/current-user.decorator';
+import { ClinicalSubrole, UserRole } from '@generated/prisma/client';
+import { TissGuidesService } from './tiss-guides.service';
+import { CreateTissSpsadtGuideDto } from './dto/create-tiss-spsadt-guide.dto';
+
+const TISS_ROLES = [
+  UserRole.NURSE,
+  UserRole.NURSE_CHIEF,
+  UserRole.DOCTOR,
+  UserRole.ONCOLOGIST,
+  UserRole.COORDINATOR,
+  UserRole.ADMIN,
+] as const;
+
+@Controller()
+@UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
+export class TissGuidesController {
+  constructor(private readonly tissGuidesService: TissGuidesService) {}
+
+  private actor(user: CurrentUserType) {
+    return {
+      id: user.id,
+      role: user.role as UserRole,
+      clinicalSubrole: user.clinicalSubrole as ClinicalSubrole | null | undefined,
+    };
+  }
+
+  @Post('patients/:patientId/clinical-notes/:clinicalNoteId/tiss/sp-sadt')
+  @Roles(...TISS_ROLES)
+  emitSpsadtGuide(
+    @Param('patientId', ParseUUIDPipe) patientId: string,
+    @Param('clinicalNoteId', ParseUUIDPipe) clinicalNoteId: string,
+    @Body() dto: CreateTissSpsadtGuideDto,
+    @CurrentUser() user: CurrentUserType
+  ) {
+    return this.tissGuidesService.emitSpsadtGuide({
+      patientId,
+      clinicalNoteId,
+      tenantId: user.tenantId,
+      actor: this.actor(user),
+      dto,
+    });
+  }
+
+  @Get('tiss/sp-sadt/:guideId')
+  @Roles(...TISS_ROLES)
+  getSpsadtGuide(
+    @Param('guideId', ParseUUIDPipe) guideId: string,
+    @CurrentUser() user: CurrentUserType
+  ) {
+    return this.tissGuidesService.getSpsadtGuide(guideId, user.tenantId);
+  }
+}
+

--- a/backend/src/tiss-guides/tiss-guides.module.ts
+++ b/backend/src/tiss-guides/tiss-guides.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { ClinicalNotesModule } from '../clinical-notes/clinical-notes.module';
+import { TissGuidesController } from './tiss-guides.controller';
+import { TissGuidesService } from './tiss-guides.service';
+
+@Module({
+  imports: [PrismaModule, ClinicalNotesModule],
+  controllers: [TissGuidesController],
+  providers: [TissGuidesService],
+})
+export class TissGuidesModule {}
+

--- a/backend/src/tiss-guides/tiss-guides.service.ts
+++ b/backend/src/tiss-guides/tiss-guides.service.ts
@@ -1,0 +1,250 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma, UserRole } from '@generated/prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { ClinicalNotesService, type ClinicalNoteActor } from '../clinical-notes/clinical-notes.service';
+import { CreateTissSpsadtGuideDto } from './dto/create-tiss-spsadt-guide.dto';
+
+const TISS_ROLES = [
+  UserRole.NURSE,
+  UserRole.NURSE_CHIEF,
+  UserRole.DOCTOR,
+  UserRole.ONCOLOGIST,
+  UserRole.COORDINATOR,
+  UserRole.ADMIN,
+] as const;
+
+@Injectable()
+export class TissGuidesService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly clinicalNotesService: ClinicalNotesService
+  ) {}
+
+  private assertCanEmit(actor: ClinicalNoteActor) {
+    if (!TISS_ROLES.includes(actor.role)) {
+      throw new ForbiddenException('Sem permissão para emitir guia TISS');
+    }
+  }
+
+  private normalizeGuideNumber(n: number): string {
+    // MVP: sequência por tenant. Mantém como string para permitir futura formatação.
+    return String(n);
+  }
+
+  private async nextGuideNumberInTx(
+    tx: Prisma.TransactionClient,
+    tenantId: string
+  ): Promise<string> {
+    const last = await tx.tissSpsadtGuide.findFirst({
+      where: { tenantId },
+      orderBy: { createdAt: 'desc' },
+      select: { guideNumber: true },
+    });
+    const lastN = last?.guideNumber ? Number.parseInt(last.guideNumber, 10) : 0;
+    const next = Number.isFinite(lastN) ? lastN + 1 : 1;
+    return this.normalizeGuideNumber(next);
+  }
+
+  async emitSpsadtGuide(params: {
+    patientId: string;
+    clinicalNoteId: string;
+    tenantId: string;
+    actor: ClinicalNoteActor;
+    dto: CreateTissSpsadtGuideDto;
+  }) {
+    const { patientId, clinicalNoteId, tenantId, actor, dto } = params;
+    this.assertCanEmit(actor);
+
+    const note = await this.prisma.clinicalNote.findFirst({
+      where: { id: clinicalNoteId, tenantId, patientId },
+      select: { id: true, noteType: true },
+    });
+    if (!note) {
+      throw new NotFoundException('Evolução não encontrada para este paciente');
+    }
+    // Mantém a mesma regra de permissão do prontuário por tipo de evolução.
+    if (
+      !this.clinicalNotesService.canCreateOrSignNoteType(
+        actor.role,
+        actor.clinicalSubrole,
+        note.noteType
+      )
+    ) {
+      throw new ForbiddenException('Sem permissão para emitir guia nesta evolução');
+    }
+
+    const patient = await this.prisma.patient.findFirst({
+      where: { id: patientId, tenantId },
+      select: { id: true, name: true },
+    });
+    if (!patient) {
+      throw new NotFoundException('Paciente não encontrado');
+    }
+
+    const examRequests = await this.prisma.clinicalExamRequest.findMany({
+      where: { tenantId, patientId, clinicalNoteId },
+      orderBy: { createdAt: 'asc' },
+      select: {
+        id: true,
+        displayName: true,
+        examCatalogCode: true,
+        code: true,
+        loincCode: true,
+      },
+    });
+    if (examRequests.length === 0) {
+      throw new BadRequestException(
+        'Não há solicitações de exame para emitir guia TISS nesta evolução'
+      );
+    }
+
+    const operatorName = dto.operatorName.trim();
+    const beneficiaryName = (dto.beneficiaryName?.trim() || patient.name).trim();
+    const requestingProfessionalName = dto.requestingProfessionalName?.trim() || '';
+
+    if (!operatorName) {
+      throw new BadRequestException('Operadora é obrigatória');
+    }
+    if (!beneficiaryName) {
+      throw new BadRequestException('Nome do beneficiário é obrigatório');
+    }
+
+    // Se não veio explicitamente do frontend, tenta inferir do usuário do sistema.
+    let resolvedProfessionalName = requestingProfessionalName;
+    if (!resolvedProfessionalName) {
+      const user = await this.prisma.user.findFirst({
+        where: { id: actor.id, tenantId },
+        select: { name: true },
+      });
+      resolvedProfessionalName = user?.name?.trim() || 'Profissional';
+    }
+
+    // Gera sequência com retry em caso de conflito de unique(tenantId, guideNumber).
+    const maxRetries = 5;
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        return await this.prisma.$transaction(async (tx) => {
+          const guideNumber = await this.nextGuideNumberInTx(tx, tenantId);
+
+          const guide = await tx.tissSpsadtGuide.create({
+            data: {
+              tenantId,
+              patientId,
+              clinicalNoteId,
+              guideNumber,
+              operatorName,
+              operatorANSCode: dto.operatorANSCode?.trim() || null,
+              beneficiaryName,
+              beneficiaryCardNumber: dto.beneficiaryCardNumber?.trim() || null,
+              requestingProfessionalName: resolvedProfessionalName,
+              requestingProfessionalCouncil:
+                dto.requestingProfessionalCouncil?.trim() || null,
+              requestingProfessionalCouncilUf:
+                dto.requestingProfessionalCouncilUf?.trim() || null,
+              requestingProfessionalRegistration:
+                dto.requestingProfessionalRegistration?.trim() || null,
+              requestingFacilityCnes: dto.requestingFacilityCnes?.trim() || null,
+              createdById: actor.id,
+            },
+            select: {
+              id: true,
+              guideNumber: true,
+              operatorName: true,
+              operatorANSCode: true,
+              beneficiaryName: true,
+              beneficiaryCardNumber: true,
+              requestingProfessionalName: true,
+              requestingProfessionalCouncil: true,
+              requestingProfessionalCouncilUf: true,
+              requestingProfessionalRegistration: true,
+              requestingFacilityCnes: true,
+              createdAt: true,
+              patient: { select: { id: true, name: true } },
+            },
+          });
+
+          await tx.tissSpsadtGuideItem.createMany({
+            data: examRequests.map((r) => ({
+              tenantId,
+              guideId: guide.id,
+              examRequestId: r.id,
+              procedureName: r.displayName,
+              procedureCode: r.examCatalogCode || r.code || r.loincCode || null,
+              quantity: 1,
+              notes: null,
+            })),
+          });
+
+          const items = await tx.tissSpsadtGuideItem.findMany({
+            where: { tenantId, guideId: guide.id },
+            orderBy: { createdAt: 'asc' },
+            select: {
+              id: true,
+              procedureName: true,
+              procedureCode: true,
+              quantity: true,
+              notes: true,
+              examRequestId: true,
+            },
+          });
+
+          return { ...guide, items };
+        });
+      } catch (e: any) {
+        // Unique constraint conflict: tenta novamente com novo número.
+        const code = e?.code;
+        if (code === 'P2002') {
+          continue;
+        }
+        throw e;
+      }
+    }
+
+    throw new ConflictException(
+      'Não foi possível gerar número de guia TISS (conflito concorrente). Tente novamente.'
+    );
+  }
+
+  async getSpsadtGuide(guideId: string, tenantId: string) {
+    const guide = await this.prisma.tissSpsadtGuide.findFirst({
+      where: { id: guideId, tenantId },
+      select: {
+        id: true,
+        guideNumber: true,
+        operatorName: true,
+        operatorANSCode: true,
+        beneficiaryName: true,
+        beneficiaryCardNumber: true,
+        requestingProfessionalName: true,
+        requestingProfessionalCouncil: true,
+        requestingProfessionalCouncilUf: true,
+        requestingProfessionalRegistration: true,
+        requestingFacilityCnes: true,
+        createdAt: true,
+        patient: { select: { id: true, name: true } },
+        items: {
+          orderBy: { createdAt: 'asc' },
+          select: {
+            id: true,
+            procedureName: true,
+            procedureCode: true,
+            quantity: true,
+            notes: true,
+            examRequestId: true,
+          },
+        },
+      },
+    });
+    if (!guide) {
+      throw new NotFoundException('Guia não encontrada');
+    }
+    return guide;
+  }
+}
+

--- a/backend/src/tiss-guides/tiss-guides.service.ts
+++ b/backend/src/tiss-guides/tiss-guides.service.ts
@@ -5,7 +5,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { Prisma, UserRole } from '@generated/prisma/client';
+import { ClinicalNoteStatus, Prisma, UserRole } from '@generated/prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { ClinicalNotesService, type ClinicalNoteActor } from '../clinical-notes/clinical-notes.service';
 import { CreateTissSpsadtGuideDto } from './dto/create-tiss-spsadt-guide.dto';
@@ -63,10 +63,13 @@ export class TissGuidesService {
 
     const note = await this.prisma.clinicalNote.findFirst({
       where: { id: clinicalNoteId, tenantId, patientId },
-      select: { id: true, noteType: true },
+      select: { id: true, noteType: true, status: true },
     });
     if (!note) {
       throw new NotFoundException('Evolução não encontrada para este paciente');
+    }
+    if (note.status === ClinicalNoteStatus.VOIDED) {
+      throw new BadRequestException('Não é possível emitir guia para evolução anulada');
     }
     // Mantém a mesma regra de permissão do prontuário por tipo de evolução.
     if (

--- a/frontend/src/components/patients/clinical-note-orders-panel.tsx
+++ b/frontend/src/components/patients/clinical-note-orders-panel.tsx
@@ -5,13 +5,25 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from '@/components/ui/dialog';
+import {
   clinicalNoteOrdersApi,
   type ClinicalExamRequestRow,
   type ClinicalPrescriptionLineRow,
 } from '@/lib/api/clinical-note-orders';
+import { tissGuidesApi } from '@/lib/api/tiss-guides';
 import type { ClinicalNoteType } from '@/lib/api/clinical-notes';
 import { toast } from 'sonner';
 import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
 
 const qk = ['clinical-note-orders'] as const;
 
@@ -31,19 +43,14 @@ function escapeHtml(s: string): string {
 }
 
 function openPrintHtml(args: { title: string; htmlBody: string }) {
-  const w = window.open('', '_blank', 'noopener,noreferrer');
-  if (!w) {
-    toast.error('Não foi possível abrir a janela de impressão.');
-    return;
-  }
-  w.document.open();
-  w.document.write(`<!doctype html>
+  const html = `<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>${escapeHtml(args.title)}</title>
     <style>
+      @page { size: A4; margin: 10mm; content: "A4"; }
       body { font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; color: #111827; padding: 24px; }
       h1 { font-size: 16px; margin: 0 0 12px; }
       h2 { font-size: 14px; margin: 16px 0 8px; }
@@ -53,17 +60,59 @@ function openPrintHtml(args: { title: string; htmlBody: string }) {
       th, td { border-bottom: 1px solid #e5e7eb; text-align: left; padding: 8px 6px; font-size: 12px; vertical-align: top; }
       th { font-weight: 600; }
       .page-break { page-break-before: always; }
-      @media print { body { padding: 0; } .no-print { display: none; } }
+      @media print {
+        body { padding: 0; }
+        .no-print { display: none; }
+      }
     </style>
   </head>
   <body>
     ${args.htmlBody}
-    <script>
-      window.onload = () => { window.focus(); window.print(); };
-    </script>
   </body>
-</html>`);
-  w.document.close();
+</html>`;
+
+  // Imprime via iframe invisível na mesma página (sem abrir nova aba)
+  const iframe = document.createElement('iframe');
+  iframe.style.position = 'fixed';
+  iframe.style.right = '0';
+  iframe.style.bottom = '0';
+  iframe.style.width = '0';
+  iframe.style.height = '0';
+  iframe.style.border = '0';
+  iframe.setAttribute('aria-hidden', 'true');
+  document.body.appendChild(iframe);
+
+  const doc = iframe.contentDocument;
+  if (!doc) {
+    toast.error('Não foi possível iniciar impressão (documento indisponível).');
+    iframe.remove();
+    return;
+  }
+
+  doc.open();
+  doc.write(html);
+  doc.close();
+
+  // Espera o iframe carregar o conteúdo antes de printar
+  let didPrint = false;
+  const tryPrint = () => {
+    if (didPrint) return;
+    const win = iframe.contentWindow;
+    if (!win) {
+      toast.error('Não foi possível iniciar impressão (janela indisponível).');
+      iframe.remove();
+      return;
+    }
+    didPrint = true;
+    win.focus();
+    win.print();
+    // Limpeza: remover após um tempo curto (evita acumular iframes)
+    window.setTimeout(() => iframe.remove(), 1000);
+  };
+
+  // Alguns browsers disparam onload; outros não. Então tentamos ambos.
+  iframe.onload = () => tryPrint();
+  window.setTimeout(() => tryPrint(), 250);
 }
 
 export function ClinicalNoteOrdersPanel(props: {
@@ -154,6 +203,7 @@ export function ClinicalNoteOrdersPanel(props: {
   const [medDose, setMedDose] = useState('');
   const [medFreq, setMedFreq] = useState('');
   const [medRoute, setMedRoute] = useState('');
+  const [medPosology, setMedPosology] = useState('');
 
   const addRx = useMutation({
     mutationFn: () =>
@@ -163,7 +213,7 @@ export function ClinicalNoteOrdersPanel(props: {
         {
           medicationName: medName.trim(),
           dosage: medDose.trim() || undefined,
-          frequency: medFreq.trim() || undefined,
+          frequency: (medFreq.trim() || medPosology.trim()) || undefined,
           route: medRoute.trim() || undefined,
         }
       ),
@@ -172,6 +222,7 @@ export function ClinicalNoteOrdersPanel(props: {
       setMedDose('');
       setMedFreq('');
       setMedRoute('');
+      setMedPosology('');
       invalidate();
       toast.success('Medicamento adicionado à prescrição.');
     },
@@ -198,24 +249,151 @@ export function ClinicalNoteOrdersPanel(props: {
     onError: () => toast.error('Não foi possível remover o item.'),
   });
 
-  const draftLocked = noteStatus !== 'DRAFT';
-  const canEditExams = !draftLocked && canManageExamRequests;
-  const canEditRx = !draftLocked && canManagePrescriptions;
+  const canEditExams = noteStatus !== 'VOIDED' && canManageExamRequests;
+  const canEditRx = noteStatus !== 'VOIDED' && canManagePrescriptions;
 
   const safePatientName = patientName?.trim() ? patientName.trim() : 'Paciente';
   const safeProfessionalName =
     professionalName?.trim() ? professionalName.trim() : '—';
 
+  const tissFormSchema = z.object({
+    operatorName: z.string().trim().min(1, 'Operadora é obrigatória').max(200),
+    operatorANSCode: z.string().trim().max(32).optional().or(z.literal('')),
+    beneficiaryName: z.string().trim().max(200).optional().or(z.literal('')),
+    beneficiaryCardNumber: z.string().trim().max(64).optional().or(z.literal('')),
+    requestingProfessionalName: z
+      .string()
+      .trim()
+      .max(200)
+      .optional()
+      .or(z.literal('')),
+    requestingProfessionalCouncil: z.string().trim().max(32).optional().or(z.literal('')),
+    requestingProfessionalCouncilUf: z.string().trim().max(2).optional().or(z.literal('')),
+    requestingProfessionalRegistration: z.string().trim().max(32).optional().or(z.literal('')),
+    requestingFacilityCnes: z.string().trim().max(16).optional().or(z.literal('')),
+  });
+
+  type TissFormValues = z.infer<typeof tissFormSchema>;
+  const [tissOpen, setTissOpen] = useState(false);
+  const tissForm = useForm<TissFormValues>({
+    resolver: zodResolver(tissFormSchema),
+    defaultValues: {
+      operatorName: '',
+      operatorANSCode: '',
+      beneficiaryName: safePatientName,
+      beneficiaryCardNumber: '',
+      requestingProfessionalName: safeProfessionalName !== '—' ? safeProfessionalName : '',
+      requestingProfessionalCouncil: '',
+      requestingProfessionalCouncilUf: '',
+      requestingProfessionalRegistration: '',
+      requestingFacilityCnes: '',
+    },
+  });
+
+  const emitTiss = useMutation({
+    mutationFn: async (values: TissFormValues) => {
+      const payload = {
+        operatorName: values.operatorName,
+        operatorANSCode: values.operatorANSCode || undefined,
+        beneficiaryName: values.beneficiaryName || undefined,
+        beneficiaryCardNumber: values.beneficiaryCardNumber || undefined,
+        requestingProfessionalName: values.requestingProfessionalName || undefined,
+        requestingProfessionalCouncil: values.requestingProfessionalCouncil || undefined,
+        requestingProfessionalCouncilUf: values.requestingProfessionalCouncilUf || undefined,
+        requestingProfessionalRegistration:
+          values.requestingProfessionalRegistration || undefined,
+        requestingFacilityCnes: values.requestingFacilityCnes || undefined,
+      };
+      return tissGuidesApi.emitSpsadtGuide(patientId, clinicalNoteId, payload);
+    },
+    onSuccess: (guide) => {
+      setTissOpen(false);
+      toast.success('Guia TISS (SP/SADT) emitida.');
+      const dateStr = new Date(guide.createdAt).toLocaleDateString('pt-BR');
+      const itemsHtml = (guide.items ?? [])
+        .map((it) => {
+          return `<tr>
+            <td class="muted">${escapeHtml(it.procedureCode || '—')}</td>
+            <td>${escapeHtml(it.procedureName)}</td>
+            <td>${escapeHtml(String(it.quantity ?? 1))}</td>
+            <td class="muted">${escapeHtml(it.notes || '—')}</td>
+          </tr>`;
+        })
+        .join('');
+
+      openPrintHtml({
+        title: `Guia TISS SP/SADT — ${guide.beneficiaryName}`,
+        htmlBody: `
+          <h1>Guia TISS SP/SADT — Solicitação</h1>
+          <div class="muted">Data: ${escapeHtml(dateStr)} · Nº Guia: ${escapeHtml(guide.guideNumber)}</div>
+
+          <h2>Operadora</h2>
+          <div class="box">
+            <div><strong>Operadora:</strong> ${escapeHtml(guide.operatorName)}</div>
+            <div><strong>Código ANS:</strong> <span class="muted">${escapeHtml(guide.operatorANSCode || '—')}</span></div>
+          </div>
+
+          <h2>Beneficiário</h2>
+          <div class="box">
+            <div><strong>Nome:</strong> ${escapeHtml(guide.beneficiaryName)}</div>
+            <div><strong>Nº carteirinha:</strong> <span class="muted">${escapeHtml(guide.beneficiaryCardNumber || '—')}</span></div>
+          </div>
+
+          <h2>Solicitante</h2>
+          <div class="box">
+            <div><strong>Profissional:</strong> ${escapeHtml(guide.requestingProfessionalName)}</div>
+            <div><strong>Conselho/UF/Registro:</strong> <span class="muted">${escapeHtml(
+              [
+                guide.requestingProfessionalCouncil,
+                guide.requestingProfessionalCouncilUf,
+                guide.requestingProfessionalRegistration,
+              ]
+                .filter(Boolean)
+                .join(' ')
+                .trim() || '—'
+            )}</span></div>
+            <div><strong>CNES:</strong> <span class="muted">${escapeHtml(guide.requestingFacilityCnes || '—')}</span></div>
+          </div>
+
+          <h2>Procedimentos solicitados</h2>
+          <div class="box">
+            <table>
+              <thead>
+                <tr>
+                  <th>Código (TUSS/LOINC)</th>
+                  <th>Procedimento</th>
+                  <th>Qtd</th>
+                  <th>Obs.</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${itemsHtml || `<tr><td colspan="4" class="muted">Sem itens.</td></tr>`}
+              </tbody>
+            </table>
+          </div>
+        `,
+      });
+    },
+    onError: (e: unknown) => {
+      const msg =
+        e && typeof e === 'object' && 'message' in e
+          ? String((e as { message?: string }).message)
+          : 'Não foi possível emitir a guia TISS.';
+      toast.error(msg);
+    },
+  });
+
   const handlePrintExamRequests = () => {
     const rows = (examsQuery.data as ClinicalExamRequestRow[] | undefined) ?? [];
     const items = rows
       .map(
-        (r) =>
-          `<tr>
+        (r) => {
+          const code = r.code || r.loincCode || '—';
+          return `<tr>
             <td>${escapeHtml(r.displayName)}</td>
-            <td class="muted">${escapeHtml(r.code ?? '—')}</td>
-            <td class="muted">${escapeHtml(formatVersionHint(r))}</td>
-          </tr>`
+            <td class="muted">${escapeHtml(code)}</td>
+          </tr>`;
+        }
       )
       .join('');
     openPrintHtml({
@@ -226,10 +404,10 @@ export function ClinicalNoteOrdersPanel(props: {
         <div class="box" style="margin-top: 12px;">
           <table>
             <thead>
-              <tr><th>Exame</th><th>Código</th><th>Versão</th></tr>
+              <tr><th>Exame</th><th>Código (TUSS/LOINC)</th></tr>
             </thead>
             <tbody>
-              ${items || `<tr><td colspan="3" class="muted">Sem exames solicitados.</td></tr>`}
+              ${items || `<tr><td colspan="2" class="muted">Sem exames solicitados.</td></tr>`}
             </tbody>
           </table>
         </div>
@@ -238,10 +416,7 @@ export function ClinicalNoteOrdersPanel(props: {
   };
 
   const [rxCopiesRaw, setRxCopiesRaw] = useState('2');
-  const rxCopies = Math.min(
-    Math.max(parseInt(rxCopiesRaw || '1', 10) || 1, 1),
-    10
-  );
+  const rxCopies = Math.max(parseInt(rxCopiesRaw || '1', 10) || 1, 1);
   const handlePrintPrescription = () => {
     const rows =
       (rxQuery.data as ClinicalPrescriptionLineRow[] | undefined) ?? [];
@@ -251,7 +426,6 @@ export function ClinicalNoteOrdersPanel(props: {
         return `<tr>
           <td>${escapeHtml(r.medicationName)}</td>
           <td class="muted">${escapeHtml(sig || '—')}</td>
-          <td class="muted">${escapeHtml(formatVersionHint(r))}</td>
         </tr>`;
       })
       .join('');
@@ -261,18 +435,20 @@ export function ClinicalNoteOrdersPanel(props: {
       <div class="muted">Paciente: ${escapeHtml(safePatientName)} · Profissional: ${escapeHtml(safeProfessionalName)}</div>
       <div class="box" style="margin-top: 12px;">
         <table>
-          <thead><tr><th>Medicamento</th><th>Posologia</th><th>Versão</th></tr></thead>
+          <thead><tr><th>Medicamento</th><th>Posologia</th></tr></thead>
           <tbody>
-            ${tableRows || `<tr><td colspan="3" class="muted">Sem itens prescritos.</td></tr>`}
+            ${tableRows || `<tr><td colspan="2" class="muted">Sem itens prescritos.</td></tr>`}
           </tbody>
         </table>
       </div>
     `;
 
+    // 1 via por página. O “2 páginas por folha” deve ser configurado no diálogo de impressão do navegador.
     const copiesHtml = Array.from({ length: rxCopies })
-      .map((_, idx) =>
-        idx === 0 ? single : `<div class="page-break"></div>${single}`
-      )
+      .map((_, idx) => {
+        const label = `<div class="muted" style="margin-bottom: 6px;">Via ${idx + 1} de ${rxCopies}</div>`;
+        return `${idx === 0 ? '' : '<div class="page-break"></div>'}${label}${single}`;
+      })
       .join('');
 
     openPrintHtml({
@@ -290,20 +466,43 @@ export function ClinicalNoteOrdersPanel(props: {
         >
           <div className="flex flex-wrap items-center justify-between gap-2">
             <h4 className="text-sm font-medium">Solicitações de exames</h4>
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              onClick={handlePrintExamRequests}
-              disabled={!enabled}
-            >
-              Imprimir solicitação
-            </Button>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => {
+                  tissForm.reset({
+                    operatorName: '',
+                    operatorANSCode: '',
+                    beneficiaryName: safePatientName,
+                    beneficiaryCardNumber: '',
+                    requestingProfessionalName:
+                      safeProfessionalName !== '—' ? safeProfessionalName : '',
+                    requestingProfessionalCouncil: '',
+                    requestingProfessionalCouncilUf: '',
+                    requestingProfessionalRegistration: '',
+                    requestingFacilityCnes: '',
+                  });
+                  setTissOpen(true);
+                }}
+                disabled={!enabled}
+              >
+                Emitir guia TISS (SP/SADT)
+              </Button>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={handlePrintExamRequests}
+                disabled={!enabled}
+              >
+                Imprimir solicitação
+              </Button>
+            </div>
           </div>
           <p className="text-xs text-muted-foreground">
-            {draftLocked
-              ? 'Visível após assinatura; não editável.'
-              : 'Inclua/remova pedidos antes de assinar.'}
+            {'Inclua/remova pedidos com a evolução aberta ou assinada.'}
           </p>
         {examsQuery.isLoading && (
           <p className="text-xs text-muted-foreground">Carregando…</p>
@@ -384,7 +583,10 @@ export function ClinicalNoteOrdersPanel(props: {
                 <Label htmlFor="rx-copies">Nº de vias</Label>
                 <Input
                   id="rx-copies"
+                  type="number"
                   inputMode="numeric"
+                  min={1}
+                  step={1}
                   value={rxCopiesRaw}
                   onChange={(e) => setRxCopiesRaw(e.target.value)}
                   className="w-20"
@@ -403,9 +605,10 @@ export function ClinicalNoteOrdersPanel(props: {
             </div>
           </div>
           <p className="text-xs text-muted-foreground">
-            {draftLocked
-              ? 'Visível após assinatura; não editável.'
-              : 'Inclua/remova itens antes de assinar.'}
+            {'Inclua/remova itens com a evolução aberta ou assinada.'}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {'Cada via sai em 1 página. Para 2 páginas por folha, ajuste no diálogo de impressão (Páginas por folha = 2).'}
           </p>
           {rxQuery.isLoading && (
             <p className="text-xs text-muted-foreground">Carregando…</p>
@@ -467,7 +670,7 @@ export function ClinicalNoteOrdersPanel(props: {
                   id="rx-dose"
                   value={medDose}
                   onChange={(e) => setMedDose(e.target.value)}
-                  placeholder="Ex.: 50 mg"
+                  placeholder="Ex.: 1 comprimido"
                   autoComplete="off"
                 />
               </div>
@@ -479,6 +682,16 @@ export function ClinicalNoteOrdersPanel(props: {
                   onChange={(e) => setMedFreq(e.target.value)}
                   placeholder="Ex.: 12/12 h"
                   autoComplete="off"
+                />
+              </div>
+              <div className="space-y-1 sm:col-span-2">
+                <Label htmlFor="rx-posology">Posologia (texto livre)</Label>
+                <Input
+                  id="rx-posology"
+                  value={medPosology}
+                  onChange={(e) => setMedPosology(e.target.value)}
+                  placeholder="Ex.: 50 mg 12/12 h VO"
+                  autoComplete="on"
                 />
               </div>
               <div className="space-y-1 sm:col-span-2">
@@ -505,6 +718,100 @@ export function ClinicalNoteOrdersPanel(props: {
           )}
         </section>
       )}
+
+      <Dialog open={tissOpen} onOpenChange={setTissOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogClose onClose={() => setTissOpen(false)} />
+          <DialogHeader>
+            <DialogTitle>Emitir guia TISS (SP/SADT)</DialogTitle>
+            <DialogDescription>
+              MVP: gera uma guia de solicitação e prepara para impressão (1 guia por página).
+            </DialogDescription>
+          </DialogHeader>
+
+          <form
+            className="space-y-4"
+            onSubmit={tissForm.handleSubmit((values) => emitTiss.mutate(values))}
+          >
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="operatorName">Operadora</Label>
+                <Input id="operatorName" {...tissForm.register('operatorName')} />
+                {tissForm.formState.errors.operatorName?.message && (
+                  <div className="text-xs text-red-600">
+                    {tissForm.formState.errors.operatorName.message}
+                  </div>
+                )}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="operatorANSCode">Código ANS (opcional)</Label>
+                <Input id="operatorANSCode" {...tissForm.register('operatorANSCode')} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="beneficiaryName">Beneficiário</Label>
+                <Input id="beneficiaryName" {...tissForm.register('beneficiaryName')} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="beneficiaryCardNumber">Nº carteirinha (opcional)</Label>
+                <Input
+                  id="beneficiaryCardNumber"
+                  {...tissForm.register('beneficiaryCardNumber')}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="requestingProfessionalName">Profissional solicitante</Label>
+                <Input
+                  id="requestingProfessionalName"
+                  {...tissForm.register('requestingProfessionalName')}
+                />
+              </div>
+              <div className="grid grid-cols-3 gap-2 md:col-span-1">
+                <div className="space-y-2">
+                  <Label htmlFor="requestingProfessionalCouncil">Conselho</Label>
+                  <Input
+                    id="requestingProfessionalCouncil"
+                    {...tissForm.register('requestingProfessionalCouncil')}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="requestingProfessionalCouncilUf">UF</Label>
+                  <Input
+                    id="requestingProfessionalCouncilUf"
+                    {...tissForm.register('requestingProfessionalCouncilUf')}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="requestingProfessionalRegistration">Registro</Label>
+                  <Input
+                    id="requestingProfessionalRegistration"
+                    {...tissForm.register('requestingProfessionalRegistration')}
+                  />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="requestingFacilityCnes">CNES (opcional)</Label>
+                <Input
+                  id="requestingFacilityCnes"
+                  {...tissForm.register('requestingFacilityCnes')}
+                />
+              </div>
+            </div>
+
+            <div className="flex items-center justify-end gap-2">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => setTissOpen(false)}
+              >
+                Cancelar
+              </Button>
+              <Button type="submit" disabled={emitTiss.isPending}>
+                Emitir
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/src/components/patients/clinical-note-orders-panel.tsx
+++ b/frontend/src/components/patients/clinical-note-orders-panel.tsx
@@ -388,7 +388,7 @@ export function ClinicalNoteOrdersPanel(props: {
     const items = rows
       .map(
         (r) => {
-          const code = r.code || r.loincCode || '—';
+          const code = r.examCatalogCode || r.code || r.loincCode || '—';
           return `<tr>
             <td>${escapeHtml(r.displayName)}</td>
             <td class="muted">${escapeHtml(code)}</td>
@@ -416,7 +416,8 @@ export function ClinicalNoteOrdersPanel(props: {
   };
 
   const [rxCopiesRaw, setRxCopiesRaw] = useState('2');
-  const rxCopies = Math.max(parseInt(rxCopiesRaw || '1', 10) || 1, 1);
+  const rxCopiesParsed = parseInt(rxCopiesRaw || '1', 10) || 1;
+  const rxCopies = Math.min(Math.max(rxCopiesParsed, 1), 10);
   const handlePrintPrescription = () => {
     const rows =
       (rxQuery.data as ClinicalPrescriptionLineRow[] | undefined) ?? [];

--- a/frontend/src/components/patients/current-medications-form.tsx
+++ b/frontend/src/components/patients/current-medications-form.tsx
@@ -205,7 +205,7 @@ export function CurrentMedicationsForm({
                     <div>
                       <Label className="text-xs">Dose</Label>
                       <Input
-                        placeholder="Ex: 50 mg"
+                        placeholder="Ex: 1 comprimido"
                         value={med.dosage ?? ''}
                         onChange={(e) =>
                           update(index, 'dosage', e.target.value)

--- a/frontend/src/lib/api/clinical-note-orders.ts
+++ b/frontend/src/lib/api/clinical-note-orders.ts
@@ -6,6 +6,7 @@ export type ClinicalExamRequestRow = {
   displayName: string;
   code: string | null;
   loincCode: string | null;
+  examCatalogCode: string | null;
   requestedBy: { id: string; name: string };
   createdAt: string;
   updatedAt: string;
@@ -39,7 +40,12 @@ export const clinicalNoteOrdersApi = {
   createExamRequest(
     patientId: string,
     clinicalNoteId: string,
-    body: { displayName: string; code?: string; loincCode?: string }
+    body: {
+      displayName: string;
+      code?: string;
+      loincCode?: string;
+      examCatalogCode?: string;
+    }
   ): Promise<ClinicalExamRequestRow> {
     return apiClient.post<ClinicalExamRequestRow>(
       `/patients/${patientId}/clinical-notes/${clinicalNoteId}/clinical-orders/exam-requests`,

--- a/frontend/src/lib/api/tiss-guides.ts
+++ b/frontend/src/lib/api/tiss-guides.ts
@@ -1,0 +1,55 @@
+import { apiClient } from '@/lib/api/client';
+
+export type TissSpsadtGuideItem = {
+  id: string;
+  procedureName: string;
+  procedureCode: string | null;
+  quantity: number;
+  notes: string | null;
+  examRequestId: string;
+};
+
+export type TissSpsadtGuide = {
+  id: string;
+  guideNumber: string;
+  operatorName: string;
+  operatorANSCode: string | null;
+  beneficiaryName: string;
+  beneficiaryCardNumber: string | null;
+  requestingProfessionalName: string;
+  requestingProfessionalCouncil: string | null;
+  requestingProfessionalCouncilUf: string | null;
+  requestingProfessionalRegistration: string | null;
+  requestingFacilityCnes: string | null;
+  createdAt: string;
+  patient: { id: string; name: string };
+  items: TissSpsadtGuideItem[];
+};
+
+export const tissGuidesApi = {
+  emitSpsadtGuide(
+    patientId: string,
+    clinicalNoteId: string,
+    body: {
+      operatorName: string;
+      operatorANSCode?: string;
+      beneficiaryName?: string;
+      beneficiaryCardNumber?: string;
+      requestingProfessionalName?: string;
+      requestingProfessionalCouncil?: string;
+      requestingProfessionalCouncilUf?: string;
+      requestingProfessionalRegistration?: string;
+      requestingFacilityCnes?: string;
+    }
+  ): Promise<TissSpsadtGuide> {
+    return apiClient.post(
+      `/patients/${patientId}/clinical-notes/${clinicalNoteId}/tiss/sp-sadt`,
+      body
+    );
+  },
+
+  getSpsadtGuide(guideId: string): Promise<TissSpsadtGuide> {
+    return apiClient.get(`/tiss/sp-sadt/${guideId}`);
+  },
+};
+


### PR DESCRIPTION
## Summary
- Adiciona models e migration para guias TISS SP/SADT (cabeçalho e itens) no Prisma.
- Inclui `examCatalogCode` nos pedidos de exame para suportar emissão TISS.
- Cria módulo backend `tiss-guides` para emissão de guia.
- Adiciona UI no prontuário para emitir e imprimir guia TISS (template HTML).

## Test plan
- [ ] Backend: `cd backend && npm test`
- [ ] Frontend: `cd frontend && npm test`
- [ ] Fluxo manual: abrir paciente → Evolução → Pedidos (exames) → "Emitir guia TISS (SP/SADT)" → imprimir no navegador

Made with [Cursor](https://cursor.com)