### PR TITLE
fix(frontend): ocultar ROI e observabilidade na navegação

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -25,7 +25,6 @@ import { MetricsCharts } from '@/components/dashboard/oncologist/metrics-charts'
 import { CriticalAlertsPanel } from '@/components/dashboard/oncologist/critical-alerts-panel';
 import { TeamPerformance } from '@/components/dashboard/oncologist/team-performance';
 import { CriticalStepsSection } from '@/components/dashboard/oncologist/critical-steps-section';
-import { ROISection } from '@/components/dashboard/oncologist/roi-section';
 import { ExecutiveView } from '@/components/dashboard/oncologist/executive-view';
 import { CriticalTimelinesSection } from '@/components/dashboard/oncologist/critical-timelines-section';
 
@@ -595,11 +594,6 @@ function ManagementDashboard() {
               {/* Visão Executiva */}
               {metrics && statistics && (
                 <ExecutiveView metrics={metrics} statistics={statistics} />
-              )}
-
-              {/* Seção de ROI */}
-              {metrics && statistics && (
-                <ROISection metrics={metrics} statistics={statistics} />
               )}
 
               {/* Seção de Prazos Críticos por Tipo de Câncer */}

--- a/frontend/src/components/shared/__tests__/navigation-bar.test.tsx
+++ b/frontend/src/components/shared/__tests__/navigation-bar.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import { NavigationBar } from '../navigation-bar';
+
+const pushMock = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+  usePathname: () => '/dashboard',
+}));
+
+vi.mock('@/hooks/useAlerts', () => ({
+  useCriticalAlertsCount: () => ({ data: { count: 0 } }),
+}));
+
+vi.mock('@/hooks/useMessages', () => ({
+  useUnassumedPatientIds: () => ({ data: { patientIds: [] as string[] } }),
+}));
+
+vi.mock('@/hooks/useReadPatients', () => ({
+  useReadPatients: () => ({ readPatientIds: new Set<string>() }),
+}));
+
+vi.mock('@/stores/auth-store', () => ({
+  useAuthStore: () => ({
+    user: {
+      role: 'ADMIN',
+      name: 'Admin',
+      tenant: { name: 'Hospital Teste' },
+    },
+    logout: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('@/components/shared/welcome-onboarding', () => ({
+  WelcomeOnboarding: () => null,
+}));
+
+describe('NavigationBar', () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+    // `useNavCompactMode` depende de matchMedia.
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    });
+  });
+
+  it('does not render removed nav items', () => {
+    render(<NavigationBar />);
+
+    expect(
+      screen.queryByRole('button', { name: 'Calculadora ROI' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Observabilidade' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders expected base items (smoke)', () => {
+    render(<NavigationBar />);
+
+    expect(screen.getByRole('navigation', { name: 'Navegação principal' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Dashboard' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Navegação' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Agenda' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Chat' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Pacientes' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Integrações' })).toBeInTheDocument();
+  });
+});
+

--- a/frontend/src/components/shared/navigation-bar.tsx
+++ b/frontend/src/components/shared/navigation-bar.tsx
@@ -8,12 +8,10 @@ import {
   LayoutDashboard,
   Navigation,
   CalendarDays,
-  Calculator,
   LogOut,
   Settings,
   Users,
   UserCircle,
-  Activity,
   Bug,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -49,7 +47,7 @@ interface NavItem {
   icon: React.ComponentType<{ className?: string }>;
 }
 
-// Itens de navegação base (sem calculadora ROI)
+// Itens de navegação base.
 const baseNavItems: NavItem[] = [
   {
     path: '/dashboard',
@@ -83,13 +81,6 @@ const baseNavItems: NavItem[] = [
   },
 ];
 
-// Item de calculadora ROI (não disponível para NURSE)
-const roiNavItem: NavItem = {
-  path: '/calculadora-roi',
-  label: 'Calculadora ROI',
-  icon: Calculator,
-};
-
 const adminNavItems: NavItem[] = [
   {
     path: '/dashboard/users',
@@ -106,12 +97,6 @@ const adminOnlyNavItems: NavItem[] = [
     icon: Bug,
   },
 ];
-
-const observabilityNavItem: NavItem = {
-  path: '/observability',
-  label: 'Observabilidade',
-  icon: Activity,
-};
 
 export function NavigationBar() {
   const compactNav = useNavCompactMode();
@@ -135,23 +120,8 @@ export function NavigationBar() {
     user?.role === 'NURSE_CHIEF' ||
     user?.role === 'COORDINATOR';
 
-  // Verificar se o usuário pode ver calculadora ROI (não permitido para NURSE)
-  const canSeeROI = user?.role !== 'NURSE';
-
-  // Observabilidade: apenas para ADMIN, ONCOLOGIST e COORDINATOR
-  const canSeeObservability =
-    user?.role === 'ADMIN' ||
-    user?.role === 'ONCOLOGIST' ||
-    user?.role === 'COORDINATOR';
-
   // Montar lista de itens de navegação baseada nas permissões
   const navItems = [...baseNavItems];
-  if (canSeeROI) {
-    navItems.push(roiNavItem);
-  }
-  if (canSeeObservability) {
-    navItems.push(observabilityNavItem);
-  }
 
   const isActive = (itemPath: string): boolean => {
     if (!pathname) return false;


### PR DESCRIPTION
## Summary
- Remove os itens \"Calculadora ROI\" e \"Observabilidade\" da `NavigationBar`.
- Remove a renderização da `ROISection` no dashboard.
- Adiciona teste de regressão garantindo que os botões removidos não aparecem e que itens base seguem presentes.

## Test plan
- [x] `cd frontend && npx vitest run --reporter=verbose src/components/shared/__tests__/navigation-bar.test.tsx`

Made with [Cursor](https://cursor.com)