### PR TITLE
feat: evolução clínica, merge de sugestões e UX do prontuário

### DIFF
--- a/backend/src/clinical-notes/clinical-note-evolution-scaffolds.spec.ts
+++ b/backend/src/clinical-notes/clinical-note-evolution-scaffolds.spec.ts
@@ -18,6 +18,8 @@ describe('clinical-note-evolution-scaffolds', () => {
   it('cancerTypeLabelPt maps known types', () => {
     expect(cancerTypeLabelPt('bladder')).toContain('bexiga');
     expect(cancerTypeLabelPt('unknown_x')).toBe('unknown_x');
+    expect(cancerTypeLabelPt(null)).toBe('Não informado');
+    expect(cancerTypeLabelPt('')).toBe('Não informado');
   });
 
   it('buildEvolutionSectionScaffolds adds MEDICAL narrative templates', () => {
@@ -40,10 +42,12 @@ describe('clinical-note-evolution-scaffolds', () => {
         ],
         focusNavigationStepId: 's1',
       });
-    expect(sections.hda).toContain('História da doença atual');
+    expect(sections.hda?.trim()).toMatch(/^•\s*$/m);
+    expect(sections.hda).not.toContain('História da doença atual');
+    expect(sections.examesComplementares).toContain('• Lab');
     expect(sections.navegacao).toContain('Cistoscopia');
-    expect(sections.navegacao).toContain('Foco clínico desta etapa');
-    expect(examesComplementaresAppend).toContain('Sugestões de registro');
+    expect(sections.navegacao).not.toContain('Foco clínico desta etapa');
+    expect(examesComplementaresAppend).toBe('');
   });
 
   it('buildEvolutionSectionScaffolds uses NURSING templates', () => {
@@ -54,7 +58,8 @@ describe('clinical-note-evolution-scaffolds', () => {
       navigationSteps: [],
       focusNavigationStepId: null,
     });
-    expect(sections.hda).toContain('História de enfermagem');
-    expect(sections.conduta).toContain('Conduta de enfermagem');
+    expect(sections.hda).toContain('Motivo do contato');
+    expect(sections.hda).not.toContain('História de enfermagem');
+    expect(sections.conduta).toContain('Educação em saúde e mediação');
   });
 });

--- a/backend/src/clinical-notes/clinical-note-evolution-scaffolds.ts
+++ b/backend/src/clinical-notes/clinical-note-evolution-scaffolds.ts
@@ -31,7 +31,7 @@ const CANCER_TYPE_LABEL_PT: Record<string, string> = {
 
 export function cancerTypeLabelPt(cancerType: string | null | undefined): string {
   if (!cancerType?.trim()) {
-    return 'Tipo de câncer não informado no cadastro';
+    return 'Não informado';
   }
   const k = cancerType.trim().toLowerCase();
   return CANCER_TYPE_LABEL_PT[k] ?? cancerType.trim();
@@ -163,68 +163,29 @@ export function buildEvolutionSectionScaffolds(
         s.status === NavigationStepStatus.OVERDUE)
   );
 
-  const navLines: string[] = [
-    `Contexto da jornada: ${stageLb} (estágio atual do paciente no sistema).`,
-    `Tipo de câncer (cadastro): ${cancerLb}.`,
-  ];
-
-  if (focus) {
-    navLines.push(
-      `Esta evolução refere-se à etapa: ${focus.stepName} — ${navStatusLabelPt(focus.status)}.`
-    );
-    const hint = stepExamHintPt(baseNavigationStepKey(focus.stepKey));
-    if (hint) {
-      navLines.push(`Foco clínico desta etapa: ${hint}`);
-    }
-  }
-
   const formatStepLine = (s: StepRow) => {
     const st = navStatusLabelPt(s.status);
     const due = s.dueDate
-      ? ` — prazo: ${s.dueDate.toLocaleDateString('pt-BR', { timeZone: 'America/Sao_Paulo' })}`
+      ? ` — ${s.dueDate.toLocaleDateString('pt-BR', { timeZone: 'America/Sao_Paulo' })}`
       : '';
-    const n = s.notes?.trim() ? ` — obs.: ${s.notes.trim()}` : '';
+    const n = s.notes?.trim() ? ` — ${s.notes.trim()}` : '';
     return `• ${s.stepName} (${st})${due}${n}`;
   };
 
-  if (activeInStage.length > 0) {
-    navLines.push('', 'Etapas pendentes ou em andamento nesta fase:');
-    activeInStage.forEach((s) => navLines.push(formatStepLine(s)));
+  // Seção "navegação": manter apenas as etapas (sem meta, cabeçalhos ou dicas).
+  const stepLines: string[] = [];
+  if (focus) {
+    stepLines.push(formatStepLine(focus));
   }
-
-  const other = sorted.filter((s) => !activeInStage.includes(s));
-  if (other.length > 0) {
-    navLines.push('', 'Demais etapas registradas na navegação:');
-    other.slice(0, 25).forEach((s) => navLines.push(formatStepLine(s)));
-    if (other.length > 25) {
-      navLines.push(`… (+${other.length - 25} etapas)`);
-    }
-  }
-
-  const examHints: string[] = [];
-  const keysForHints = new Set<string>();
-  for (const s of activeInStage.length > 0 ? activeInStage : sorted.slice(0, 12)) {
-    const bk = baseNavigationStepKey(s.stepKey);
-    if (keysForHints.has(bk)) {
+  for (const s of sorted) {
+    if (focus && s.id === focus.id) {
       continue;
     }
-    keysForHints.add(bk);
-    const h = stepExamHintPt(bk);
-    if (h) {
-      examHints.push(`• (${s.stepName}) ${h}`);
-    }
+    stepLines.push(formatStepLine(s));
   }
 
-  let examesComplementaresAppend = '';
-  if (examHints.length > 0) {
-    examesComplementaresAppend = [
-      '',
-      '--- Sugestões de registro conforme etapas em curso ---',
-      ...examHints.slice(0, 8),
-    ].join('\n');
-  }
-
-  const navegacaoBlock = navLines.join('\n');
+  const navegacaoBlock = stepLines.join('\n');
+  const examesComplementaresAppend = '';
 
   if (!noteType) {
     return {
@@ -237,39 +198,44 @@ export function buildEvolutionSectionScaffolds(
     return {
       sections: {
         hda: [
-          'História da doença atual:',
-          '• Motivo do atendimento / encaminhamento:',
-          '• Tempo de evolução e sintomas principais:',
-          '• Tratamentos oncológicos em curso ou recentes (linha, resposta, toxicidades):',
+          '• ',
           '',
         ].join('\n'),
         subjetivo: [
-          `Subjetivo — ${cancerLb} (${stageLb}):`,
-          '• Queixa principal e expectativas do paciente:',
-          '• Adesão, compreensão do plano e apoio familiar/social:',
+          '• ',
           '',
         ].join('\n'),
         exameFisico: [
-          'Exame físico (sinais vitais e sistemas relevantes):',
           '• Geral:',
-          '• Loco-regional / específico ao tumor ou tratamento:',
+          '• NEURO:',
+          '• ACV',
+          '• AR',
+          '• ABD',
+          '• MMII',
+          '',
+        ].join('\n'),
+        examesComplementares: [
+          '• Lab',
+          '• USG',
+          '• TC',
+          '• PET',
+          '• EDA',
+          '• BIOPSIA',
+          '• CITOLOGIA',
+          '• LAUDOS',
+          '• OUTROS',
           '',
         ].join('\n'),
         analise: [
-          'Análise / problema clínico:',
-          '• Síntese diagnóstica e raciocínio:',
+          '',
           '',
         ].join('\n'),
         conduta: [
-          'Conduta médica:',
-          '• Prescrições e encaminhamentos:',
-          '• Orientações ao paciente:',
+          '• ',
           '',
         ].join('\n'),
         planos: [
-          'Plano terapêutico e próximos passos:',
-          '• Curto prazo:',
-          '• Médio prazo / seguimento:',
+          '• ',
           '',
         ].join('\n'),
         navegacao: navegacaoBlock,
@@ -282,36 +248,30 @@ export function buildEvolutionSectionScaffolds(
   return {
     sections: {
       hda: [
-        'História de enfermagem / demanda assistencial:',
         '• Motivo do contato (consulta de navegação oncológica):',
         '• Percepções do paciente e familiares sobre diagnóstico e tratamento:',
         '• Barreiras (acesso, transporte, financeiras, adesão):',
         '',
       ].join('\n'),
       subjetivo: [
-        `Subjetivo — ${cancerLb} (${stageLb}):`,
         '• Narrativa do paciente e principais preocupações:',
         '• Sintomas relatados e autocuidado:',
         '',
       ].join('\n'),
       exameFisico: [
-        'Avaliação (sinais vitais e necessidades observadas):',
         '• Condições gerais e suporte:',
         '',
       ].join('\n'),
       analise: [
-        'Análise de enfermagem:',
         '• Necessidades identificadas (ex.: educação, suporte, sintomas):',
         '',
       ].join('\n'),
       conduta: [
-        'Conduta de enfermagem / navegação:',
         '• Educação em saúde e mediação:',
         '• Encaminhamentos e articulação com a equipe:',
         '',
       ].join('\n'),
       planos: [
-        'Plano de cuidados e próximos passos:',
         '• Ações pactuadas com o paciente:',
         '• Retorno / contato:',
         '',

--- a/backend/src/clinical-notes/clinical-note-evolution-text.util.spec.ts
+++ b/backend/src/clinical-notes/clinical-note-evolution-text.util.spec.ts
@@ -1,0 +1,41 @@
+import {
+  normalizeEvolutionLine,
+  normalizeEvolutionSectionBody,
+} from './clinical-note-evolution-text.util';
+
+describe('clinical-note-evolution-text.util', () => {
+  it('normalizeEvolutionLine remove rótulo quando há valor após dois-pontos', () => {
+    expect(normalizeEvolutionLine('Paciente: João Silva')).toBe('João Silva');
+    expect(normalizeEvolutionLine('• Paciente: João')).toBe('• João');
+  });
+
+  it('normalizeEvolutionLine mantém linha-guia que termina em dois-pontos sem valor', () => {
+    expect(normalizeEvolutionLine('• Motivo do atendimento:')).toBe(
+      '• Motivo do atendimento:'
+    );
+    expect(normalizeEvolutionLine('Conduta médica:')).toBe('Conduta médica:');
+  });
+
+  it('normalizeEvolutionLine não corta quando o dois-pontos vem após ) (exames com data)', () => {
+    const line = '• Hemograma (08/05/2026): 12 g/dL';
+    expect(normalizeEvolutionLine(line)).toBe(line);
+  });
+
+  it('normalizeEvolutionLine preserva indentação e bullet', () => {
+    expect(normalizeEvolutionLine('  Tabagismo: Ex-fumante')).toBe(
+      '  Ex-fumante'
+    );
+  });
+
+  it('normalizeEvolutionSectionBody processa múltiplas linhas', () => {
+    const md = ['Paciente: A', 'Idade: 40 anos', '', '• item:'].join('\n');
+    expect(normalizeEvolutionSectionBody(md)).toBe(
+      ['A', '40 anos', '', '• item:'].join('\n')
+    );
+  });
+
+  it('primeiro dois-pontos em linha tipo tratamento remove contexto (por isso tratamentos não é normalizado no serviço)', () => {
+    const line = '• Quimioterapia — bexiga — Início: 01/01/2025 — Ativo';
+    expect(normalizeEvolutionLine(line)).toBe('• 01/01/2025 — Ativo');
+  });
+});

--- a/backend/src/clinical-notes/clinical-note-evolution-text.util.spec.ts
+++ b/backend/src/clinical-notes/clinical-note-evolution-text.util.spec.ts
@@ -38,4 +38,9 @@ describe('clinical-note-evolution-text.util', () => {
     const line = '• Quimioterapia — bexiga — Início: 01/01/2025 — Ativo';
     expect(normalizeEvolutionLine(line)).toBe('• 01/01/2025 — Ativo');
   });
+
+  it('linha tipo nota de etapa com dois-pontos no texto perde o contexto se normalizada (navegacao é excluída no serviço)', () => {
+    const line = '• Etapa X (Pendente) — obs: revisar laudo';
+    expect(normalizeEvolutionLine(line)).toBe('• revisar laudo');
+  });
 });

--- a/backend/src/clinical-notes/clinical-note-evolution-text.util.ts
+++ b/backend/src/clinical-notes/clinical-note-evolution-text.util.ts
@@ -1,0 +1,37 @@
+/**
+ * Normaliza linhas geradas para evolução: remove o prefixo "rótulo:" quando há valor,
+ * preservando indentação, bullets (•) e linhas-guia que terminam em ":" sem conteúdo.
+ */
+export function normalizeEvolutionLine(line: string): string {
+  const m = /^(\s*)(•\s*)?(.*)$/.exec(line);
+  if (!m) {
+    return line;
+  }
+  const indent = m[1];
+  const bullet = m[2] ?? '';
+  const core = m[3];
+  const colonIdx = core.indexOf(':');
+  if (colonIdx === -1) {
+    return line;
+  }
+  // Linhas tipo "• Exame (12/05/2026): valor" — manter o rótulo com data entre parênteses.
+  if (colonIdx > 0 && core[colonIdx - 1] === ')') {
+    return line;
+  }
+  const value = core.slice(colonIdx + 1).trim();
+  if (value === '') {
+    return line;
+  }
+  return `${indent}${bullet}${value}`;
+}
+
+/** Aplica {@link normalizeEvolutionLine} a cada linha do texto. */
+export function normalizeEvolutionSectionBody(body: string): string {
+  if (!body) {
+    return body;
+  }
+  return body
+    .split('\n')
+    .map((ln) => normalizeEvolutionLine(ln))
+    .join('\n');
+}

--- a/backend/src/clinical-notes/clinical-note-legacy-content.util.spec.ts
+++ b/backend/src/clinical-notes/clinical-note-legacy-content.util.spec.ts
@@ -13,7 +13,7 @@ describe('sectionsRecordToMarkdown', () => {
     expect(md).toContain('Queixa');
     expect(md).toContain('## Conduta');
     expect(md).toContain('Observar');
-    expect(md).toContain('---');
+    expect(md).not.toContain('\n---\n');
   });
 });
 

--- a/backend/src/clinical-notes/clinical-note-legacy-content.util.ts
+++ b/backend/src/clinical-notes/clinical-note-legacy-content.util.ts
@@ -40,7 +40,7 @@ export function sectionsRecordToMarkdown(
     const title = CLINICAL_NOTE_SECTION_LABELS_PT[k];
     parts.push(`## ${title}\n\n${raw ?? ''}`.trimEnd());
   }
-  return parts.join('\n\n---\n\n');
+  return parts.join('\n\n');
 }
 
 /**

--- a/backend/src/clinical-notes/clinical-note-section-suggestion.service.ts
+++ b/backend/src/clinical-notes/clinical-note-section-suggestion.service.ts
@@ -6,6 +6,7 @@ import {
   CLINICAL_NOTE_SECTION_KEYS,
   type ClinicalNoteSectionKey,
 } from './clinical-notes.constants';
+import { normalizeEvolutionSectionBody } from './clinical-note-evolution-text.util';
 import { sectionsRecordToMarkdown } from './clinical-note-legacy-content.util';
 import {
   formatStoredAllergyLine,
@@ -155,7 +156,7 @@ export class ClinicalNoteSectionSuggestionService {
 
     out.identificacao = [
       `Paciente: ${patient.name}`,
-      `Idade: ${age} anos (referência de data: fuso ${TZ_SP})`,
+      `Idade: ${age} anos`,
       `Sexo: ${genderLabelPt(patient.gender)}`,
       patient.medicalRecordNumber
         ? `Prontuário hospitalar: ${patient.medicalRecordNumber}`
@@ -191,7 +192,7 @@ export class ClinicalNoteSectionSuggestionService {
         hppLines.push(line);
       }
       if (typeof o.notes === 'string' && o.notes.trim()) {
-        hppLines.push(`  Notas (tabagismo): ${o.notes.trim()}`);
+        hppLines.push(`  ${o.notes.trim()}`);
       }
     } else if (patient.smokingHistory?.trim()) {
       hppLines.push(`Tabagismo: ${patient.smokingHistory.trim()}`);
@@ -216,7 +217,7 @@ export class ClinicalNoteSectionSuggestionService {
         hppLines.push(line);
       }
       if (typeof o.notes === 'string' && o.notes.trim()) {
-        hppLines.push(`  Notas (álcool): ${o.notes.trim()}`);
+        hppLines.push(`  ${o.notes.trim()}`);
       }
     } else if (patient.alcoholHistory?.trim()) {
       hppLines.push(`Etilismo: ${patient.alcoholHistory.trim()}`);
@@ -255,7 +256,7 @@ export class ClinicalNoteSectionSuggestionService {
           typeof r.ageAtDiagnosis === 'number' ? `${r.ageAtDiagnosis} anos` : '';
         if (rel || ct) {
           hppLines.push(
-            `História familiar: ${rel || '—'} — ${ct || '—'}${ageD ? ` (idade no diagnóstico: ${ageD})` : ''}`
+            `${rel || '—'} · ${ct || '—'}${ageD ? ` · ${ageD}` : ''}`
           );
         }
       }
@@ -325,11 +326,7 @@ export class ClinicalNoteSectionSuggestionService {
       }
     }
     if (patient.allergies?.trim()) {
-      if (allergyBits.length) {
-        allergyBits.push(`Observações adicionais: ${patient.allergies.trim()}`);
-      } else {
-        allergyBits.push(patient.allergies.trim());
-      }
+      allergyBits.push(patient.allergies.trim());
     }
     out.alergias = allergyBits.join('\n');
 
@@ -342,10 +339,8 @@ export class ClinicalNoteSectionSuggestionService {
           ? String(last.valueNumeric)
           : (last.valueText?.trim() ?? '');
       const unit = last.unit?.trim() ? ` ${last.unit.trim()}` : '';
-      const abn =
-        last.isAbnormal === true ? ' (alterado)' : last.isAbnormal === false ? '' : '';
       examChunks.push(
-        `• ${ex.name} (${formatDatePt(last.performedAt)}): ${val}${unit}${abn}`
+        `• ${ex.name} (${formatDatePt(last.performedAt)}): ${val}${unit}`
       );
     }
     out.examesComplementares = examChunks.join('\n');
@@ -358,7 +353,7 @@ export class ClinicalNoteSectionSuggestionService {
         : '';
       const name = t.treatmentName?.trim() ? ` — ${t.treatmentName.trim()}` : '';
       const proto = t.protocol?.trim() ? ` — ${t.protocol.trim()}` : '';
-      const start = t.startDate ? `Início: ${formatDatePt(t.startDate)}` : '';
+      const start = t.startDate ? `${formatDatePt(t.startDate)}` : '';
       const status = t.status
         ? ` — ${TREATMENT_STATUS_LABELS[t.status] ?? t.status}`
         : '';
@@ -396,6 +391,16 @@ export class ClinicalNoteSectionSuggestionService {
       out.examesComplementares = base
         ? `${base}\n${examesComplementaresAppend}`
         : examesComplementaresAppend.trim();
+    }
+
+    for (const k of CLINICAL_NOTE_SECTION_KEYS) {
+      if (k === 'tratamentos') {
+        continue;
+      }
+      const v = out[k];
+      if (typeof v === 'string' && v.trim() !== '') {
+        out[k] = normalizeEvolutionSectionBody(v);
+      }
     }
 
     return { contentMarkdown: sectionsRecordToMarkdown(out) };

--- a/backend/src/clinical-notes/clinical-note-section-suggestion.service.ts
+++ b/backend/src/clinical-notes/clinical-note-section-suggestion.service.ts
@@ -393,8 +393,10 @@ export class ClinicalNoteSectionSuggestionService {
         : examesComplementaresAppend.trim();
     }
 
+    // `tratamentos`: linhas com "Início:" etc. perdem contexto.
+    // `navegacao`: notas livres podem conter ":" (ex. "obs: revisar laudo") e não são rótulo:valor.
     for (const k of CLINICAL_NOTE_SECTION_KEYS) {
-      if (k === 'tratamentos') {
+      if (k === 'tratamentos' || k === 'navegacao') {
         continue;
       }
       const v = out[k];

--- a/frontend/src/components/patients/patient-prontuario-tab.tsx
+++ b/frontend/src/components/patients/patient-prontuario-tab.tsx
@@ -24,6 +24,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Label } from '@/components/ui/label';
 import { AutoResizeTextarea } from '@/components/ui/auto-resize-textarea';
+import { Textarea } from '@/components/ui/textarea';
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -181,7 +182,11 @@ export function PatientProntuarioTab({
     if (update.isPending) return;
 
     update.mutate(
-      { id: noteId, contentMarkdown: debouncedDraftPayload.contentMarkdown },
+      {
+        id: noteId,
+        contentMarkdown: debouncedDraftPayload.contentMarkdown,
+        silent: true,
+      },
       {
         onSuccess: () => {
           draftBaselineSerialized.current = serialized;
@@ -631,13 +636,6 @@ export function PatientProntuarioTab({
                         </Button>
                       )}
                   </div>
-                  {detail.status === 'DRAFT' && detailPerms?.canEditDraft && (
-                    <p className="text-xs text-muted-foreground text-right max-w-md sm:max-w-lg">
-                      {update.isPending
-                        ? 'Salvando rascunho…'
-                        : 'Salvamento automático cerca de 1 s após parar de digitar. Use Markdown (## títulos, listas, **negrito**).'}
-                    </p>
-                  )}
                 </div>
               </div>
 
@@ -658,12 +656,12 @@ export function PatientProntuarioTab({
                         : 'Evolução clínica'}
                     </Label>
                     {isDraftEditable ? (
-                      <AutoResizeTextarea
+                      <Textarea
                         id="clinical-note-markdown"
                         value={draftMarkdown}
                         onChange={(e) => setDraftMarkdown(e.target.value)}
-                        minRows={10}
-                        className="font-mono text-sm pb-12 md:pb-16"
+                        rows={30}
+                        className="font-mono text-sm pb-12 md:pb-16 resize-none overflow-y-auto"
                         spellCheck
                       />
                     ) : (

--- a/frontend/src/components/ui/__tests__/auto-resize-textarea.test.tsx
+++ b/frontend/src/components/ui/__tests__/auto-resize-textarea.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { AutoResizeTextarea } from '../auto-resize-textarea';
+
+describe('AutoResizeTextarea (scroll)', () => {
+  it('não chama scrollIntoView ao digitar (evita scroll jump)', async () => {
+    if (!('scrollIntoView' in HTMLElement.prototype)) {
+      Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+        value: () => {},
+        writable: true,
+      });
+    }
+
+    const scrollIntoViewSpy = vi
+      .spyOn(HTMLElement.prototype, 'scrollIntoView')
+      .mockImplementation(() => {});
+
+    function Harness() {
+      const [value, setValue] = React.useState('linha 1');
+      return (
+        <AutoResizeTextarea
+          aria-label="Evolução clínica (Markdown)"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          minRows={3}
+        />
+      );
+    }
+
+    render(<Harness />);
+    const textarea = screen.getByLabelText(
+      'Evolução clínica (Markdown)'
+    ) as HTMLTextAreaElement;
+
+    await userEvent.click(textarea);
+    await userEvent.type(textarea, '\nlinha 2');
+
+    expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+  });
+});
+

--- a/frontend/src/components/ui/auto-resize-textarea.tsx
+++ b/frontend/src/components/ui/auto-resize-textarea.tsx
@@ -84,12 +84,19 @@ export const AutoResizeTextarea = React.forwardRef<
   const innerRef = React.useRef<HTMLTextAreaElement | null>(null);
   const mergedRef = React.useMemo(() => mergeRefs(innerRef, ref), [ref]);
   const scrollParentsRef = React.useRef<HTMLElement[]>([]);
+  const isRestoringScrollRef = React.useRef(false);
+  const lastManualScrollAtRef = React.useRef<number>(0);
   const lastScrollRef = React.useRef<{
     winY: number | null;
     docTop: number | null;
     parents: number[];
   }>({ winY: null, docTop: null, parents: [] });
   const lastScrollLogTsRef = React.useRef<number>(0);
+
+  const SCROLL_COOLDOWN_MS = 700;
+  const isInManualScrollCooldown = React.useCallback(() => {
+    return Date.now() - lastManualScrollAtRef.current < SCROLL_COOLDOWN_MS;
+  }, []);
 
   React.useEffect(() => {
     const el = innerRef.current;
@@ -123,6 +130,12 @@ export const AutoResizeTextarea = React.forwardRef<
 
       if (!changed) return;
       lastScrollRef.current = { winY, docTop, parents: parentTops };
+
+      // Marca scroll manual (ou do browser) enquanto o campo está focado.
+      // Evita "disputa" de scroll quando o usuário acabou de rolar e voltou a digitar.
+      if (!isRestoringScrollRef.current) {
+        lastManualScrollAtRef.current = now;
+      }
 
       // #region agent log (H1)
       debugLog(
@@ -253,8 +266,13 @@ export const AutoResizeTextarea = React.forwardRef<
 
     // Se o resize mexeu no scroll do documento, restaura. Isso impede o “pulo” ao inserir quebra de linha.
     if (document.activeElement === el && scrollingEl && scrollTopBefore !== null) {
+      if (isInManualScrollCooldown()) {
+        return;
+      }
       if (scrollingEl.scrollTop !== scrollTopBefore) {
+        isRestoringScrollRef.current = true;
         scrollingEl.scrollTop = scrollTopBefore;
+        isRestoringScrollRef.current = false;
         // #region agent log (H1)
         debugLog(
           'auto-resize-textarea.tsx:adjustHeight',
@@ -273,6 +291,9 @@ export const AutoResizeTextarea = React.forwardRef<
 
     // Se houver container scrollável acima (tabs, painel, etc.), também restaura para evitar “tremida”.
     if (document.activeElement === el) {
+      if (isInManualScrollCooldown()) {
+        return;
+      }
       for (const parent of scrollParents) {
         const snap = (before as any).scrollParents?.find(
           (p: any) =>
@@ -282,7 +303,9 @@ export const AutoResizeTextarea = React.forwardRef<
         );
         if (snap && typeof snap.scrollTop === 'number' && parent.scrollTop !== snap.scrollTop) {
           const beforeRestore = parent.scrollTop;
+          isRestoringScrollRef.current = true;
           parent.scrollTop = snap.scrollTop;
+          isRestoringScrollRef.current = false;
           // #region agent log (H1)
           debugLog(
             'auto-resize-textarea.tsx:adjustHeight',
@@ -303,67 +326,19 @@ export const AutoResizeTextarea = React.forwardRef<
       }
     }
 
-    // Mantém o foco visível com o mínimo de scroll (evita “teleportar” ao rodapé como `block: center/start`).
-    if (document.activeElement === el) {
+    // Alguns navegadores ajustam o scroll *depois* do layout (na mesma frame).
+    // Se houver “tremida” (scroll muda e volta), esse é o ponto de captura/correção.
+    if (document.activeElement === el && !isInManualScrollCooldown()) {
       requestAnimationFrame(() => {
-        const r = el.getBoundingClientRect();
-        const cushion = 32;
-        // Se a textarea é maior que a viewport, `r.bottom` estará quase sempre fora da tela
-        // e `scrollIntoView` vira um "puxão" constante. Só ajusta scroll quando o campo
-        // inteiro cabe na viewport.
-        if (r.height <= window.innerHeight && r.bottom > window.innerHeight - cushion) {
-          // #region agent log (H2)
-          debugLog(
-            'auto-resize-textarea.tsx:scrollIntoView',
-            'trigger-scrollIntoView',
-            {
-              ...before,
-              rectBottom: r.bottom,
-              rectTop: r.top,
-              innerHeight: window.innerHeight,
-              cushion,
-              nextHeight: next,
-            },
-            'H2',
-            'pre-fix'
-          );
-          // #endregion
-          el.scrollIntoView({
-            block: 'nearest',
-            inline: 'nearest',
-            behavior: 'instant',
-          });
-        }
-
-        // #region agent log (H1)
-        debugLog(
-          'auto-resize-textarea.tsx:adjustHeight',
-          'post-raf-rect-and-scroll',
-          {
-            rectTop: r.top,
-            rectBottom: r.bottom,
-            rectHeight: r.height,
-            innerHeight: window.innerHeight,
-            winScrollY: window.scrollY,
-            scrollTop:
-              typeof document !== 'undefined'
-                ? (document.scrollingElement as HTMLElement | null)?.scrollTop ?? null
-                : null,
-          },
-          'H1',
-          'pre-fix'
-        );
-        // #endregion
-
-        // Alguns navegadores ajustam o scroll *depois* do layout (na mesma frame).
-        // Se houver “tremida” (scroll muda e volta), esse é o ponto de captura/correção.
         const se =
           typeof document !== 'undefined'
             ? (document.scrollingElement as HTMLElement | null)
             : null;
         if (se && scrollTopBefore !== null && se.scrollTop !== scrollTopBefore) {
           const beforeRaf = se.scrollTop;
+          isRestoringScrollRef.current = true;
           se.scrollTop = scrollTopBefore;
+          isRestoringScrollRef.current = false;
           // #region agent log (H1)
           debugLog(
             'auto-resize-textarea.tsx:adjustHeight',

--- a/frontend/src/hooks/use-clinical-notes.ts
+++ b/frontend/src/hooks/use-clinical-notes.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   clinicalNotesApi,
+  type ClinicalNoteMutationResponse,
   type ClinicalNoteType,
 } from '@/lib/api/clinical-notes';
 
@@ -69,17 +70,41 @@ export function useClinicalNoteMutations(patientId: string) {
       contentMarkdown: string;
       changeReason?: string;
       navigationStepId?: string;
+      /** Quando true, evita invalidar/refetch (ex.: autosave) */
+      silent?: boolean;
     }) =>
       clinicalNotesApi.update(args.id, {
         contentMarkdown: args.contentMarkdown,
         changeReason: args.changeReason,
         navigationStepId: args.navigationStepId,
       }),
-    onSuccess: (_, v) => {
+    onSuccess: (res, v) => {
+      // Atualiza cache do detalhe imediatamente para não depender de refetch.
+      queryClient.setQueryData(
+        ['clinical-notes', 'detail', v.id],
+        (old: unknown) => {
+          if (!old || typeof old !== 'object') return old;
+          const prev = old as Record<string, unknown>;
+          return {
+            ...prev,
+            contentMarkdown: v.contentMarkdown,
+            latestVersionNumber:
+              (res as ClinicalNoteMutationResponse | undefined)
+                ?.latestVersionNumber ?? prev.latestVersionNumber,
+            sectionsContentHash:
+              (res as ClinicalNoteMutationResponse | undefined)
+                ?.sectionsContentHash ?? prev.sectionsContentHash,
+            updatedAt:
+              (res as ClinicalNoteMutationResponse | undefined)?.updatedAt ??
+              prev.updatedAt,
+          };
+        }
+      );
+
+      // Em autosave, evitar invalidate/refetch para não gerar layout shift/scroll jump.
+      if (v.silent) return;
+
       invalidate();
-      queryClient.invalidateQueries({
-        queryKey: ['clinical-notes', 'detail', v.id],
-      });
     },
   });
 

--- a/frontend/src/lib/api/__tests__/clinical-notes-serialize.test.ts
+++ b/frontend/src/lib/api/__tests__/clinical-notes-serialize.test.ts
@@ -9,16 +9,19 @@ describe('mergeMarkdownWithCadastroSuggestion', () => {
     );
   });
 
+  it('usa a sugestão quando o anterior é só espaços em branco', () => {
+    expect(mergeMarkdownWithCadastroSuggestion('   \n', 'sugestão')).toBe(
+      'sugestão'
+    );
+  });
+
   it('mantém só o anterior quando a sugestão está vazia', () => {
     expect(mergeMarkdownWithCadastroSuggestion('já tenho texto', '')).toBe(
       'já tenho texto'
     );
   });
 
-  it('concatena com separador quando ambos têm conteúdo', () => {
-    const m = mergeMarkdownWithCadastroSuggestion('A', 'B');
-    expect(m).toContain('A');
-    expect(m).toContain('B');
-    expect(m).toContain('---');
+  it('prioriza a evolução anterior quando ambos têm conteúdo (não concatena)', () => {
+    expect(mergeMarkdownWithCadastroSuggestion('A', 'B')).toBe('A');
   });
 });

--- a/frontend/src/lib/api/clinical-notes.ts
+++ b/frontend/src/lib/api/clinical-notes.ts
@@ -20,18 +20,17 @@ export type ClinicalNoteNavigationStepRef = {
 };
 
 /**
- * Combina texto da evolução anterior com o Markdown sugerido a partir do cadastro.
- * Se só um lado tiver conteúdo, devolve esse; se ambos, concatena com separador.
+ * Conteúdo inicial da nova evolução: usa a evolução anterior quando houver texto;
+ * caso contrário, usa o Markdown sugerido a partir do cadastro (não soma os dois).
  */
 export function mergeMarkdownWithCadastroSuggestion(
   previousMarkdown: string,
   suggestionMarkdown: string
 ): string {
-  const prev = previousMarkdown.trim();
-  const sug = suggestionMarkdown.trim();
-  if (!prev) return suggestionMarkdown;
-  if (!sug) return previousMarkdown;
-  return `${previousMarkdown.trimEnd()}\n\n---\n\n${sug}`;
+  if (previousMarkdown.trim()) {
+    return previousMarkdown;
+  }
+  return suggestionMarkdown;
 }
 
 export type ClinicalNoteUserRef = {


### PR DESCRIPTION
## O quê
- **Backend (clinical-notes):** util para normalizar linhas da evolução (rótulo: valor); scaffolds médicos mais enxutos e navegação só com bullets de etapas; chave `examesComplementares`; agregação de markdown legado sem `---`; sugestões de seção alinhadas à normalização (sem prefixos literais desnecessários).
- **Frontend:** `mergeMarkdownWithCadastroSuggestion` passa a **priorizar o texto da evolução** quando não vazio (não concatena sugestão por cima).
- **Prontuário:** autosave com `silent: true`, atualização otimista do detalhe no React Query e campo de evolução com `Textarea` fixa para reduzir saltos de layout.
- **AutoResizeTextarea:** cooldown após scroll manual para não disputar com a restauração automática (ainda usado noutros ecrãs, p.ex. navegação oncológica).

## Por quê
Melhorar legibilidade da evolução, evitar duplicar conteúdo ao abrir nota com cadastro sugerido, e reduzir "pulo" de scroll durante edição e autosave.

## Como testar
- [ ] `cd backend && npm test -- clinical-note-evolution-text clinical-note-evolution-scaffolds clinical-note-section-suggestion clinical-note-legacy-content`
- [ ] `cd frontend && npm test -- clinical-notes-serialize auto-resize-textarea`
- [ ] Abrir prontuário, rascunho: editar evolução, confirmar autosave sem flicker excessivo; fluxo com sugestão de cadastro não deve sobrescrever evolução já escrita.

## Checklist
- [ ] Testes passando nos pacotes alterados
- [ ] Sem inclusão de `backend/dist/`, `frontend/.next/`, logs `.cursor/`
- [ ] Commits atómicos por tema (backend util → backend resto → API merge → hook/prontuário → textarea)


Made with [Cursor](https://cursor.com)