### PR TITLE
fix(clinical-notes): TUSS/LOINC na sugestão de exames para copiar

### DIFF
--- a/backend/src/clinical-notes/clinical-note-section-suggestion.service.spec.ts
+++ b/backend/src/clinical-notes/clinical-note-section-suggestion.service.spec.ts
@@ -1,4 +1,48 @@
-import { ageYearsInTimeZone } from './clinical-note-section-suggestion.service';
+import {
+  ageYearsInTimeZone,
+  formatComplementaryExamDisplayName,
+} from './clinical-note-section-suggestion.service';
+
+describe('formatComplementaryExamDisplayName', () => {
+  it('inclui código TUSS/sigla quando code está preenchido', () => {
+    expect(
+      formatComplementaryExamDisplayName({
+        name: 'Hemograma completo',
+        code: '40304361',
+        loincCode: '58410-2',
+      })
+    ).toBe('Hemograma completo (40304361)');
+  });
+
+  it('usa LOINC quando não há code', () => {
+    expect(
+      formatComplementaryExamDisplayName({
+        name: 'Glicemia',
+        code: null,
+        loincCode: '2345-7',
+      })
+    ).toBe('Glicemia (LOINC 2345-7)');
+  });
+
+  it('retorna só o nome quando não há código nem LOINC', () => {
+    expect(
+      formatComplementaryExamDisplayName({
+        name: 'Raio-X de tórax',
+        code: undefined,
+        loincCode: '',
+      })
+    ).toBe('Raio-X de tórax');
+  });
+
+  it('normaliza espaços e nome vazio vira "Exame"', () => {
+    expect(
+      formatComplementaryExamDisplayName({
+        name: '   ',
+        code: '  ABC  ',
+      })
+    ).toBe('Exame (ABC)');
+  });
+});
 
 describe('ageYearsInTimeZone', () => {
   it('calcula idade no fuso America/Sao_Paulo', () => {

--- a/backend/src/clinical-notes/clinical-note-section-suggestion.service.ts
+++ b/backend/src/clinical-notes/clinical-note-section-suggestion.service.ts
@@ -74,6 +74,27 @@ function formatDatePt(d: Date | null | undefined): string {
   }
 }
 
+/**
+ * Rótulo do exame para texto de evolução (copiar/colar): nome + sigla/código TUSS
+ * ou LOINC quando existir — alinhado ao catálogo no frontend (`Nome (código)`).
+ */
+export function formatComplementaryExamDisplayName(ex: {
+  name: string;
+  code?: string | null;
+  loincCode?: string | null;
+}): string {
+  const name = ex.name?.trim() || 'Exame';
+  const code = ex.code?.trim();
+  if (code) {
+    return `${name} (${code})`;
+  }
+  const loinc = ex.loincCode?.trim();
+  if (loinc) {
+    return `${name} (LOINC ${loinc})`;
+  }
+  return name;
+}
+
 export interface SectionSuggestionsOptions {
   /** Etapa à qual a evolução será vinculada — ajusta foco e dicas por tipo de exame/consulta */
   navigationStepId?: string;
@@ -339,8 +360,9 @@ export class ClinicalNoteSectionSuggestionService {
           ? String(last.valueNumeric)
           : (last.valueText?.trim() ?? '');
       const unit = last.unit?.trim() ? ` ${last.unit.trim()}` : '';
+      const examLabel = formatComplementaryExamDisplayName(ex);
       examChunks.push(
-        `• ${ex.name} (${formatDatePt(last.performedAt)}): ${val}${unit}`
+        `• ${examLabel} (${formatDatePt(last.performedAt)}): ${val}${unit}`
       );
     }
     out.examesComplementares = examChunks.join('\n');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Contexto

Ao gerar o texto de evolução para copiar/colar, a seção de **exames complementares** listava apenas o nome do exame e a data, sem o código TUSS (catálogo) ou LOINC armazenado no `ComplementaryExam`.

## Alterações

- Nova função exportada `formatComplementaryExamDisplayName` em `clinical-note-section-suggestion.service.ts`, alinhada ao padrão do frontend (`Nome (código)`), com fallback `Nome (LOINC …)` quando não há `code`.
- Linhas de exame na sugestão usam esse rótulo antes da data e do valor.
- Testes unitários em `clinical-note-section-suggestion.service.spec.ts` cobrindo prioridade `code` > LOINC, ausência de códigos e trim de strings.

## Como validar

1. `cd backend && npx jest clinical-note-section-suggestion.service.spec.ts`
2. Paciente com exame complementar com `code` ou `loincCode` preenchido: solicitar sugestões de seção e verificar o markdown da área de exames complementares.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca426401-ff14-4194-aa8c-398fe4e39f17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca426401-ff14-4194-aa8c-398fe4e39f17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

