### PR TITLE
Agrupar exames complementares duplicados na ingestão e UI

### DIFF
--- a/backend/src/clinical-note-extraction/apply-complementary-exams.spec.ts
+++ b/backend/src/clinical-note-extraction/apply-complementary-exams.spec.ts
@@ -1,0 +1,280 @@
+import { ComplementaryExamType, Prisma } from '@generated/prisma/client';
+import { applyComplementaryExamsFromAiItems } from './apply-complementary-exams';
+import type { AiComplementaryExamItem } from './clinical-note-extraction.types';
+
+function makeTx() {
+  const exams: Array<{
+    id: string;
+    tenantId: string;
+    patientId: string;
+    type: ComplementaryExamType;
+    name: string;
+    code: string | null;
+    loincCode: string | null;
+  }> = [];
+  const results: Array<{
+    id: string;
+    tenantId: string;
+    examId: string;
+    performedAt: Date;
+    deletedAt: Date | null;
+    valueNumeric: number | null;
+    collectionId?: string | null;
+  }> = [];
+  let examSeq = 0;
+  let resSeq = 0;
+
+  return {
+    exams,
+    results,
+    tx: {
+      complementaryExam: {
+        findMany: jest.fn(
+          async ({
+            where,
+          }: {
+            where: {
+              tenantId: string;
+              patientId: string;
+              type?: ComplementaryExamType;
+            };
+          }) =>
+            exams.filter(
+              (e) =>
+                e.tenantId === where.tenantId &&
+                e.patientId === where.patientId &&
+                (where.type === undefined || e.type === where.type),
+            ),
+        ),
+        create: jest.fn(
+          async ({
+            data,
+          }: {
+            data: {
+              tenantId: string;
+              patientId: string;
+              type: ComplementaryExamType;
+              name: string;
+              code: string | null;
+              loincCode: string | null;
+            };
+          }) => {
+            examSeq += 1;
+            const row = {
+              id: `exam-${examSeq}`,
+              ...data,
+            };
+            exams.push(row);
+            return row;
+          },
+        ),
+      },
+      complementaryExamResult: {
+        findFirst: jest.fn(
+          async ({
+            where,
+          }: {
+            where: {
+              tenantId: string;
+              examId: string;
+              performedAt: Date;
+              deletedAt: null;
+            };
+          }) =>
+            results.find(
+              (r) =>
+                r.tenantId === where.tenantId &&
+                r.examId === where.examId &&
+                r.performedAt.getTime() === where.performedAt.getTime() &&
+                r.deletedAt === null,
+            ) ?? null,
+        ),
+        create: jest.fn(
+          async ({
+            data,
+          }: {
+            data: {
+              tenantId: string;
+              examId: string;
+              performedAt: Date;
+              valueNumeric?: number | null;
+              collectionId?: string;
+            };
+          }) => {
+            resSeq += 1;
+            const row = {
+              id: `res-${resSeq}`,
+              deletedAt: null as Date | null,
+              valueNumeric: data.valueNumeric ?? null,
+              ...data,
+            };
+            results.push(row);
+            return row;
+          },
+        ),
+        update: jest.fn(
+          async ({
+            where,
+            data,
+          }: {
+            where: { id: string };
+            data: { valueNumeric?: number | null };
+          }) => {
+            const row = results.find((r) => r.id === where.id);
+            if (!row) throw new Error('not found');
+            if (data.valueNumeric !== undefined) {
+              row.valueNumeric = data.valueNumeric;
+            }
+            return row;
+          },
+        ),
+      },
+    },
+  };
+}
+
+describe('applyComplementaryExamsFromAiItems', () => {
+  const baseArgs = {
+    tenantId: 't1',
+    patientId: 'p1',
+    mergedRejections: [] as Array<{
+      domain: string;
+      reason: string;
+      field?: string | null;
+    }>,
+  };
+
+  it('dois itens mesmo nome e datas diferentes → 1 exam create, 2 results', async () => {
+    const { tx, exams, results } = makeTx();
+    const items: AiComplementaryExamItem[] = [
+      {
+        type: 'LABORATORY',
+        name: 'Hemoglobina',
+        result: { performed_at: '2025-01-01', value_numeric: 12 },
+      },
+      {
+        type: 'LABORATORY',
+        name: 'Hemoglobina',
+        result: { performed_at: '2025-02-01', value_numeric: 13 },
+      },
+    ];
+
+    const out = await applyComplementaryExamsFromAiItems(
+      tx as unknown as Prisma.TransactionClient,
+      baseArgs,
+      items,
+    );
+
+    expect(exams).toHaveLength(1);
+    expect(results).toHaveLength(2);
+    expect(out.complementaryExamIds).toEqual(['exam-1']);
+    expect(out.complementaryExamResultIds).toHaveLength(2);
+  });
+
+  it('mesmo performedAt → 1 result (update)', async () => {
+    const { tx, results } = makeTx();
+    const items: AiComplementaryExamItem[] = [
+      {
+        type: 'LABORATORY',
+        name: 'Creatinina',
+        result: {
+          performed_at: '2025-06-15T10:30:00.000Z',
+          value_numeric: 1.0,
+        },
+      },
+      {
+        type: 'LABORATORY',
+        name: 'Creatinina',
+        result: {
+          performed_at: '2025-06-15T10:30:00.000Z',
+          value_numeric: 1.2,
+        },
+      },
+    ];
+
+    const out = await applyComplementaryExamsFromAiItems(
+      tx as unknown as Prisma.TransactionClient,
+      baseArgs,
+      items,
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.valueNumeric).toBe(1.2);
+    expect(out.complementaryExamResultIds).toEqual(['res-1', 'res-1']);
+  });
+
+  it('mesmo dia com horários diferentes → 2 results', async () => {
+    const { tx, results } = makeTx();
+    const items: AiComplementaryExamItem[] = [
+      {
+        type: 'LABORATORY',
+        name: 'Glicemia',
+        result: {
+          performed_at: '2025-03-10T08:00:00.000Z',
+          value_numeric: 90,
+        },
+      },
+      {
+        type: 'LABORATORY',
+        name: 'Glicemia',
+        result: {
+          performed_at: '2025-03-10T18:00:00.000Z',
+          value_numeric: 110,
+        },
+      },
+    ];
+
+    await applyComplementaryExamsFromAiItems(
+      tx as unknown as Prisma.TransactionClient,
+      baseArgs,
+      items,
+    );
+
+    expect(results).toHaveLength(2);
+    expect(results.map((r) => r.performedAt.toISOString())).toEqual([
+      '2025-03-10T08:00:00.000Z',
+      '2025-03-10T18:00:00.000Z',
+    ]);
+  });
+
+  it('mesmo lote reutiliza exame (batchCache)', async () => {
+    const { tx, exams } = makeTx();
+    const items: AiComplementaryExamItem[] = [
+      {
+        type: 'LABORATORY',
+        name: 'TTPa',
+        result: { performed_at: '2025-01-01', value_numeric: 28 },
+      },
+      {
+        type: 'LABORATORY',
+        name: 'TTPa',
+        result: { performed_at: '2025-02-01', value_numeric: 30 },
+      },
+    ];
+
+    await applyComplementaryExamsFromAiItems(
+      tx as unknown as Prisma.TransactionClient,
+      baseArgs,
+      items,
+    );
+
+    expect(tx.complementaryExam.create).toHaveBeenCalledTimes(1);
+    expect(exams).toHaveLength(1);
+  });
+
+  it('YYYY-MM-DD usa início do dia UTC', async () => {
+    const { tx, results } = makeTx();
+    await applyComplementaryExamsFromAiItems(
+      tx as unknown as Prisma.TransactionClient,
+      baseArgs,
+      [
+        {
+          type: 'LABORATORY',
+          name: 'Hb',
+          result: { performed_at: '2025-04-20', value_numeric: 14 },
+        },
+      ],
+    );
+    expect(results[0]?.performedAt.toISOString()).toBe('2025-04-20T00:00:00.000Z');
+  });
+});

--- a/backend/src/clinical-note-extraction/apply-complementary-exams.spec.ts
+++ b/backend/src/clinical-note-extraction/apply-complementary-exams.spec.ts
@@ -121,7 +121,7 @@ function makeTx() {
             data: { valueNumeric?: number | null };
           }) => {
             const row = results.find((r) => r.id === where.id);
-            if (!row) throw new Error('not found');
+            if (!row) {throw new Error('not found');}
             if (data.valueNumeric !== undefined) {
               row.valueNumeric = data.valueNumeric;
             }

--- a/backend/src/clinical-note-extraction/apply-complementary-exams.ts
+++ b/backend/src/clinical-note-extraction/apply-complementary-exams.ts
@@ -2,6 +2,13 @@ import {
   ComplementaryExamType,
   Prisma,
 } from '@generated/prisma/client';
+import { collapseRedundantComponentsForSave } from '../complementary-exams/collapse-redundant-components.util';
+import {
+  type ComplementaryExamMatchBatchCache,
+  findOrCreateComplementaryExam,
+  parseComplementaryPerformedAt,
+  upsertComplementaryExamResult,
+} from '../complementary-exams/complementary-exam-match.util';
 import { LEDGER_OP_CREATE_COMPLEMENTARY_EXAM } from './clinical-note-extraction.constants';
 import type { AiComplementaryExamItem } from './clinical-note-extraction.types';
 
@@ -13,30 +20,13 @@ type RejectionSink = Array<{
   field?: string | null;
 }>;
 
-function parseIsoDate(
-  raw: string | null | undefined,
-  rej: RejectionSink,
-  domain: string,
-  field: string
-): Date | null {
-  if ((raw === null || raw === undefined) || String(raw).trim() === '') {
-    return null;
-  }
-  const d = new Date(String(raw));
-  if (Number.isNaN(d.getTime())) {
-    rej.push({ domain, reason: `data inválida: ${field}`, field });
-    return null;
-  }
-  return d;
-}
-
 export type ApplyComplementaryExamsFromAiResult = {
   complementaryExamIds: string[];
   complementaryExamResultIds: string[];
 };
 
 /**
- * Cria ComplementaryExam + ComplementaryExamResult a partir de itens da IA.
+ * Find-or-create ComplementaryExam + upsert ComplementaryExamResult a partir de itens da IA.
  * Usado na extração de evolução e no exam-ingest (sem ledger quando pushLedger omitido).
  */
 export async function applyComplementaryExamsFromAiItems(
@@ -60,6 +50,8 @@ export async function applyComplementaryExamsFromAiItems(
 
   const complementaryExamIds: string[] = [];
   const complementaryExamResultIds: string[] = [];
+  const seenExamIds = new Set<string>();
+  const batchCache: ComplementaryExamMatchBatchCache = new Map();
 
   for (let i = 0; i < items.length; i++) {
     const raw = items[i];
@@ -82,25 +74,25 @@ export async function applyComplementaryExamsFromAiItems(
       continue;
     }
 
-    const exam = await tx.complementaryExam.create({
-      data: {
+    const { id: examId, created: examCreated } = await findOrCreateComplementaryExam(
+      tx,
+      {
         tenantId,
         patientId,
         type: typ as ComplementaryExamType,
-        name: name.slice(0, 400),
-        code:
-          raw.code === null || raw.code === undefined
-            ? null
-            : String(raw.code).trim().slice(0, 64) || null,
-        loincCode:
-          raw.loinc_code === null || raw.loinc_code === undefined
-            ? null
-            : String(raw.loinc_code).trim().slice(0, 32) || null,
+        name,
+        code: raw.code,
+        loincCode: raw.loinc_code,
+        batchCache,
       },
-    });
-    complementaryExamIds.push(exam.id);
-    if (pushLedger) {
-      await pushLedger(LEDGER_OP_CREATE_COMPLEMENTARY_EXAM, exam.id);
+    );
+
+    if (!seenExamIds.has(examId)) {
+      seenExamIds.add(examId);
+      complementaryExamIds.push(examId);
+    }
+    if (examCreated && pushLedger) {
+      await pushLedger(LEDGER_OP_CREATE_COMPLEMENTARY_EXAM, examId);
     }
 
     const res = raw.result;
@@ -108,51 +100,65 @@ export async function applyComplementaryExamsFromAiItems(
       continue;
     }
     const performedAt =
-      parseIsoDate(
-        res.performed_at,
-        rej,
-        'complementary_exams',
-        `complementary_exams[${i}].result.performed_at`
-      ) ?? new Date();
+      parseComplementaryPerformedAt(res.performed_at) ?? new Date();
+    if (
+      res.performed_at !== null &&
+      res.performed_at !== undefined &&
+      String(res.performed_at).trim() !== '' &&
+      parseComplementaryPerformedAt(res.performed_at) === null
+    ) {
+      rej.push({
+        domain: 'complementary_exams',
+        reason: `data inválida: complementary_exams[${i}].result.performed_at`,
+        field: `complementary_exams[${i}].result.performed_at`,
+      });
+      continue;
+    }
 
-    const row = await tx.complementaryExamResult.create({
-      data: {
-        tenantId,
-        examId: exam.id,
-        performedAt,
-        ...(collectionId !== null &&
-        collectionId !== undefined &&
-        collectionId !== ''
-          ? { collectionId }
-          : {}),
-        valueNumeric:
-          res.value_numeric === null || res.value_numeric === undefined
-            ? null
-            : Number.isFinite(Number(res.value_numeric))
-              ? Number(res.value_numeric)
-              : null,
-        valueText:
-          res.value_text === null || res.value_text === undefined
-            ? null
-            : String(res.value_text).trim().slice(0, 8000) || null,
-        unit:
-          res.unit === null || res.unit === undefined
-            ? null
-            : String(res.unit).trim().slice(0, 64) || null,
-        referenceRange:
-          res.reference_range === null || res.reference_range === undefined
-            ? null
-            : String(res.reference_range).trim().slice(0, 200) || null,
-        isAbnormal:
-          typeof res.is_abnormal === 'boolean' ? res.is_abnormal : null,
-        report:
-          res.report === null || res.report === undefined
-            ? null
-            : String(res.report).trim().slice(0, 12000) || null,
-        components: res.components as Prisma.InputJsonValue | undefined,
+    const collapsed = collapseRedundantComponentsForSave(name, {
+      valueNumeric:
+        res.value_numeric === null || res.value_numeric === undefined
+          ? null
+          : Number.isFinite(Number(res.value_numeric))
+            ? Number(res.value_numeric)
+            : null,
+      valueText:
+        res.value_text === null || res.value_text === undefined
+          ? null
+          : String(res.value_text).trim().slice(0, 8000) || null,
+      unit:
+        res.unit === null || res.unit === undefined
+          ? null
+          : String(res.unit).trim().slice(0, 64) || null,
+      referenceRange:
+        res.reference_range === null || res.reference_range === undefined
+          ? null
+          : String(res.reference_range).trim().slice(0, 200) || null,
+      isAbnormal:
+        typeof res.is_abnormal === 'boolean' ? res.is_abnormal : null,
+      report:
+        res.report === null || res.report === undefined
+          ? null
+          : String(res.report).trim().slice(0, 12000) || null,
+      components: res.components,
+    });
+
+    const { id: resultId } = await upsertComplementaryExamResult(tx, {
+      tenantId,
+      examId,
+      performedAt,
+      collectionId,
+      payload: {
+        valueNumeric: collapsed.valueNumeric ?? null,
+        valueText: collapsed.valueText ?? null,
+        unit: collapsed.unit ?? null,
+        referenceRange: collapsed.referenceRange ?? null,
+        isAbnormal: collapsed.isAbnormal ?? null,
+        report: collapsed.report ?? null,
+        components: collapsed.components as Prisma.InputJsonValue | undefined,
       },
     });
-    complementaryExamResultIds.push(row.id);
+    complementaryExamResultIds.push(resultId);
   }
 
   return { complementaryExamIds, complementaryExamResultIds };

--- a/backend/src/clinical-note-extraction/apply-complementary-exams.ts
+++ b/backend/src/clinical-note-extraction/apply-complementary-exams.ts
@@ -155,7 +155,12 @@ export async function applyComplementaryExamsFromAiItems(
         referenceRange: collapsed.referenceRange ?? null,
         isAbnormal: collapsed.isAbnormal ?? null,
         report: collapsed.report ?? null,
-        components: collapsed.components as Prisma.InputJsonValue | undefined,
+        components:
+          collapsed.components &&
+          Array.isArray(collapsed.components) &&
+          collapsed.components.length > 0
+            ? (collapsed.components as Prisma.InputJsonValue)
+            : null,
       },
     });
     complementaryExamResultIds.push(resultId);

--- a/backend/src/clinical-notes/exam-ingest.service.spec.ts
+++ b/backend/src/clinical-notes/exam-ingest.service.spec.ts
@@ -263,8 +263,15 @@ describe('ExamIngestService', () => {
     const resCreate = jest.fn().mockResolvedValue({ id: 'res-1' });
     prisma.$transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) =>
       fn({
-        complementaryExam: { create: examCreate },
-        complementaryExamResult: { create: resCreate },
+        complementaryExam: {
+          findMany: jest.fn().mockResolvedValue([]),
+          create: examCreate,
+        },
+        complementaryExamResult: {
+          findFirst: jest.fn().mockResolvedValue(null),
+          create: resCreate,
+          update: jest.fn(),
+        },
       })
     );
 

--- a/backend/src/complementary-exams/collapse-redundant-components.util.spec.ts
+++ b/backend/src/complementary-exams/collapse-redundant-components.util.spec.ts
@@ -1,0 +1,63 @@
+import {
+  collapseRedundantComponentsForSave,
+  extractParentheticalAliases,
+  normalizeExamLabelKey,
+} from './collapse-redundant-components.util';
+
+describe('collapse-redundant-components.util', () => {
+  it('normalizeExamLabelKey remove acentos e pontuação', () => {
+    expect(normalizeExamLabelKey('TTPa (ativo)')).toBe('ttpaativo');
+  });
+
+  it('extractParentheticalAliases lê sigla entre parênteses', () => {
+    expect(
+      extractParentheticalAliases('Tempo de Tromboplastina Parcial Ativado (TTPa)'),
+    ).toEqual(['TTPa']);
+  });
+
+  it('promove TTPa sinônimo para campos do resultado pai', () => {
+    const out = collapseRedundantComponentsForSave(
+      'Tempo de Tromboplastina Parcial Ativado (TTPa)',
+      {
+        valueNumeric: null,
+        valueText: null,
+        unit: null,
+        referenceRange: null,
+        components: [
+          {
+            name: 'TTPa',
+            valueNumeric: 28.7,
+            unit: 'seg',
+            referenceRange: '25,4 a 33,4',
+          },
+        ],
+      },
+    );
+    expect(out.valueNumeric).toBe(28.7);
+    expect(out.unit).toBe('seg');
+    expect(out.referenceRange).toBe('25,4 a 33,4');
+    expect(out.components).toBeUndefined();
+  });
+
+  it('não colapsa painel com vários componentes', () => {
+    const out = collapseRedundantComponentsForSave('Hemograma completo', {
+      valueNumeric: null,
+      components: [
+        { name: 'Hb', valueNumeric: 13 },
+        { name: 'Leucócitos', valueNumeric: 8000 },
+      ],
+    });
+    expect(out.components).toHaveLength(2);
+    expect(out.valueNumeric).toBeNull();
+  });
+
+  it('não colapsa quando o pai já tem valueNumeric', () => {
+    const components = [{ name: 'ALT', valueNumeric: 45 }];
+    const out = collapseRedundantComponentsForSave('Hemograma', {
+      valueNumeric: 14,
+      components,
+    });
+    expect(out.valueNumeric).toBe(14);
+    expect(out.components).toEqual(components);
+  });
+});

--- a/backend/src/complementary-exams/collapse-redundant-components.util.ts
+++ b/backend/src/complementary-exams/collapse-redundant-components.util.ts
@@ -1,0 +1,144 @@
+import type { ExamResultComponentInput } from './reference-range.util';
+
+export function normalizeExamLabelKey(name: string): string {
+  return name
+    .normalize('NFD')
+    .replace(/\p{M}/gu, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '');
+}
+
+export function extractParentheticalAliases(examName: string): string[] {
+  const aliases: string[] = [];
+  const re = /\(([^)]+)\)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(examName)) !== null) {
+    const inner = m[1].trim();
+    if (inner) aliases.push(inner);
+  }
+  return aliases;
+}
+
+function parseComponents(raw: unknown): ExamResultComponentInput[] {
+  if (raw == null) return [];
+  if (typeof raw === 'string') {
+    const t = raw.trim();
+    if (!t) return [];
+    try {
+      return parseComponents(JSON.parse(t) as unknown);
+    } catch {
+      return [];
+    }
+  }
+  if (!Array.isArray(raw)) return [];
+  const out: ExamResultComponentInput[] = [];
+  for (const el of raw) {
+    if (!el || typeof el !== 'object' || Array.isArray(el)) continue;
+    const o = el as Record<string, unknown>;
+    const nameRaw = o.name;
+    if (typeof nameRaw !== 'string' || !nameRaw.trim()) continue;
+    const vn = o.valueNumeric ?? o.value_numeric;
+    let valueNumeric: number | undefined;
+    if (vn !== null && vn !== undefined && vn !== '') {
+      if (typeof vn === 'number' && Number.isFinite(vn)) {
+        valueNumeric = vn;
+      } else {
+        const n = Number(vn);
+        if (Number.isFinite(n)) valueNumeric = n;
+      }
+    }
+    const vt = o.valueText ?? o.value_text;
+    const u = o.unit;
+    const rr = o.referenceRange ?? o.reference_range;
+    const ia = o.isAbnormal ?? o.is_abnormal;
+    out.push({
+      name: nameRaw.trim(),
+      valueNumeric,
+      valueText:
+        vt === null || vt === undefined
+          ? undefined
+          : String(vt).trim().slice(0, 8000) || undefined,
+      unit:
+        u === null || u === undefined
+          ? undefined
+          : String(u).trim().slice(0, 64) || undefined,
+      referenceRange:
+        rr === null || rr === undefined
+          ? undefined
+          : String(rr).trim().slice(0, 200) || undefined,
+      isAbnormal: typeof ia === 'boolean' ? ia : undefined,
+    });
+  }
+  return out;
+}
+
+function resultHasMainValue(fields: {
+  valueNumeric?: number | null;
+  valueText?: string | null;
+  report?: string | null;
+}): boolean {
+  if (
+    fields.valueNumeric !== null &&
+    fields.valueNumeric !== undefined &&
+    !Number.isNaN(fields.valueNumeric)
+  ) {
+    return true;
+  }
+  if ((fields.valueText ?? '').trim()) return true;
+  if ((fields.report ?? '').trim()) return true;
+  return false;
+}
+
+function componentNameMatchesExam(
+  examName: string,
+  componentName: string,
+): boolean {
+  const examKey = normalizeExamLabelKey(examName);
+  const compKey = normalizeExamLabelKey(componentName);
+  if (!examKey || !compKey) return false;
+  if (examKey === compKey) return true;
+  for (const alias of extractParentheticalAliases(examName)) {
+    if (normalizeExamLabelKey(alias) === compKey) return true;
+  }
+  if (examKey.includes(compKey) || compKey.includes(examKey)) return true;
+  return false;
+}
+
+export interface CollapsibleExamResultFields {
+  valueNumeric?: number | null;
+  valueText?: string | null;
+  unit?: string | null;
+  referenceRange?: string | null;
+  isAbnormal?: boolean | null;
+  report?: string | null;
+  components?: unknown;
+}
+
+/**
+ * Promove único subitem sinônimo do exame para campos do resultado pai antes de persistir.
+ */
+export function collapseRedundantComponentsForSave(
+  examName: string,
+  fields: CollapsibleExamResultFields,
+): CollapsibleExamResultFields {
+  const comps = parseComponents(fields.components);
+  if (comps.length !== 1 || resultHasMainValue(fields)) {
+    return fields;
+  }
+  const sole = comps[0];
+  if (!sole.name?.trim() || !componentNameMatchesExam(examName, sole.name)) {
+    return fields;
+  }
+  return {
+    ...fields,
+    valueNumeric: sole.valueNumeric ?? fields.valueNumeric ?? null,
+    valueText: sole.valueText ?? fields.valueText ?? null,
+    unit: sole.unit ?? fields.unit ?? null,
+    referenceRange: sole.referenceRange ?? fields.referenceRange ?? null,
+    isAbnormal:
+      typeof sole.isAbnormal === 'boolean'
+        ? sole.isAbnormal
+        : (fields.isAbnormal ?? null),
+    components: undefined,
+  };
+}

--- a/backend/src/complementary-exams/collapse-redundant-components.util.ts
+++ b/backend/src/complementary-exams/collapse-redundant-components.util.ts
@@ -14,29 +14,31 @@ export function extractParentheticalAliases(examName: string): string[] {
   let m: RegExpExecArray | null;
   while ((m = re.exec(examName)) !== null) {
     const inner = m[1].trim();
-    if (inner) aliases.push(inner);
+    if (inner) {aliases.push(inner);}
   }
   return aliases;
 }
 
 function parseComponents(raw: unknown): ExamResultComponentInput[] {
-  if (raw == null) return [];
+  if (raw === null || raw === undefined) {
+    return [];
+  }
   if (typeof raw === 'string') {
     const t = raw.trim();
-    if (!t) return [];
+    if (!t) {return [];}
     try {
       return parseComponents(JSON.parse(t) as unknown);
     } catch {
       return [];
     }
   }
-  if (!Array.isArray(raw)) return [];
+  if (!Array.isArray(raw)) {return [];}
   const out: ExamResultComponentInput[] = [];
   for (const el of raw) {
-    if (!el || typeof el !== 'object' || Array.isArray(el)) continue;
+    if (!el || typeof el !== 'object' || Array.isArray(el)) {continue;}
     const o = el as Record<string, unknown>;
     const nameRaw = o.name;
-    if (typeof nameRaw !== 'string' || !nameRaw.trim()) continue;
+    if (typeof nameRaw !== 'string' || !nameRaw.trim()) {continue;}
     const vn = o.valueNumeric ?? o.value_numeric;
     let valueNumeric: number | undefined;
     if (vn !== null && vn !== undefined && vn !== '') {
@@ -44,7 +46,7 @@ function parseComponents(raw: unknown): ExamResultComponentInput[] {
         valueNumeric = vn;
       } else {
         const n = Number(vn);
-        if (Number.isFinite(n)) valueNumeric = n;
+        if (Number.isFinite(n)) {valueNumeric = n;}
       }
     }
     const vt = o.valueText ?? o.value_text;
@@ -84,8 +86,8 @@ function resultHasMainValue(fields: {
   ) {
     return true;
   }
-  if ((fields.valueText ?? '').trim()) return true;
-  if ((fields.report ?? '').trim()) return true;
+  if ((fields.valueText ?? '').trim()) {return true;}
+  if ((fields.report ?? '').trim()) {return true;}
   return false;
 }
 
@@ -95,12 +97,12 @@ function componentNameMatchesExam(
 ): boolean {
   const examKey = normalizeExamLabelKey(examName);
   const compKey = normalizeExamLabelKey(componentName);
-  if (!examKey || !compKey) return false;
-  if (examKey === compKey) return true;
+  if (!examKey || !compKey) {return false;}
+  if (examKey === compKey) {return true;}
   for (const alias of extractParentheticalAliases(examName)) {
-    if (normalizeExamLabelKey(alias) === compKey) return true;
+    if (normalizeExamLabelKey(alias) === compKey) {return true;}
   }
-  if (examKey.includes(compKey) || compKey.includes(examKey)) return true;
+  if (examKey.includes(compKey) || compKey.includes(examKey)) {return true;}
   return false;
 }
 

--- a/backend/src/complementary-exams/complementary-exam-match.util.ts
+++ b/backend/src/complementary-exams/complementary-exam-match.util.ts
@@ -1,0 +1,180 @@
+import {
+  ComplementaryExamType,
+  Prisma,
+} from '@generated/prisma/client';
+import { normalizeExamLabelKey } from './collapse-redundant-components.util';
+
+const YMD_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+export type ComplementaryExamMatchBatchCache = Map<
+  string,
+  { id: string; name: string }
+>;
+
+export function buildComplementaryExamMatchKey(
+  type: string,
+  name: string,
+  code?: string | null,
+): string {
+  const codePart =
+    code === null || code === undefined || String(code).trim() === ''
+      ? ''
+      : normalizeExamLabelKey(String(code).trim());
+  return `${type}|${normalizeExamLabelKey(name)}|${codePart}`;
+}
+
+/**
+ * Data só com YYYY-MM-DD → início do dia UTC (00:00:00.000Z).
+ * ISO com hora → instante exato após parse.
+ */
+export function parseComplementaryPerformedAt(
+  raw: string | null | undefined,
+): Date | null {
+  if (raw === null || raw === undefined || String(raw).trim() === '') {
+    return null;
+  }
+  const s = String(raw).trim();
+  if (YMD_ONLY.test(s)) {
+    return new Date(`${s}T00:00:00.000Z`);
+  }
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) {
+    return null;
+  }
+  return d;
+}
+
+function examRowMatchesKey(
+  row: { type: ComplementaryExamType; name: string; code: string | null },
+  matchKey: string,
+): boolean {
+  return (
+    buildComplementaryExamMatchKey(row.type, row.name, row.code) === matchKey
+  );
+}
+
+export async function findOrCreateComplementaryExam(
+  tx: Prisma.TransactionClient,
+  args: {
+    tenantId: string;
+    patientId: string;
+    type: ComplementaryExamType;
+    name: string;
+    code?: string | null;
+    loincCode?: string | null;
+    batchCache?: ComplementaryExamMatchBatchCache;
+  },
+): Promise<{ id: string; created: boolean }> {
+  const { tenantId, patientId, type, name, code, loincCode, batchCache } = args;
+  const trimmedName = name.trim().slice(0, 400);
+  const trimmedCode =
+    code === null || code === undefined
+      ? null
+      : String(code).trim().slice(0, 64) || null;
+  const matchKey = buildComplementaryExamMatchKey(type, trimmedName, trimmedCode);
+
+  const cached = batchCache?.get(matchKey);
+  if (cached) {
+    return { id: cached.id, created: false };
+  }
+
+  const existingRows = await tx.complementaryExam.findMany({
+    where: { tenantId, patientId, type },
+    select: { id: true, name: true, code: true, type: true },
+  });
+  const found = existingRows.find((row) => examRowMatchesKey(row, matchKey));
+  if (found) {
+    batchCache?.set(matchKey, { id: found.id, name: found.name });
+    return { id: found.id, created: false };
+  }
+
+  const created = await tx.complementaryExam.create({
+    data: {
+      tenantId,
+      patientId,
+      type,
+      name: trimmedName,
+      code: trimmedCode,
+      loincCode:
+        loincCode === null || loincCode === undefined
+          ? null
+          : String(loincCode).trim().slice(0, 32) || null,
+    },
+  });
+  batchCache?.set(matchKey, { id: created.id, name: created.name });
+  return { id: created.id, created: true };
+}
+
+export type UpsertComplementaryExamResultPayload = {
+  valueNumeric?: number | null;
+  valueText?: string | null;
+  unit?: string | null;
+  referenceRange?: string | null;
+  isAbnormal?: boolean | null;
+  report?: string | null;
+  components?: Prisma.InputJsonValue | undefined;
+};
+
+export async function upsertComplementaryExamResult(
+  tx: Prisma.TransactionClient,
+  args: {
+    tenantId: string;
+    examId: string;
+    performedAt: Date;
+    collectionId?: string | null;
+    payload: UpsertComplementaryExamResultPayload;
+  },
+): Promise<{ id: string; created: boolean }> {
+  const { tenantId, examId, performedAt, collectionId, payload } = args;
+
+  const existing = await tx.complementaryExamResult.findFirst({
+    where: {
+      tenantId,
+      examId,
+      performedAt,
+      deletedAt: null,
+    },
+    select: { id: true },
+  });
+
+  const collection =
+    collectionId !== null &&
+    collectionId !== undefined &&
+    collectionId !== ''
+      ? { collectionId }
+      : {};
+
+  if (existing) {
+    const updated = await tx.complementaryExamResult.update({
+      where: { id: existing.id },
+      data: {
+        valueNumeric: payload.valueNumeric ?? null,
+        valueText: payload.valueText ?? null,
+        unit: payload.unit ?? null,
+        referenceRange: payload.referenceRange ?? null,
+        isAbnormal: payload.isAbnormal ?? null,
+        report: payload.report ?? null,
+        components: payload.components,
+        ...collection,
+      },
+    });
+    return { id: updated.id, created: false };
+  }
+
+  const created = await tx.complementaryExamResult.create({
+    data: {
+      tenantId,
+      examId,
+      performedAt,
+      ...collection,
+      valueNumeric: payload.valueNumeric ?? null,
+      valueText: payload.valueText ?? null,
+      unit: payload.unit ?? null,
+      referenceRange: payload.referenceRange ?? null,
+      isAbnormal: payload.isAbnormal ?? null,
+      report: payload.report ?? null,
+      components: payload.components,
+    },
+  });
+  return { id: created.id, created: true };
+}

--- a/frontend/src/components/patients/complementary-exam-chart-dialog.tsx
+++ b/frontend/src/components/patients/complementary-exam-chart-dialog.tsx
@@ -65,10 +65,14 @@ export function ComplementaryExamChartDialog({
   const chartData = React.useMemo(() => {
     if (needsSubitemPick) {
       if (!selectedSubitem.trim()) return [];
-      return buildComponentNumericChartPoints(exam.results, selectedSubitem);
+      return buildComponentNumericChartPoints(
+        exam.results,
+        selectedSubitem,
+        exam.name
+      );
     }
-    return buildParentNumericChartPoints(exam.results);
-  }, [exam.results, needsSubitemPick, selectedSubitem]);
+    return buildParentNumericChartPoints(exam.results, exam.name);
+  }, [exam.results, exam.name, needsSubitemPick, selectedSubitem]);
 
   const hasNumericSeries = chartData.length >= 1;
   const chartUnit = needsSubitemPick && selectedSubitem

--- a/frontend/src/components/patients/patient-clinical-tab.tsx
+++ b/frontend/src/components/patients/patient-clinical-tab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   PatientDetail,
   Comorbidity,
@@ -20,6 +20,10 @@ import { ComplementaryExamChartDialog } from './complementary-exam-chart-dialog'
 import { ComplementaryExamCreateDialog } from './complementary-exam-create-dialog';
 import { ComplementaryExamResultCreateDialog } from './complementary-exam-result-create-dialog';
 import { PatientSymptomTimeline } from './patient-symptom-timeline';
+import {
+  formatComplementaryResultPerformedAt,
+  groupComplementaryExamsByName,
+} from '@/lib/utils/complementary-exam-series';
 
 interface PatientClinicalTabProps {
   patient: PatientDetail;
@@ -69,11 +73,15 @@ export function PatientClinicalTab({
     null
   );
 
-  const complementaryExams: ComplementaryExam[] = Array.isArray(
-    patient.complementaryExams
-  )
-    ? patient.complementaryExams
-    : [];
+  const complementaryExams: ComplementaryExam[] = useMemo(
+    () =>
+      groupComplementaryExamsByName(
+        Array.isArray(patient.complementaryExams)
+          ? patient.complementaryExams
+          : []
+      ),
+    [patient.complementaryExams]
+  );
 
   const comorbidities: Comorbidity[] = Array.isArray(patient.comorbidities)
     ? patient.comorbidities
@@ -252,10 +260,9 @@ export function PatientClinicalTab({
                                   className="flex items-baseline justify-between gap-2 py-1 border-b border-border/50 last:border-0"
                                 >
                                   <span className="text-muted-foreground shrink-0">
-                                    {format(
-                                      new Date(r.performedAt),
-                                      'dd/MM/yyyy',
-                                      { locale: ptBR }
+                                    {formatComplementaryResultPerformedAt(
+                                      exam.results,
+                                      r.performedAt
                                     )}
                                   </span>
                                   <span className="text-right truncate min-w-0">

--- a/frontend/src/components/patients/patient-prontuario-lab-history.tsx
+++ b/frontend/src/components/patients/patient-prontuario-lab-history.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import React, { useMemo, useState } from 'react';
-import { format } from 'date-fns';
-import { ptBR } from 'date-fns/locale';
 import { ChevronDown, ChevronRight, LineChart as LineChartIcon } from 'lucide-react';
 import type {
   ComplementaryExam,
@@ -12,8 +10,9 @@ import type {
 import { Button } from '@/components/ui/button';
 import { ComplementaryExamChartDialog } from '@/components/patients/complementary-exam-chart-dialog';
 import {
-  filterActiveComplementaryResults,
-  normalizeComplementaryResultComponents,
+  collapseRedundantSingleComponent,
+  formatComplementaryResultPerformedAt,
+  groupComplementaryExamsByName,
 } from '@/lib/utils/complementary-exam-series';
 
 interface PatientProntuarioLabHistoryProps {
@@ -37,11 +36,10 @@ export function PatientProntuarioLabHistory({
     const raw = Array.isArray(patient.complementaryExams)
       ? patient.complementaryExams
       : [];
-    return raw
-      .filter((e) => e.type === 'LABORATORY')
+    return groupComplementaryExamsByName(raw.filter((e) => e.type === 'LABORATORY'))
       .map((e) => ({
         ...e,
-        results: filterActiveComplementaryResults(e.results).sort(
+        results: [...e.results].sort(
           (a, b) =>
             new Date(a.performedAt).getTime() - new Date(b.performedAt).getTime()
         ),
@@ -144,9 +142,8 @@ export function PatientProntuarioLabHistory({
                   </tr>
                 ) : (
                   exam.results.map((r) => {
-                    const comps = normalizeComplementaryResultComponents(
-                      r.components
-                    );
+                    const { result: displayResult, displayComponents: comps } =
+                      collapseRedundantSingleComponent(exam.name, r);
                     const hasChildren = comps.length > 0;
                     const isOpen = expandedIds.has(r.id);
                     const panelId = `lab-panel-${exam.id}-${r.id}`;
@@ -166,8 +163,8 @@ export function PatientProntuarioLabHistory({
                                 onClick={() => toggleExpanded(r.id)}
                                 aria-label={
                                   isOpen
-                                    ? `Recolher subitens da coleta de ${format(new Date(r.performedAt), 'dd/MM/yyyy', { locale: ptBR })}`
-                                    : `Expandir subitens da coleta de ${format(new Date(r.performedAt), 'dd/MM/yyyy', { locale: ptBR })}`
+                                    ? `Recolher subitens da coleta de ${formatComplementaryResultPerformedAt(exam.results, r.performedAt)}`
+                                    : `Expandir subitens da coleta de ${formatComplementaryResultPerformedAt(exam.results, r.performedAt)}`
                                 }
                               >
                                 {isOpen ? (
@@ -179,25 +176,26 @@ export function PatientProntuarioLabHistory({
                             ) : null}
                           </td>
                           <td className="sticky left-10 z-10 whitespace-nowrap border-b border-border/60 bg-background px-2 py-2 text-muted-foreground shadow-[1px_0_0_0_hsl(var(--border))] odd:bg-muted/30">
-                            {format(new Date(r.performedAt), 'dd/MM/yyyy', {
-                              locale: ptBR,
-                            })}
+                            {formatComplementaryResultPerformedAt(
+                              exam.results,
+                              r.performedAt
+                            )}
                           </td>
                           <td className="border-b border-border/60 px-2 py-2 font-medium">
-                            {formatResultMainValue(r)}
+                            {formatResultMainValue(displayResult)}
                           </td>
                           <td className="border-b border-border/60 px-2 py-2 text-muted-foreground">
-                            {r.unit ?? '—'}
+                            {displayResult.unit ?? '—'}
                           </td>
                           <td className="border-b border-border/60 px-2 py-2 text-muted-foreground">
-                            {r.referenceRange ?? '—'}
+                            {displayResult.referenceRange ?? '—'}
                           </td>
                           <td className="border-b border-border/60 px-2 py-2 text-xs">
                             {(() => {
                               const bits: string[] = [];
-                              if (r.criticalHigh) bits.push('Crítico alto');
-                              if (r.criticalLow) bits.push('Crítico baixo');
-                              if (r.isAbnormal) bits.push('Fora da ref.');
+                              if (displayResult.criticalHigh) bits.push('Crítico alto');
+                              if (displayResult.criticalLow) bits.push('Crítico baixo');
+                              if (displayResult.isAbnormal) bits.push('Fora da ref.');
                               if (bits.length === 0) {
                                 return <span className="text-muted-foreground">—</span>;
                               }

--- a/frontend/src/lib/utils/__tests__/complementary-exam-series.test.ts
+++ b/frontend/src/lib/utils/__tests__/complementary-exam-series.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildComponentNumericChartPoints,
+  buildComplementaryExamMatchKey,
   buildParentNumericChartPoints,
+  collapseRedundantSingleComponent,
   collectUniqueComponentNames,
+  dedupeResultsByPerformedInstant,
   examHasPanelComponents,
   filterActiveComplementaryResults,
   findComponentInResult,
+  formatComplementaryResultPerformedAt,
+  groupComplementaryExamsByName,
   guessComponentUnit,
   normalizeComplementaryResultComponents,
 } from '../complementary-exam-series';
@@ -28,6 +33,138 @@ const baseExam = (): ComplementaryExam => ({
 });
 
 describe('complementary-exam-series', () => {
+  it('buildComplementaryExamMatchKey normaliza nome e código', () => {
+    expect(
+      buildComplementaryExamMatchKey('LABORATORY', 'Hemoglobina', 'Hb')
+    ).toBe(buildComplementaryExamMatchKey('LABORATORY', 'hemoglobina', 'hb'));
+  });
+
+  it('dedupeResultsByPerformedInstant remove só mesmo ms', () => {
+    const t = '2025-03-10T08:00:00.000Z';
+    const rows = dedupeResultsByPerformedInstant([
+      {
+        id: 'a',
+        performedAt: t,
+        collectionId: null,
+        valueNumeric: 1,
+        valueText: null,
+        unit: null,
+        referenceRange: null,
+        isAbnormal: null,
+        criticalHigh: null,
+        criticalLow: null,
+        report: null,
+      },
+      {
+        id: 'b',
+        performedAt: t,
+        collectionId: null,
+        valueNumeric: 2,
+        valueText: null,
+        unit: null,
+        referenceRange: null,
+        isAbnormal: null,
+        criticalHigh: null,
+        criticalLow: null,
+        report: null,
+      },
+      {
+        id: 'c',
+        performedAt: '2025-03-10T18:00:00.000Z',
+        collectionId: null,
+        valueNumeric: 3,
+        valueText: null,
+        unit: null,
+        referenceRange: null,
+        isAbnormal: null,
+        criticalHigh: null,
+        criticalLow: null,
+        report: null,
+      },
+    ]);
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.id)).toEqual(['a', 'c']);
+  });
+
+  it('groupComplementaryExamsByName funde exames legados duplicados', () => {
+    const e1 = baseExam();
+    e1.id = 'legacy-1';
+    e1.name = 'Creatinina';
+    e1.results = [
+      {
+        id: 'r1',
+        performedAt: '2025-01-01T00:00:00.000Z',
+        collectionId: null,
+        valueNumeric: 1,
+        valueText: null,
+        unit: null,
+        referenceRange: null,
+        isAbnormal: null,
+        criticalHigh: null,
+        criticalLow: null,
+        report: null,
+      },
+    ];
+    const e2 = baseExam();
+    e2.id = 'legacy-2';
+    e2.name = 'creatinina';
+    e2.results = [
+      {
+        id: 'r2',
+        performedAt: '2025-02-01T00:00:00.000Z',
+        collectionId: null,
+        valueNumeric: 1.1,
+        valueText: null,
+        unit: null,
+        referenceRange: null,
+        isAbnormal: null,
+        criticalHigh: null,
+        criticalLow: null,
+        report: null,
+      },
+    ];
+    const grouped = groupComplementaryExamsByName([e1, e2]);
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0]?.results).toHaveLength(2);
+  });
+
+  it('formatComplementaryResultPerformedAt inclui hora se >1 no mesmo dia', () => {
+    const results = [
+      {
+        id: 'r1',
+        performedAt: '2025-03-10T08:00:00.000Z',
+        collectionId: null,
+        valueNumeric: 1,
+        valueText: null,
+        unit: null,
+        referenceRange: null,
+        isAbnormal: null,
+        criticalHigh: null,
+        criticalLow: null,
+        report: null,
+      },
+      {
+        id: 'r2',
+        performedAt: '2025-03-10T18:00:00.000Z',
+        collectionId: null,
+        valueNumeric: 2,
+        valueText: null,
+        unit: null,
+        referenceRange: null,
+        isAbnormal: null,
+        criticalHigh: null,
+        criticalLow: null,
+        report: null,
+      },
+    ];
+    expect(formatComplementaryResultPerformedAt(results, results[0]!.performedAt)).toBe(
+      '10/03/2025 08:00'
+    );
+    expect(formatComplementaryResultPerformedAt(results, '2025-04-01T00:00:00.000Z')).toBe(
+      '01/04/2025'
+    );
+  });
+
   it('normalizeComplementaryResultComponents aceita string JSON (hemograma-like)', () => {
     const json = JSON.stringify([
       { name: 'Hb', value_numeric: 12.5, unit: 'g/dL' },
@@ -187,8 +324,136 @@ describe('complementary-exam-series', () => {
       report: null,
       components: [{ name: '  ALT  ', valueNumeric: 42 }],
     };
-    expect(findComponentInResult(result, 'alt')?.valueNumeric).toBe(42);
-    expect(findComponentInResult(result, 'AST')).toBeUndefined();
+    expect(findComponentInResult('Painel', result, 'alt')?.valueNumeric).toBe(42);
+    expect(findComponentInResult('Painel', result, 'AST')).toBeUndefined();
+  });
+
+  it('collapseRedundantSingleComponent promove TTPa sinônimo para linha principal', () => {
+    const examName = 'Tempo de Tromboplastina Parcial Ativado (TTPa)';
+    const raw = {
+      id: 'r-ttpa',
+      performedAt: '2023-10-17T00:00:00.000Z',
+      collectionId: null,
+      valueNumeric: null,
+      valueText: null,
+      unit: null,
+      referenceRange: null,
+      isAbnormal: null,
+      criticalHigh: null,
+      criticalLow: null,
+      report: null,
+      components: [
+        {
+          name: 'TTPa',
+          valueNumeric: 28.7,
+          unit: 'seg',
+          referenceRange: '25,4 a 33,4',
+        },
+      ],
+    };
+    const { result, displayComponents } = collapseRedundantSingleComponent(
+      examName,
+      raw
+    );
+    expect(displayComponents).toHaveLength(0);
+    expect(result.valueNumeric).toBe(28.7);
+    expect(result.unit).toBe('seg');
+    expect(result.referenceRange).toBe('25,4 a 33,4');
+  });
+
+  it('collapseRedundantSingleComponent não colapsa hemograma com vários subitens', () => {
+    const raw = {
+      id: 'r-hem',
+      performedAt: '2024-01-01T00:00:00.000Z',
+      collectionId: null,
+      valueNumeric: null,
+      valueText: null,
+      unit: null,
+      referenceRange: null,
+      isAbnormal: null,
+      criticalHigh: null,
+      criticalLow: null,
+      report: null,
+      components: [
+        { name: 'Hb', valueNumeric: 13.2 },
+        { name: 'Leucócitos', valueNumeric: 8000 },
+      ],
+    };
+    const { displayComponents } = collapseRedundantSingleComponent(
+      'Hemograma completo',
+      raw
+    );
+    expect(displayComponents).toHaveLength(2);
+  });
+
+  it('collapseRedundantSingleComponent não colapsa quando pai já tem valor', () => {
+    const raw = {
+      id: 'r1',
+      performedAt: '2024-06-15T12:00:00.000Z',
+      collectionId: null,
+      valueNumeric: 14,
+      valueText: null,
+      unit: 'g/dL',
+      referenceRange: '12–16',
+      isAbnormal: null,
+      criticalHigh: null,
+      criticalLow: null,
+      report: null,
+      components: [{ name: 'ALT', valueNumeric: 45, unit: 'U/L' }],
+    };
+    const { result, displayComponents } = collapseRedundantSingleComponent(
+      'Hemograma',
+      raw
+    );
+    expect(result.valueNumeric).toBe(14);
+    expect(displayComponents).toHaveLength(1);
+  });
+
+  it('examHasPanelComponents false para exame simples com subitem sinônimo colapsável', () => {
+    const e = baseExam();
+    e.name = 'Tempo de Tromboplastina Parcial Ativado (TTPa)';
+    e.results = [
+      {
+        id: 'r-ttpa',
+        performedAt: '2023-10-17T00:00:00.000Z',
+        collectionId: null,
+        valueNumeric: null,
+        valueText: null,
+        unit: null,
+        referenceRange: null,
+        isAbnormal: null,
+        criticalHigh: null,
+        criticalLow: null,
+        report: null,
+        components: [{ name: 'TTPa', valueNumeric: 28.7, unit: 'seg' }],
+      },
+    ];
+    expect(examHasPanelComponents(e)).toBe(false);
+  });
+
+  it('buildParentNumericChartPoints usa valor colapsado de subitem sinônimo', () => {
+    const examName = 'Tempo de Tromboplastina Parcial Ativado (TTPa)';
+    const pts = buildParentNumericChartPoints(
+      [
+        {
+          id: 'r-ttpa',
+          performedAt: '2023-10-17T00:00:00.000Z',
+          collectionId: null,
+          valueNumeric: null,
+          valueText: null,
+          unit: null,
+          referenceRange: null,
+          isAbnormal: null,
+          criticalHigh: null,
+          criticalLow: null,
+          report: null,
+          components: [{ name: 'TTPa', valueNumeric: 28.7 }],
+        },
+      ],
+      examName
+    );
+    expect(pts).toHaveLength(1);
+    expect(pts[0]?.value).toBe(28.7);
   });
 
   it('guessComponentUnit prefere unit do componente; fallback exam.unit', () => {

--- a/frontend/src/lib/utils/complementary-exam-series.ts
+++ b/frontend/src/lib/utils/complementary-exam-series.ts
@@ -4,7 +4,95 @@ import type {
   ComplementaryExam,
   ComplementaryExamResult,
   ComplementaryExamResultComponent,
+  ComplementaryExamType,
 } from '@/lib/api/patients';
+
+export function buildComplementaryExamMatchKey(
+  type: ComplementaryExamType | string,
+  name: string,
+  code?: string | null
+): string {
+  const codePart =
+    code === null || code === undefined || String(code).trim() === ''
+      ? ''
+      : normalizeExamLabelKey(String(code).trim());
+  return `${type}|${normalizeExamLabelKey(name)}|${codePart}`;
+}
+
+/** Agrupa registros legados com o mesmo nome/tipo/código num único cabeçalho. */
+export function groupComplementaryExamsByName(
+  exams: ComplementaryExam[]
+): ComplementaryExam[] {
+  const groups = new Map<string, ComplementaryExam>();
+  for (const exam of exams) {
+    const key = buildComplementaryExamMatchKey(exam.type, exam.name, exam.code);
+    const active = dedupeResultsByPerformedInstant(
+      filterActiveComplementaryResults(exam.results)
+    );
+    const existing = groups.get(key);
+    if (!existing) {
+      groups.set(key, { ...exam, results: active });
+      continue;
+    }
+    const merged = dedupeResultsByPerformedInstant([
+      ...existing.results,
+      ...active,
+    ]).sort(
+      (a, b) =>
+        new Date(a.performedAt).getTime() - new Date(b.performedAt).getTime()
+    );
+    groups.set(key, { ...existing, results: merged });
+  }
+  return [...groups.values()];
+}
+
+/** Remove apenas resultados com o mesmo instante (ms) — não colapsa horários do mesmo dia. */
+export function dedupeResultsByPerformedInstant(
+  results: ComplementaryExamResult[]
+): ComplementaryExamResult[] {
+  const byInstant = new Map<number, ComplementaryExamResult>();
+  for (const r of results) {
+    const t = new Date(r.performedAt).getTime();
+    if (!byInstant.has(t)) {
+      byInstant.set(t, r);
+    }
+  }
+  return [...byInstant.values()];
+}
+
+function utcCalendarDayKey(d: Date): string {
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
+}
+
+function formatUtcDate(d: Date): string {
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  const month = String(d.getUTCMonth() + 1).padStart(2, '0');
+  return `${day}/${month}/${d.getUTCFullYear()}`;
+}
+
+function formatUtcDateTime(d: Date): string {
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  const month = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const hours = String(d.getUTCHours()).padStart(2, '0');
+  const minutes = String(d.getUTCMinutes()).padStart(2, '0');
+  return `${day}/${month}/${d.getUTCFullYear()} ${hours}:${minutes}`;
+}
+
+/** dd/MM/yyyy (UTC); se >1 resultado no mesmo dia calendário UTC, inclui HH:mm. */
+export function formatComplementaryResultPerformedAt(
+  allResultsInExam: ComplementaryExamResult[],
+  performedAt: string | Date
+): string {
+  const d = new Date(performedAt);
+  const dayKey = utcCalendarDayKey(d);
+  const sameDayCount = allResultsInExam.filter(
+    (r) => utcCalendarDayKey(new Date(r.performedAt)) === dayKey
+  ).length;
+  if (sameDayCount > 1) {
+    return formatUtcDateTime(d);
+  }
+  return formatUtcDate(d);
+}
 
 /**
  * Garante array de subitens a partir do JSON do backend/Prisma.
@@ -60,6 +148,80 @@ export function normalizeComplementaryResultComponents(
   return out;
 }
 
+/** Chave de comparação de rótulos (sem acentos, minúsculas, só alfanumérico). */
+export function normalizeExamLabelKey(name: string): string {
+  return name
+    .normalize('NFD')
+    .replace(/\p{M}/gu, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '');
+}
+
+/** Siglas/nomes entre parênteses no título do exame, ex.: "(TTPa)". */
+export function extractParentheticalAliases(examName: string): string[] {
+  const aliases: string[] = [];
+  const re = /\(([^)]+)\)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(examName)) !== null) {
+    const inner = m[1].trim();
+    if (inner) aliases.push(inner);
+  }
+  return aliases;
+}
+
+function resultHasMainValue(result: ComplementaryExamResult): boolean {
+  if (result.valueNumeric != null) return true;
+  const vt = (result.valueText ?? '').trim();
+  if (vt) return true;
+  const report = (result.report ?? '').trim();
+  if (report) return true;
+  return false;
+}
+
+function componentNameMatchesExam(examName: string, componentName: string): boolean {
+  const examKey = normalizeExamLabelKey(examName);
+  const compKey = normalizeExamLabelKey(componentName);
+  if (!examKey || !compKey) return false;
+  if (examKey === compKey) return true;
+  for (const alias of extractParentheticalAliases(examName)) {
+    if (normalizeExamLabelKey(alias) === compKey) return true;
+  }
+  if (examKey.includes(compKey) || compKey.includes(examKey)) return true;
+  return false;
+}
+
+/**
+ * Quando há um único subitem sinônimo do exame e o pai está vazio, promove o valor
+ * para a linha principal (ex.: TTPa dentro de "Tempo de Tromboplastina... (TTPa)").
+ */
+export function collapseRedundantSingleComponent(
+  examName: string,
+  result: ComplementaryExamResult
+): {
+  result: ComplementaryExamResult;
+  displayComponents: ComplementaryExamResultComponent[];
+} {
+  const comps = normalizeComplementaryResultComponents(result.components);
+  if (comps.length !== 1 || resultHasMainValue(result)) {
+    return { result, displayComponents: comps };
+  }
+  const sole = comps[0];
+  if (!sole.name?.trim() || !componentNameMatchesExam(examName, sole.name)) {
+    return { result, displayComponents: comps };
+  }
+  return {
+    result: {
+      ...result,
+      valueNumeric: sole.valueNumeric ?? result.valueNumeric,
+      valueText: sole.valueText ?? result.valueText,
+      unit: sole.unit ?? result.unit,
+      referenceRange: sole.referenceRange ?? result.referenceRange,
+      isAbnormal: sole.isAbnormal ?? result.isAbnormal,
+    },
+    displayComponents: [],
+  };
+}
+
 export interface ComplementaryExamChartPoint {
   date: string;
   dateSort: number;
@@ -73,16 +235,18 @@ export function filterActiveComplementaryResults(
 }
 
 export function examHasPanelComponents(exam: ComplementaryExam): boolean {
-  return exam.results.some(
-    (r) => normalizeComplementaryResultComponents(r.components).length > 0
-  );
+  return exam.results.some((r) => {
+    const { displayComponents } = collapseRedundantSingleComponent(exam.name, r);
+    return displayComponents.length > 0;
+  });
 }
 
 /** Nomes únicos estáveis (chave case-insensitive, rótulo preserva primeira grafia vista). */
 export function collectUniqueComponentNames(exam: ComplementaryExam): string[] {
   const byKey = new Map<string, string>();
   for (const r of exam.results) {
-    for (const c of normalizeComplementaryResultComponents(r.components)) {
+    const { displayComponents } = collapseRedundantSingleComponent(exam.name, r);
+    for (const c of displayComponents) {
       const raw = c.name?.trim();
       if (!raw) continue;
       const key = raw.toLowerCase();
@@ -93,19 +257,25 @@ export function collectUniqueComponentNames(exam: ComplementaryExam): string[] {
 }
 
 export function findComponentInResult(
+  examName: string,
   result: ComplementaryExamResult,
   componentDisplayName: string
 ): ComplementaryExamResultComponent | undefined {
   const want = componentDisplayName.trim().toLowerCase();
-  return normalizeComplementaryResultComponents(result.components).find(
+  const { displayComponents } = collapseRedundantSingleComponent(examName, result);
+  return displayComponents.find(
     (c) => c.name && c.name.trim().toLowerCase() === want
   );
 }
 
 export function buildParentNumericChartPoints(
-  results: ComplementaryExamResult[]
+  results: ComplementaryExamResult[],
+  examName?: string
 ): ComplementaryExamChartPoint[] {
   return results
+    .map((r) =>
+      examName ? collapseRedundantSingleComponent(examName, r).result : r
+    )
     .filter((r) => r.valueNumeric != null)
     .map((r) => ({
       date: format(new Date(r.performedAt), 'dd/MM/yyyy', { locale: ptBR }),
@@ -117,12 +287,18 @@ export function buildParentNumericChartPoints(
 
 export function buildComponentNumericChartPoints(
   results: ComplementaryExamResult[],
-  componentDisplayName: string
+  componentDisplayName: string,
+  examName?: string
 ): ComplementaryExamChartPoint[] {
   const want = componentDisplayName.trim().toLowerCase();
   return results
     .map((r) => {
-      const c = normalizeComplementaryResultComponents(r.components).find(
+      const { displayComponents } = examName
+        ? collapseRedundantSingleComponent(examName, r)
+        : {
+            displayComponents: normalizeComplementaryResultComponents(r.components),
+          };
+      const c = displayComponents.find(
         (x) => x.name && x.name.trim().toLowerCase() === want
       );
       return {
@@ -142,7 +318,8 @@ export function guessComponentUnit(
 ): string | null {
   const want = componentDisplayName.trim().toLowerCase();
   for (const r of exam.results) {
-    const c = normalizeComplementaryResultComponents(r.components).find(
+    const { displayComponents } = collapseRedundantSingleComponent(exam.name, r);
+    const c = displayComponents.find(
       (x) => x.name && x.name.trim().toLowerCase() === want
     );
     if (c?.unit?.trim()) return c.unit.trim();


### PR DESCRIPTION
## Summary
- Ingestão (evolução + exam-ingest): find-or-create de `ComplementaryExam` por chave nome/tipo/código; upsert de resultado por `performedAt` exato (reingestão no mesmo instante atualiza em vez de duplicar).
- Datas só `YYYY-MM-DD` passam a `00:00:00.000Z`; horários diferentes no mesmo dia geram resultados separados.
- UI: agrupa exames legados com o mesmo nome num cabeçalho; formata data com hora quando há >1 resultado no mesmo dia (UTC).

## Test plan
- [x] `cd backend && npm test -- apply-complementary-exams exam-ingest.service.spec`
- [x] `cd frontend && npm test -- complementary-exam-series`
- [ ] Reingestão manual do mesmo exame/data no exam-ingest
- [ ] Verificar prontuário laboratorial e aba clínica com paciente que tinha duplicatas legadas


Made with [Cursor](https://cursor.com)