### PR TITLE
feat(clinical-orders): catálogos de exame/medicamento e histórico de prescrição

### DIFF
--- a/ai-service/.env.example
+++ b/ai-service/.env.example
@@ -25,6 +25,7 @@ RAG_SCORE_THRESHOLD=0.30
 
 # Modelos de chat LLM (opcional; vazios = inferir provedor pelas chaves e modelos padrão por provedor)
 # LLM_DEFAULT_PROVIDER=anthropic|openai  (vazio = preferir anthropic se ANTHROPIC_API_KEY existir)
+# Se Anthropic estiver sem créditos e OpenAI ativa: LLM_DEFAULT_PROVIDER=openai
 # LLM_DEFAULT_MODEL=  (vazio = claude-haiku-4-5 ou gpt-4o-mini conforme o provedor)
 # LLM_FALLBACK_PROVIDER=
 # LLM_FALLBACK_MODEL=

--- a/ai-service/src/agent/llm_provider.py
+++ b/ai-service/src/agent/llm_provider.py
@@ -70,6 +70,10 @@ def is_anthropic_openai_fallback_eligible(exc: BaseException) -> bool:
         blob = f"{exc} {_anthropic_error_body_blob(getattr(exc, 'body', None))}".lower()
         if "insufficient_quota" in blob:
             return True
+        if any(k in blob for k in _BILLING_QUOTA_KEYWORDS):
+            # Anthropic may return 400 invalid_request_error when credits are depleted.
+            if code in (400, 402, 403, 429):
+                return True
         if code == 403 and isinstance(exc, PermissionDeniedError):
             if err_type == "billing_error":
                 return True
@@ -739,6 +743,48 @@ class LLMProvider:
         except Exception as e:
             logger.error("exam_extract LLM failed: %s", e, exc_info=True)
             text_out = ""
+            if is_anthropic_openai_fallback_eligible(e) and self._get_openai_client(
+                cfg.get("openai_api_key")
+            ):
+                logger.warning(
+                    "exam_extract: outer failure; falling back to OpenAI: %s",
+                    e,
+                )
+                try:
+                    text_out = await self._exam_extract_via_openai(
+                        cfg,
+                        system_prompt=system_prompt,
+                        openai_user_content=openai_user_content,
+                        user_text_instruction=user_text_instruction,
+                    )
+                except Exception as oae:
+                    logger.error(
+                        "exam_extract OpenAI fallback failed: %s",
+                        oae,
+                        exc_info=True,
+                    )
+                    text_out = ""
+
+        if not (text_out or "").strip() and self._get_openai_client(
+            cfg.get("openai_api_key")
+        ):
+            logger.warning(
+                "exam_extract: empty output after primary path; attempting OpenAI"
+            )
+            try:
+                text_out = await self._exam_extract_via_openai(
+                    cfg,
+                    system_prompt=system_prompt,
+                    openai_user_content=openai_user_content,
+                    user_text_instruction=user_text_instruction,
+                )
+            except Exception as oae:
+                logger.error(
+                    "exam_extract OpenAI last-resort failed: %s",
+                    oae,
+                    exc_info=True,
+                )
+                text_out = ""
 
         parsed = self._parse_exam_extract_json(text_out)
         if parsed:

--- a/ai-service/src/agent/prompts/exam_extract_prompt.py
+++ b/ai-service/src/agent/prompts/exam_extract_prompt.py
@@ -20,12 +20,18 @@ Responda APENAS com um único objeto JSON (sem markdown fences, sem texto antes 
   "disclaimer" (string curta em PT-BR lembrando que o conteúdo foi gerado por IA e deve ser validado pelo profissional),
   "complementary_exams" (lista opcional; omita a chave ou use [] se não houver linhas estruturáveis). Cada elemento é um objeto com:
     - "type": um de LABORATORY, IMAGING, ANATOMOPATHOLOGICAL, IMMUNOHISTOCHEMICAL (alinhado ao cadastro de exames complementares),
-    - "name": nome curto do exame (obrigatório),
+    - "name": nome curto do exame (obrigatório; preferir rótulos do catálogo, ex.: "Creatinina", "Vitamina D 25(OH)D"),
     - "code": código/sigla interna (opcional),
     - "loinc_code": código LOINC (opcional),
     - "result" (opcional): objeto com campos apenas se constarem no material —
         "performed_at" (ISO ou data do laudo), "value_numeric", "value_text", "unit", "reference_range",
-        "is_abnormal" (boolean), "report" (laudo/impressão), "components" (lista JSON de sub-itens, hemograma, etc.).
+        "is_abnormal" (boolean), "report" (laudo/impressão), "components" (lista JSON de sub-itens de painéis compostos).
+
+Regra para exames com um único parâmetro (ex.: TTPa, creatinina, glicemia): preencha "value_numeric", "unit" e "reference_range"
+no objeto "result" e **não** use "components". Reserve "components" apenas para painéis com dois ou mais
+parâmetros distintos (hemograma, perfil lipídico, função hepática, etc.). Não repita no "components" a sigla
+ou sinônimo que já está no "name" do exame (ex.: name "Tempo de Tromboplastina Parcial Ativado (TTPa)" → valor
+no result, sem subitem "TTPa").
 
 Não invente tipos nem resultados fora do material; omita itens que não possa estruturar com segurança.
 

--- a/ai-service/tests/agent/test_llm_provider.py
+++ b/ai-service/tests/agent/test_llm_provider.py
@@ -201,6 +201,70 @@ class TestAnthropicOpenaiFallbackEligible:
         e = _anthropic_http_exc(400, body=body, cls=BadRequestError)
         assert is_anthropic_openai_fallback_eligible(e) is False
 
+    def test_400_credit_balance_true(self):
+        body = {
+            "error": {
+                "type": "invalid_request_error",
+                "message": "Your credit balance is too low to access the Anthropic API.",
+            }
+        }
+        e = _anthropic_http_exc(400, body=body, cls=BadRequestError)
+        assert is_anthropic_openai_fallback_eligible(e) is True
+
+
+class TestExamExtractAnthropicToOpenaiFallback:
+
+    _EXAM_JSON = (
+        '{"markdownSummary":"## Laboratorial\\nHb 12","detectedCategories":["LAB"],'
+        '"disclaimer":"Validar com original."}'
+    )
+
+    @pytest.mark.asyncio
+    async def test_exam_extract_falls_back_on_anthropic_400_credit(
+        self, provider, monkeypatch
+    ):
+        async def boom_create(*a, **k):
+            raise _anthropic_http_exc(
+                400,
+                body={
+                    "error": {
+                        "type": "invalid_request_error",
+                        "message": "Your credit balance is too low to access the Anthropic API.",
+                    }
+                },
+                cls=BadRequestError,
+            )
+
+        mock_client = SimpleNamespace(
+            messages=SimpleNamespace(create=boom_create),
+        )
+        called = {"openai": 0}
+
+        async def ok_openai(*a, **k):
+            called["openai"] += 1
+            return TestExamExtractAnthropicToOpenaiFallback._EXAM_JSON
+
+        monkeypatch.setattr(provider, "has_anthropic_key", lambda cfg: True)
+        monkeypatch.setattr(provider, "has_any_llm_key", lambda cfg: True)
+        monkeypatch.setattr(provider, "_get_anthropic_client", lambda key: mock_client)
+        monkeypatch.setattr(provider, "_get_openai_client", lambda key: object())
+        monkeypatch.setattr(provider, "_exam_extract_via_openai", ok_openai)
+
+        out = await provider.generate_exam_extract_structured(
+            system_prompt="sys",
+            user_text_instruction="Hemograma",
+            anthropic_user_blocks=[{"type": "text", "text": "x"}],
+            openai_user_content=[{"type": "text", "text": "x"}],
+            config={
+                "llm_provider": "anthropic",
+                "anthropic_api_key": "sk-ant-test",
+                "openai_api_key": "sk-oai-test",
+            },
+        )
+        assert called["openai"] >= 1
+        assert out["markdownFromStructuredParse"] is True
+        assert "Hb 12" in out["markdownSummary"]
+
 
 class TestOpenaiFallbackChatModel:
 

--- a/backend/prisma/medication-catalog-seed-data.ts
+++ b/backend/prisma/medication-catalog-seed-data.ts
@@ -1,0 +1,305 @@
+import { MedicationCategory } from '@generated/prisma/client';
+
+export type MedicationCatalogSeedDrug = {
+  code: string;
+  genericName: string;
+  displayName: string;
+  category: MedicationCategory;
+  allowedRoutes: string[];
+  presentations: Array<{
+    code: string;
+    label: string;
+    strength?: string;
+    form?: string;
+  }>;
+};
+
+const VO_IV_SC = ['VO', 'IV', 'SC'];
+const VO_ONLY = ['VO'];
+const VO_SC = ['VO', 'SC'];
+const SC = ['SC'];
+const IV = ['IV'];
+
+/** ~25 fármacos do catálogo clínico legado, com 1–3 apresentações cada. */
+export const MEDICATION_CATALOG_SEED_ROWS: MedicationCatalogSeedDrug[] = [
+  {
+    code: 'WARFARIN',
+    genericName: 'Varfarina',
+    displayName: 'Varfarina',
+    category: MedicationCategory.ANTICOAGULANT,
+    allowedRoutes: VO_ONLY,
+    presentations: [
+      { code: 'WARFARIN_5MG_CP', label: 'Varfarina 5 mg', strength: '5 mg', form: 'comprimido' },
+      { code: 'WARFARIN_2_5MG_CP', label: 'Varfarina 2,5 mg', strength: '2,5 mg', form: 'comprimido' },
+    ],
+  },
+  {
+    code: 'RIVAROXABAN',
+    genericName: 'Rivaroxabana',
+    displayName: 'Rivaroxabana',
+    category: MedicationCategory.ANTICOAGULANT,
+    allowedRoutes: VO_ONLY,
+    presentations: [
+      { code: 'RIVAROXABAN_20MG_CP', label: 'Rivaroxabana 20 mg', strength: '20 mg', form: 'comprimido' },
+      { code: 'RIVAROXABAN_15MG_CP', label: 'Rivaroxabana 15 mg', strength: '15 mg', form: 'comprimido' },
+    ],
+  },
+  {
+    code: 'APIXABAN',
+    genericName: 'Apixabana',
+    displayName: 'Apixabana',
+    category: MedicationCategory.ANTICOAGULANT,
+    allowedRoutes: VO_ONLY,
+    presentations: [
+      { code: 'APIXABAN_5MG_CP', label: 'Apixabana 5 mg', strength: '5 mg', form: 'comprimido' },
+    ],
+  },
+  {
+    code: 'ENOXAPARIN',
+    genericName: 'Enoxaparina',
+    displayName: 'Enoxaparina',
+    category: MedicationCategory.ANTICOAGULANT,
+    allowedRoutes: SC,
+    presentations: [
+      { code: 'ENOXAPARIN_40MG_SC', label: 'Enoxaparina 40 mg/0,4 mL', strength: '40 mg', form: 'seringa SC' },
+      { code: 'ENOXAPARIN_60MG_SC', label: 'Enoxaparina 60 mg/0,6 mL', strength: '60 mg', form: 'seringa SC' },
+    ],
+  },
+  {
+    code: 'ASPIRIN_LOW',
+    genericName: 'Ácido acetilsalicílico',
+    displayName: 'AAS (antiagregante)',
+    category: MedicationCategory.ANTIPLATELET,
+    allowedRoutes: VO_ONLY,
+    presentations: [
+      { code: 'ASPIRIN_100MG_CP', label: 'AAS 100 mg', strength: '100 mg', form: 'comprimido' },
+    ],
+  },
+  {
+    code: 'CLOPIDOGREL',
+    genericName: 'Clopidogrel',
+    displayName: 'Clopidogrel',
+    category: MedicationCategory.ANTIPLATELET,
+    allowedRoutes: VO_ONLY,
+    presentations: [
+      { code: 'CLOPIDOGREL_75MG_CP', label: 'Clopidogrel 75 mg', strength: '75 mg', form: 'comprimido' },
+    ],
+  },
+  {
+    code: 'PREDNISONE',
+    genericName: 'Prednisona',
+    displayName: 'Prednisona',
+    category: MedicationCategory.CORTICOSTEROID,
+    allowedRoutes: VO_ONLY,
+    presentations: [
+      { code: 'PREDNISONE_20MG_CP', label: 'Prednisona 20 mg', strength: '20 mg', form: 'comprimido' },
+      { code: 'PREDNISONE_5MG_CP', label: 'Prednisona 5 mg', strength: '5 mg', form: 'comprimido' },
+    ],
+  },
+  {
+    code: 'DEXAMETHASONE',
+    genericName: 'Dexametasona',
+    displayName: 'Dexametasona',
+    category: MedicationCategory.CORTICOSTEROID,
+    allowedRoutes: [...VO_IV_SC],
+    presentations: [
+      { code: 'DEXAMETHASONE_4MG_CP', label: 'Dexametasona 4 mg', strength: '4 mg', form: 'comprimido' },
+      { code: 'DEXAMETHASONE_4MG_IV', label: 'Dexametasona 4 mg/1 mL', strength: '4 mg', form: 'ampola IV' },
+    ],
+  },
+  {
+    code: 'MORPHINE',
+    genericName: 'Morfina',
+    displayName: 'Morfina',
+    category: MedicationCategory.OPIOID_ANALGESIC,
+    allowedRoutes: [...VO_IV_SC],
+    presentations: [
+      { code: 'MORPHINE_10MG_CP', label: 'Morfina 10 mg', strength: '10 mg', form: 'comprimido' },
+      { code: 'MORPHINE_10MG_ML_IV', label: 'Morfina 10 mg/mL', strength: '10 mg/mL', form: 'ampola' },
+    ],
+  },
+  {
+    code: 'OXYCODONE',
+    genericName: 'Oxicodona',
+    displayName: 'Oxicodona',
+    category: MedicationCategory.OPIOID_ANALGESIC,
+    allowedRoutes: VO_ONLY,
+    presentations: [
+      { code: 'OXYCODONE_5MG_CP', label: 'Oxicodona 5 mg', strength: '5 mg', form: 'comprimido' },
+    ],
+  },
+  {
+    code: 'TRAMADOL',
+    genericName: 'Tramadol',
+    displayName: 'Tramadol',
+    category: MedicationCategory.OPIOID_ANALGESIC,
+    allowedRoutes: VO_ONLY,
+    presentations: [
+      { code: 'TRAMADOL_50MG_CP', label: 'Tramadol 50 mg', strength: '50 mg', form: 'cápsula' },
+    ],
+  },
+  {
+    code: 'DIPYRONE',
+    genericName: 'Dipirona',
+    displayName: 'Dipirona',
+    category: MedicationCategory.NON_OPIOID_ANALGESIC,
+    allowedRoutes: [...VO_IV_SC],
+    presentations: [
+      { code: 'DIPYRONE_500MG_CP', label: 'Dipirona 500 mg', strength: '500 mg', form: 'comprimido' },
+      { code: 'DIPYRONE_1G_IV', label: 'Dipirona 1 g/2 mL', strength: '1 g', form: 'ampola IV' },
+    ],
+  },
+  {
+    code: 'PARACETAMOL',
+    genericName: 'Paracetamol',
+    displayName: 'Paracetamol',
+    category: MedicationCategory.NON_OPIOID_ANALGESIC,
+    allowedRoutes: VO_ONLY,
+    presentations: [
+      { code: 'PARACETAMOL_750MG_CP', label: 'Paracetamol 750 mg', strength: '750 mg', form: 'comprimido' },
+    ],
+  },
+  {
+    code: 'IBUPROFEN',
+    genericName: 'Ibuprofeno',
+    displayName: 'Ibuprofeno',
+    category: MedicationCategory.NSAID,
+    allowedRoutes: VO_ONLY,
+    presentations: [
+      { code: 'IBUPROFEN_600MG_CP', label: 'Ibuprofeno 600 mg', strength: '600 mg', form: 'comprimido' },
+    ],
+  },
+  {
+    code: 'NAPROXEN',
+    genericName: 'Naproxeno',
+    displayName: 'Naproxeno',
+    category: MedicationCategory.NSAID,
+    allowedRoutes: VO_ONLY,
+    presentations: [
+      { code: 'NAPROXEN_500MG_CP', label: 'Naproxeno 500 mg', strength: '500 mg', form: 'comprimido' },
+    ],
+  },
+  {
+    code: 'METFORMIN',
+    genericName: 'Metformina',
+    displayName: 'Metformina',
+    category: MedicationCategory.ANTIDIABETIC,
+    allowedRoutes: VO_ONLY,
+    presentations: [
+      { code: 'METFORMIN_850MG_CP', label: 'Metformina 850 mg', strength: '850 mg', form: 'comprimido' },
+    ],
+  },
+  {
+    code: 'INSULIN',
+    genericName: 'Insulina',
+    displayName: 'Insulina',
+    category: MedicationCategory.ANTIDIABETIC,
+    allowedRoutes: SC,
+    presentations: [
+      { code: 'INSULIN_NPH_SC', label: 'Insulina NPH', form: 'caneta/seringa SC' },
+      { code: 'INSULIN_REG_SC', label: 'Insulina regular', form: 'caneta/seringa SC' },
+    ],
+  },
+  {
+    code: 'LOSARTAN',
+    genericName: 'Losartana',
+    displayName: 'Losartana',
+    category: MedicationCategory.ANTIHYPERTENSIVE,
+    allowedRoutes: VO_ONLY,
+    presentations: [
+      { code: 'LOSARTAN_50MG_CP', label: 'Losartana 50 mg', strength: '50 mg', form: 'comprimido' },
+    ],
+  },
+  {
+    code: 'ENALAPRIL',
+    genericName: 'Enalapril',
+    displayName: 'Enalapril',
+    category: MedicationCategory.ANTIHYPERTENSIVE,
+    allowedRoutes: VO_ONLY,
+    presentations: [
+      { code: 'ENALAPRIL_10MG_CP', label: 'Enalapril 10 mg', strength: '10 mg', form: 'comprimido' },
+    ],
+  },
+  {
+    code: 'AMLODIPINE',
+    genericName: 'Anlodipino',
+    displayName: 'Anlodipino',
+    category: MedicationCategory.ANTIHYPERTENSIVE,
+    allowedRoutes: VO_ONLY,
+    presentations: [
+      { code: 'AMLODIPINE_5MG_CP', label: 'Anlodipino 5 mg', strength: '5 mg', form: 'comprimido' },
+    ],
+  },
+  {
+    code: 'OMEPRAZOLE',
+    genericName: 'Omeprazol',
+    displayName: 'Omeprazol',
+    category: MedicationCategory.PROTON_PUMP_INHIBITOR,
+    allowedRoutes: VO_ONLY,
+    presentations: [
+      { code: 'OMEPRAZOLE_20MG_CP', label: 'Omeprazol 20 mg', strength: '20 mg', form: 'cápsula' },
+    ],
+  },
+  {
+    code: 'ONDANSETRON',
+    genericName: 'Ondansetrona',
+    displayName: 'Ondansetrona',
+    category: MedicationCategory.ANTIEMETIC,
+    allowedRoutes: [...VO_IV_SC],
+    presentations: [
+      { code: 'ONDANSETRON_8MG_CP', label: 'Ondansetrona 8 mg', strength: '8 mg', form: 'comprimido' },
+      { code: 'ONDANSETRON_4MG_IV', label: 'Ondansetrona 4 mg/2 mL', strength: '4 mg', form: 'ampola IV' },
+    ],
+  },
+  {
+    code: 'FILGRASTIM',
+    genericName: 'Filgrastim',
+    displayName: 'Filgrastim (G-CSF)',
+    category: MedicationCategory.GROWTH_FACTOR,
+    allowedRoutes: SC,
+    presentations: [
+      { code: 'FILGRASTIM_300MCG_SC', label: 'Filgrastim 300 mcg', strength: '300 mcg', form: 'seringa SC' },
+    ],
+  },
+  {
+    code: 'CICLOSPORIN',
+    genericName: 'Ciclosporina',
+    displayName: 'Ciclosporina',
+    category: MedicationCategory.IMMUNOSUPPRESSANT,
+    allowedRoutes: VO_ONLY,
+    presentations: [
+      { code: 'CICLOSPORIN_25MG_CP', label: 'Ciclosporina 25 mg', strength: '25 mg', form: 'cápsula' },
+    ],
+  },
+  {
+    code: 'TACROLIMUS',
+    genericName: 'Tacrolimo',
+    displayName: 'Tacrolimo',
+    category: MedicationCategory.IMMUNOSUPPRESSANT,
+    allowedRoutes: VO_ONLY,
+    presentations: [
+      { code: 'TACROLIMUS_1MG_CP', label: 'Tacrolimo 1 mg', strength: '1 mg', form: 'cápsula' },
+    ],
+  },
+  {
+    code: 'MEROPENEM',
+    genericName: 'Meropenem',
+    displayName: 'Meropenem',
+    category: MedicationCategory.ANTIBIOTIC,
+    allowedRoutes: IV,
+    presentations: [
+      { code: 'MEROPENEM_1G_IV', label: 'Meropenem 1 g', strength: '1 g', form: 'frasco IV' },
+    ],
+  },
+  {
+    code: 'FLUCONAZOLE',
+    genericName: 'Fluconazol',
+    displayName: 'Fluconazol',
+    category: MedicationCategory.ANTIFUNGAL,
+    allowedRoutes: [...VO_IV_SC],
+    presentations: [
+      { code: 'FLUCONAZOLE_150MG_CP', label: 'Fluconazol 150 mg', strength: '150 mg', form: 'cápsula' },
+      { code: 'FLUCONAZOLE_200MG_IV', label: 'Fluconazol 200 mg/100 mL', strength: '200 mg', form: 'bolsa IV' },
+    ],
+  },
+];

--- a/backend/prisma/medication-catalog-seed-data.ts
+++ b/backend/prisma/medication-catalog-seed-data.ts
@@ -16,7 +16,6 @@ export type MedicationCatalogSeedDrug = {
 
 const VO_IV_SC = ['VO', 'IV', 'SC'];
 const VO_ONLY = ['VO'];
-const VO_SC = ['VO', 'SC'];
 const SC = ['SC'];
 const IV = ['IV'];
 

--- a/backend/prisma/migrations/20260516215049_add_medication_catalog_and_rx_presentation/migration.sql
+++ b/backend/prisma/migrations/20260516215049_add_medication_catalog_and_rx_presentation/migration.sql
@@ -1,0 +1,50 @@
+-- AlterTable
+ALTER TABLE "clinical_prescription_lines" ADD COLUMN     "presentationCatalogCode" TEXT;
+
+-- CreateTable
+CREATE TABLE "medication_catalog_drugs" (
+    "id" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "genericName" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "category" "MedicationCategory",
+    "allowedRoutes" TEXT[],
+    "sourceVersion" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "medication_catalog_drugs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "medication_catalog_presentations" (
+    "id" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "drugCode" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "strength" TEXT,
+    "form" TEXT,
+    "sourceVersion" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "medication_catalog_presentations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "medication_catalog_drugs_code_key" ON "medication_catalog_drugs"("code");
+
+-- CreateIndex
+CREATE INDEX "medication_catalog_drugs_displayName_idx" ON "medication_catalog_drugs"("displayName");
+
+-- CreateIndex
+CREATE INDEX "medication_catalog_drugs_genericName_idx" ON "medication_catalog_drugs"("genericName");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "medication_catalog_presentations_code_key" ON "medication_catalog_presentations"("code");
+
+-- CreateIndex
+CREATE INDEX "medication_catalog_presentations_drugCode_idx" ON "medication_catalog_presentations"("drugCode");
+
+-- AddForeignKey
+ALTER TABLE "medication_catalog_presentations" ADD CONSTRAINT "medication_catalog_presentations_drugCode_fkey" FOREIGN KEY ("drugCode") REFERENCES "medication_catalog_drugs"("code") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -430,7 +430,8 @@ model ClinicalPrescriptionLine {
 
   prescribedById String
   medicationName String
-  catalogKey     String?
+  catalogKey              String?
+  presentationCatalogCode String?
   dosage         String?
   frequency      String?
   route          String?
@@ -1764,6 +1765,42 @@ model ExamCatalogItem {
   @@index([type])
   @@index([name])
   @@map("exam_catalog_items")
+}
+
+// Catálogo global de medicamentos (genérico + apresentações) — sem tenant.
+model MedicationCatalogDrug {
+  id            String              @id @default(uuid())
+  code          String              @unique
+  genericName   String
+  displayName   String
+  category      MedicationCategory?
+  allowedRoutes String[]
+  sourceVersion String?
+  createdAt     DateTime            @default(now())
+  updatedAt     DateTime            @updatedAt
+
+  presentations MedicationCatalogPresentation[]
+
+  @@index([displayName])
+  @@index([genericName])
+  @@map("medication_catalog_drugs")
+}
+
+model MedicationCatalogPresentation {
+  id            String   @id @default(uuid())
+  code          String   @unique
+  drugCode      String
+  label         String
+  strength      String?
+  form          String?
+  sourceVersion String?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  drug MedicationCatalogDrug @relation(fields: [drugCode], references: [code], onDelete: Cascade)
+
+  @@index([drugCode])
+  @@map("medication_catalog_presentations")
 }
 
 // Histórico de Intervenções (rastreabilidade de ações do enfermeiro)

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -3,6 +3,7 @@ import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from '@generated/prisma/client';
 import * as bcrypt from 'bcrypt';
 import { EXAM_CATALOG_SEED_ROWS } from './exam-catalog-seed-data';
+import { MEDICATION_CATALOG_SEED_ROWS } from './medication-catalog-seed-data';
 
 const connectionString = `${process.env.DATABASE_URL}`;
 
@@ -1894,6 +1895,52 @@ async function main() {
   }
   console.log(
     `✅ Catálogo de exames (exam_catalog_items): ${examCatalogUpserts} itens (upsert)`,
+  );
+
+  let medicationDrugUpserts = 0;
+  let medicationPresentationUpserts = 0;
+  for (const row of MEDICATION_CATALOG_SEED_ROWS) {
+    await prisma.medicationCatalogDrug.upsert({
+      where: { code: row.code },
+      create: {
+        code: row.code,
+        genericName: row.genericName,
+        displayName: row.displayName,
+        category: row.category,
+        allowedRoutes: row.allowedRoutes,
+        sourceVersion: 'prisma-seed',
+      },
+      update: {
+        genericName: row.genericName,
+        displayName: row.displayName,
+        category: row.category,
+        allowedRoutes: row.allowedRoutes,
+      },
+    });
+    medicationDrugUpserts++;
+    for (const pres of row.presentations) {
+      await prisma.medicationCatalogPresentation.upsert({
+        where: { code: pres.code },
+        create: {
+          code: pres.code,
+          drugCode: row.code,
+          label: pres.label,
+          strength: pres.strength ?? null,
+          form: pres.form ?? null,
+          sourceVersion: 'prisma-seed',
+        },
+        update: {
+          drugCode: row.code,
+          label: pres.label,
+          strength: pres.strength ?? null,
+          form: pres.form ?? null,
+        },
+      });
+      medicationPresentationUpserts++;
+    }
+  }
+  console.log(
+    `✅ Catálogo de medicamentos: ${medicationDrugUpserts} fármacos, ${medicationPresentationUpserts} apresentações (upsert)`,
   );
 
   console.log('');

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -29,6 +29,7 @@ import { AuditLogInterceptor } from './audit-log/audit-log.interceptor';
 import { ScheduledActionsModule } from './scheduled-actions/scheduled-actions.module';
 import { ComplementaryExamsModule } from './complementary-exams/complementary-exams.module';
 import { ExamCatalogModule } from './exam-catalog/exam-catalog.module';
+import { MedicationCatalogModule } from './medication-catalog/medication-catalog.module';
 import { QuestionnaireResponsesModule } from './questionnaire-responses/questionnaire-responses.module';
 import { MedicationsModule } from './medications/medications.module';
 import { ComorbiditiesModule } from './comorbidities/comorbidities.module';
@@ -84,6 +85,7 @@ import { TissGuidesModule } from './tiss-guides/tiss-guides.module';
     ScheduledActionsModule,
     ComplementaryExamsModule,
     ExamCatalogModule,
+    MedicationCatalogModule,
     QuestionnaireResponsesModule,
     MedicationsModule,
     ComorbiditiesModule,

--- a/backend/src/clinical-note-extraction/apply-complementary-exams.spec.ts
+++ b/backend/src/clinical-note-extraction/apply-complementary-exams.spec.ts
@@ -277,4 +277,74 @@ describe('applyComplementaryExamsFromAiItems', () => {
     );
     expect(results[0]?.performedAt.toISOString()).toBe('2025-04-20T00:00:00.000Z');
   });
+
+  it('sinónimos creatinina + eTFG → 1 exam, 2 results', async () => {
+    const { tx, exams, results } = makeTx();
+    const items: AiComplementaryExamItem[] = [
+      {
+        type: 'LABORATORY',
+        name: 'Creatinina',
+        code: 'CREAT',
+        result: { performed_at: '2025-01-01', value_numeric: 1.0 },
+      },
+      {
+        type: 'LABORATORY',
+        name: 'eTFG',
+        result: { performed_at: '2025-02-01', value_numeric: 72 },
+      },
+    ];
+
+    await applyComplementaryExamsFromAiItems(
+      tx as unknown as Prisma.TransactionClient,
+      baseArgs,
+      items,
+    );
+
+    expect(exams).toHaveLength(1);
+    expect(results).toHaveLength(2);
+    expect(tx.complementaryExam.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('creatinina com painel eTFG no nome reutiliza mesmo exame', async () => {
+    const { tx, exams } = makeTx();
+    await applyComplementaryExamsFromAiItems(
+      tx as unknown as Prisma.TransactionClient,
+      baseArgs,
+      [
+        {
+          type: 'LABORATORY',
+          name: 'Creatinina',
+          result: { performed_at: '2025-01-01', value_numeric: 1.1 },
+        },
+        {
+          type: 'LABORATORY',
+          name: 'Dosagem de Creatinina com eTFG',
+          result: { performed_at: '2025-02-01', value_numeric: 1.0 },
+        },
+      ],
+    );
+    expect(exams).toHaveLength(1);
+  });
+
+  it('sinónimos vitamina D 25-OH → 1 exam', async () => {
+    const { tx, exams } = makeTx();
+    await applyComplementaryExamsFromAiItems(
+      tx as unknown as Prisma.TransactionClient,
+      baseArgs,
+      [
+        {
+          type: 'LABORATORY',
+          name: 'Vitamina D 25(OH)D',
+          result: { performed_at: '2025-01-01', value_numeric: 32 },
+        },
+        {
+          type: 'LABORATORY',
+          name: '25-Hidroxi-Vitamina D',
+          result: { performed_at: '2025-03-01', value_numeric: 28 },
+        },
+      ],
+    );
+    expect(exams).toHaveLength(1);
+    expect(tx.complementaryExam.create).toHaveBeenCalledTimes(1);
+  });
 });

--- a/backend/src/clinical-note-extraction/apply-complementary-exams.spec.ts
+++ b/backend/src/clinical-note-extraction/apply-complementary-exams.spec.ts
@@ -1,0 +1,280 @@
+import { ComplementaryExamType, Prisma } from '@generated/prisma/client';
+import { applyComplementaryExamsFromAiItems } from './apply-complementary-exams';
+import type { AiComplementaryExamItem } from './clinical-note-extraction.types';
+
+function makeTx() {
+  const exams: Array<{
+    id: string;
+    tenantId: string;
+    patientId: string;
+    type: ComplementaryExamType;
+    name: string;
+    code: string | null;
+    loincCode: string | null;
+  }> = [];
+  const results: Array<{
+    id: string;
+    tenantId: string;
+    examId: string;
+    performedAt: Date;
+    deletedAt: Date | null;
+    valueNumeric: number | null;
+    collectionId?: string | null;
+  }> = [];
+  let examSeq = 0;
+  let resSeq = 0;
+
+  return {
+    exams,
+    results,
+    tx: {
+      complementaryExam: {
+        findMany: jest.fn(
+          async ({
+            where,
+          }: {
+            where: {
+              tenantId: string;
+              patientId: string;
+              type?: ComplementaryExamType;
+            };
+          }) =>
+            exams.filter(
+              (e) =>
+                e.tenantId === where.tenantId &&
+                e.patientId === where.patientId &&
+                (where.type === undefined || e.type === where.type),
+            ),
+        ),
+        create: jest.fn(
+          async ({
+            data,
+          }: {
+            data: {
+              tenantId: string;
+              patientId: string;
+              type: ComplementaryExamType;
+              name: string;
+              code: string | null;
+              loincCode: string | null;
+            };
+          }) => {
+            examSeq += 1;
+            const row = {
+              id: `exam-${examSeq}`,
+              ...data,
+            };
+            exams.push(row);
+            return row;
+          },
+        ),
+      },
+      complementaryExamResult: {
+        findFirst: jest.fn(
+          async ({
+            where,
+          }: {
+            where: {
+              tenantId: string;
+              examId: string;
+              performedAt: Date;
+              deletedAt: null;
+            };
+          }) =>
+            results.find(
+              (r) =>
+                r.tenantId === where.tenantId &&
+                r.examId === where.examId &&
+                r.performedAt.getTime() === where.performedAt.getTime() &&
+                r.deletedAt === null,
+            ) ?? null,
+        ),
+        create: jest.fn(
+          async ({
+            data,
+          }: {
+            data: {
+              tenantId: string;
+              examId: string;
+              performedAt: Date;
+              valueNumeric?: number | null;
+              collectionId?: string;
+            };
+          }) => {
+            resSeq += 1;
+            const row = {
+              id: `res-${resSeq}`,
+              deletedAt: null as Date | null,
+              valueNumeric: data.valueNumeric ?? null,
+              ...data,
+            };
+            results.push(row);
+            return row;
+          },
+        ),
+        update: jest.fn(
+          async ({
+            where,
+            data,
+          }: {
+            where: { id: string };
+            data: { valueNumeric?: number | null };
+          }) => {
+            const row = results.find((r) => r.id === where.id);
+            if (!row) throw new Error('not found');
+            if (data.valueNumeric !== undefined) {
+              row.valueNumeric = data.valueNumeric;
+            }
+            return row;
+          },
+        ),
+      },
+    },
+  };
+}
+
+describe('applyComplementaryExamsFromAiItems', () => {
+  const baseArgs = {
+    tenantId: 't1',
+    patientId: 'p1',
+    mergedRejections: [] as Array<{
+      domain: string;
+      reason: string;
+      field?: string | null;
+    }>,
+  };
+
+  it('dois itens mesmo nome e datas diferentes → 1 exam create, 2 results', async () => {
+    const { tx, exams, results } = makeTx();
+    const items: AiComplementaryExamItem[] = [
+      {
+        type: 'LABORATORY',
+        name: 'Hemoglobina',
+        result: { performed_at: '2025-01-01', value_numeric: 12 },
+      },
+      {
+        type: 'LABORATORY',
+        name: 'Hemoglobina',
+        result: { performed_at: '2025-02-01', value_numeric: 13 },
+      },
+    ];
+
+    const out = await applyComplementaryExamsFromAiItems(
+      tx as unknown as Prisma.TransactionClient,
+      baseArgs,
+      items,
+    );
+
+    expect(exams).toHaveLength(1);
+    expect(results).toHaveLength(2);
+    expect(out.complementaryExamIds).toEqual(['exam-1']);
+    expect(out.complementaryExamResultIds).toHaveLength(2);
+  });
+
+  it('mesmo performedAt → 1 result (update)', async () => {
+    const { tx, results } = makeTx();
+    const items: AiComplementaryExamItem[] = [
+      {
+        type: 'LABORATORY',
+        name: 'Creatinina',
+        result: {
+          performed_at: '2025-06-15T10:30:00.000Z',
+          value_numeric: 1.0,
+        },
+      },
+      {
+        type: 'LABORATORY',
+        name: 'Creatinina',
+        result: {
+          performed_at: '2025-06-15T10:30:00.000Z',
+          value_numeric: 1.2,
+        },
+      },
+    ];
+
+    const out = await applyComplementaryExamsFromAiItems(
+      tx as unknown as Prisma.TransactionClient,
+      baseArgs,
+      items,
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.valueNumeric).toBe(1.2);
+    expect(out.complementaryExamResultIds).toEqual(['res-1', 'res-1']);
+  });
+
+  it('mesmo dia com horários diferentes → 2 results', async () => {
+    const { tx, results } = makeTx();
+    const items: AiComplementaryExamItem[] = [
+      {
+        type: 'LABORATORY',
+        name: 'Glicemia',
+        result: {
+          performed_at: '2025-03-10T08:00:00.000Z',
+          value_numeric: 90,
+        },
+      },
+      {
+        type: 'LABORATORY',
+        name: 'Glicemia',
+        result: {
+          performed_at: '2025-03-10T18:00:00.000Z',
+          value_numeric: 110,
+        },
+      },
+    ];
+
+    await applyComplementaryExamsFromAiItems(
+      tx as unknown as Prisma.TransactionClient,
+      baseArgs,
+      items,
+    );
+
+    expect(results).toHaveLength(2);
+    expect(results.map((r) => r.performedAt.toISOString())).toEqual([
+      '2025-03-10T08:00:00.000Z',
+      '2025-03-10T18:00:00.000Z',
+    ]);
+  });
+
+  it('mesmo lote reutiliza exame (batchCache)', async () => {
+    const { tx, exams } = makeTx();
+    const items: AiComplementaryExamItem[] = [
+      {
+        type: 'LABORATORY',
+        name: 'TTPa',
+        result: { performed_at: '2025-01-01', value_numeric: 28 },
+      },
+      {
+        type: 'LABORATORY',
+        name: 'TTPa',
+        result: { performed_at: '2025-02-01', value_numeric: 30 },
+      },
+    ];
+
+    await applyComplementaryExamsFromAiItems(
+      tx as unknown as Prisma.TransactionClient,
+      baseArgs,
+      items,
+    );
+
+    expect(tx.complementaryExam.create).toHaveBeenCalledTimes(1);
+    expect(exams).toHaveLength(1);
+  });
+
+  it('YYYY-MM-DD usa início do dia UTC', async () => {
+    const { tx, results } = makeTx();
+    await applyComplementaryExamsFromAiItems(
+      tx as unknown as Prisma.TransactionClient,
+      baseArgs,
+      [
+        {
+          type: 'LABORATORY',
+          name: 'Hb',
+          result: { performed_at: '2025-04-20', value_numeric: 14 },
+        },
+      ],
+    );
+    expect(results[0]?.performedAt.toISOString()).toBe('2025-04-20T00:00:00.000Z');
+  });
+});

--- a/backend/src/clinical-note-extraction/apply-complementary-exams.spec.ts
+++ b/backend/src/clinical-note-extraction/apply-complementary-exams.spec.ts
@@ -121,7 +121,7 @@ function makeTx() {
             data: { valueNumeric?: number | null };
           }) => {
             const row = results.find((r) => r.id === where.id);
-            if (!row) throw new Error('not found');
+            if (!row) {throw new Error('not found');}
             if (data.valueNumeric !== undefined) {
               row.valueNumeric = data.valueNumeric;
             }

--- a/backend/src/clinical-note-extraction/apply-complementary-exams.ts
+++ b/backend/src/clinical-note-extraction/apply-complementary-exams.ts
@@ -2,6 +2,13 @@ import {
   ComplementaryExamType,
   Prisma,
 } from '@generated/prisma/client';
+import { collapseRedundantComponentsForSave } from '../complementary-exams/collapse-redundant-components.util';
+import {
+  type ComplementaryExamMatchBatchCache,
+  findOrCreateComplementaryExam,
+  parseComplementaryPerformedAt,
+  upsertComplementaryExamResult,
+} from '../complementary-exams/complementary-exam-match.util';
 import { LEDGER_OP_CREATE_COMPLEMENTARY_EXAM } from './clinical-note-extraction.constants';
 import type { AiComplementaryExamItem } from './clinical-note-extraction.types';
 
@@ -13,30 +20,13 @@ type RejectionSink = Array<{
   field?: string | null;
 }>;
 
-function parseIsoDate(
-  raw: string | null | undefined,
-  rej: RejectionSink,
-  domain: string,
-  field: string
-): Date | null {
-  if ((raw === null || raw === undefined) || String(raw).trim() === '') {
-    return null;
-  }
-  const d = new Date(String(raw));
-  if (Number.isNaN(d.getTime())) {
-    rej.push({ domain, reason: `data inválida: ${field}`, field });
-    return null;
-  }
-  return d;
-}
-
 export type ApplyComplementaryExamsFromAiResult = {
   complementaryExamIds: string[];
   complementaryExamResultIds: string[];
 };
 
 /**
- * Cria ComplementaryExam + ComplementaryExamResult a partir de itens da IA.
+ * Find-or-create ComplementaryExam + upsert ComplementaryExamResult a partir de itens da IA.
  * Usado na extração de evolução e no exam-ingest (sem ledger quando pushLedger omitido).
  */
 export async function applyComplementaryExamsFromAiItems(
@@ -60,6 +50,8 @@ export async function applyComplementaryExamsFromAiItems(
 
   const complementaryExamIds: string[] = [];
   const complementaryExamResultIds: string[] = [];
+  const seenExamIds = new Set<string>();
+  const batchCache: ComplementaryExamMatchBatchCache = new Map();
 
   for (let i = 0; i < items.length; i++) {
     const raw = items[i];
@@ -82,25 +74,25 @@ export async function applyComplementaryExamsFromAiItems(
       continue;
     }
 
-    const exam = await tx.complementaryExam.create({
-      data: {
+    const { id: examId, created: examCreated } = await findOrCreateComplementaryExam(
+      tx,
+      {
         tenantId,
         patientId,
         type: typ as ComplementaryExamType,
-        name: name.slice(0, 400),
-        code:
-          raw.code === null || raw.code === undefined
-            ? null
-            : String(raw.code).trim().slice(0, 64) || null,
-        loincCode:
-          raw.loinc_code === null || raw.loinc_code === undefined
-            ? null
-            : String(raw.loinc_code).trim().slice(0, 32) || null,
+        name,
+        code: raw.code,
+        loincCode: raw.loinc_code,
+        batchCache,
       },
-    });
-    complementaryExamIds.push(exam.id);
-    if (pushLedger) {
-      await pushLedger(LEDGER_OP_CREATE_COMPLEMENTARY_EXAM, exam.id);
+    );
+
+    if (!seenExamIds.has(examId)) {
+      seenExamIds.add(examId);
+      complementaryExamIds.push(examId);
+    }
+    if (examCreated && pushLedger) {
+      await pushLedger(LEDGER_OP_CREATE_COMPLEMENTARY_EXAM, examId);
     }
 
     const res = raw.result;
@@ -108,51 +100,65 @@ export async function applyComplementaryExamsFromAiItems(
       continue;
     }
     const performedAt =
-      parseIsoDate(
-        res.performed_at,
-        rej,
-        'complementary_exams',
-        `complementary_exams[${i}].result.performed_at`
-      ) ?? new Date();
+      parseComplementaryPerformedAt(res.performed_at) ?? new Date();
+    if (
+      res.performed_at !== null &&
+      res.performed_at !== undefined &&
+      String(res.performed_at).trim() !== '' &&
+      parseComplementaryPerformedAt(res.performed_at) === null
+    ) {
+      rej.push({
+        domain: 'complementary_exams',
+        reason: `data inválida: complementary_exams[${i}].result.performed_at`,
+        field: `complementary_exams[${i}].result.performed_at`,
+      });
+      continue;
+    }
 
-    const row = await tx.complementaryExamResult.create({
-      data: {
-        tenantId,
-        examId: exam.id,
-        performedAt,
-        ...(collectionId !== null &&
-        collectionId !== undefined &&
-        collectionId !== ''
-          ? { collectionId }
-          : {}),
-        valueNumeric:
-          res.value_numeric === null || res.value_numeric === undefined
-            ? null
-            : Number.isFinite(Number(res.value_numeric))
-              ? Number(res.value_numeric)
-              : null,
-        valueText:
-          res.value_text === null || res.value_text === undefined
-            ? null
-            : String(res.value_text).trim().slice(0, 8000) || null,
-        unit:
-          res.unit === null || res.unit === undefined
-            ? null
-            : String(res.unit).trim().slice(0, 64) || null,
-        referenceRange:
-          res.reference_range === null || res.reference_range === undefined
-            ? null
-            : String(res.reference_range).trim().slice(0, 200) || null,
-        isAbnormal:
-          typeof res.is_abnormal === 'boolean' ? res.is_abnormal : null,
-        report:
-          res.report === null || res.report === undefined
-            ? null
-            : String(res.report).trim().slice(0, 12000) || null,
-        components: res.components as Prisma.InputJsonValue | undefined,
+    const collapsed = collapseRedundantComponentsForSave(name, {
+      valueNumeric:
+        res.value_numeric === null || res.value_numeric === undefined
+          ? null
+          : Number.isFinite(Number(res.value_numeric))
+            ? Number(res.value_numeric)
+            : null,
+      valueText:
+        res.value_text === null || res.value_text === undefined
+          ? null
+          : String(res.value_text).trim().slice(0, 8000) || null,
+      unit:
+        res.unit === null || res.unit === undefined
+          ? null
+          : String(res.unit).trim().slice(0, 64) || null,
+      referenceRange:
+        res.reference_range === null || res.reference_range === undefined
+          ? null
+          : String(res.reference_range).trim().slice(0, 200) || null,
+      isAbnormal:
+        typeof res.is_abnormal === 'boolean' ? res.is_abnormal : null,
+      report:
+        res.report === null || res.report === undefined
+          ? null
+          : String(res.report).trim().slice(0, 12000) || null,
+      components: res.components,
+    });
+
+    const { id: resultId } = await upsertComplementaryExamResult(tx, {
+      tenantId,
+      examId,
+      performedAt,
+      collectionId,
+      payload: {
+        valueNumeric: collapsed.valueNumeric ?? null,
+        valueText: collapsed.valueText ?? null,
+        unit: collapsed.unit ?? null,
+        referenceRange: collapsed.referenceRange ?? null,
+        isAbnormal: collapsed.isAbnormal ?? null,
+        report: collapsed.report ?? null,
+        components: collapsed.components as Prisma.InputJsonValue | undefined,
       },
     });
-    complementaryExamResultIds.push(row.id);
+    complementaryExamResultIds.push(resultId);
   }
 
   return { complementaryExamIds, complementaryExamResultIds };

--- a/backend/src/clinical-notes/clinical-note-orders.service.spec.ts
+++ b/backend/src/clinical-notes/clinical-note-orders.service.spec.ts
@@ -2,6 +2,7 @@ import { BadRequestException } from '@nestjs/common';
 import { ClinicalNoteStatus, ClinicalNoteType, UserRole } from '@generated/prisma/client';
 import { ClinicalNoteOrdersService } from './clinical-note-orders.service';
 import { ClinicalNotesService } from './clinical-notes.service';
+import { MedicationCatalogService } from '../medication-catalog/medication-catalog.service';
 import { PrismaService } from '../prisma/prisma.service';
 
 describe('ClinicalNoteOrdersService', () => {
@@ -9,6 +10,7 @@ describe('ClinicalNoteOrdersService', () => {
   const mockPrisma = {
     clinicalNote: { findFirst: jest.fn() },
     clinicalNoteVersion: { findFirst: jest.fn() },
+    patient: { findFirst: jest.fn() },
     clinicalExamRequest: {
       findMany: jest.fn(),
       create: jest.fn(),
@@ -20,10 +22,15 @@ describe('ClinicalNoteOrdersService', () => {
       create: jest.fn(),
       findFirst: jest.fn(),
       delete: jest.fn(),
+      count: jest.fn(),
     },
   };
   const mockClinicalNotes = {
     canCreateOrSignNoteType: jest.fn(),
+  };
+  const mockMedicationCatalog = {
+    findDrugByCode: jest.fn(),
+    findPresentationByCode: jest.fn(),
   };
 
   const actor = {
@@ -36,7 +43,8 @@ describe('ClinicalNoteOrdersService', () => {
     jest.clearAllMocks();
     service = new ClinicalNoteOrdersService(
       mockPrisma as unknown as PrismaService,
-      mockClinicalNotes as unknown as ClinicalNotesService
+      mockClinicalNotes as unknown as ClinicalNotesService,
+      mockMedicationCatalog as unknown as MedicationCatalogService
     );
   });
 
@@ -58,6 +66,7 @@ describe('ClinicalNoteOrdersService', () => {
         displayName: 'Hemograma',
         code: null,
         loincCode: null,
+        examCatalogCode: null,
         requestedBy: { id: actor.id, name: 'Dra.' },
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -126,6 +135,55 @@ describe('ClinicalNoteOrdersService', () => {
           { medicationName: 'X' }
         )
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects route not allowed for catalog drug', async () => {
+      mockPrisma.clinicalNote.findFirst.mockResolvedValue({
+        id: 'note-1',
+        status: ClinicalNoteStatus.DRAFT,
+        noteType: ClinicalNoteType.MEDICAL,
+        patientId: 'pat-1',
+      });
+      mockPrisma.clinicalNoteVersion.findFirst.mockResolvedValue({
+        versionNumber: 1,
+      });
+      mockClinicalNotes.canCreateOrSignNoteType.mockReturnValue(true);
+      mockMedicationCatalog.findDrugByCode.mockResolvedValue({
+        code: 'WARFARIN',
+        displayName: 'Varfarina',
+        allowedRoutes: ['VO'],
+      });
+
+      await expect(
+        service.createPrescriptionLine('pat-1', 'note-1', 'tenant-1', actor, {
+          medicationName: 'x',
+          catalogKey: 'WARFARIN',
+          route: 'IV',
+        })
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('listPrescriptionHistory', () => {
+    it('scopes by tenant and patient', async () => {
+      mockPrisma.patient.findFirst.mockResolvedValue({ id: 'pat-1' });
+      mockPrisma.clinicalPrescriptionLine.findMany.mockResolvedValue([]);
+      mockPrisma.clinicalPrescriptionLine.count.mockResolvedValue(0);
+
+      await service.listPrescriptionHistory('pat-1', 'tenant-1', {
+        limit: 10,
+        offset: 0,
+      });
+
+      expect(mockPrisma.clinicalPrescriptionLine.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            tenantId: 'tenant-1',
+            patientId: 'pat-1',
+            clinicalNote: { status: { not: ClinicalNoteStatus.VOIDED } },
+          }),
+        })
+      );
     });
   });
 });

--- a/backend/src/clinical-notes/clinical-note-orders.service.ts
+++ b/backend/src/clinical-notes/clinical-note-orders.service.ts
@@ -7,17 +7,21 @@ import {
 import {
   ClinicalNoteStatus,
   ClinicalNoteType,
+  Prisma,
 } from '@generated/prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { ClinicalNotesService, type ClinicalNoteActor } from './clinical-notes.service';
 import { CreateClinicalExamRequestDto } from './dto/create-clinical-exam-request.dto';
 import { CreateClinicalPrescriptionLineDto } from './dto/create-clinical-prescription-line.dto';
+import { MedicationCatalogService } from '../medication-catalog/medication-catalog.service';
+import { isAllowedMedicationRoute } from '../medication-catalog/medication-catalog.routes';
 
 @Injectable()
 export class ClinicalNoteOrdersService {
   constructor(
     private readonly prisma: PrismaService,
-    private readonly clinicalNotesService: ClinicalNotesService
+    private readonly clinicalNotesService: ClinicalNotesService,
+    private readonly medicationCatalogService: MedicationCatalogService
   ) {}
 
   private async resolveNoteForOrders(
@@ -187,6 +191,7 @@ export class ClinicalNoteOrdersService {
         clinicalNoteVersionNumber: true,
         medicationName: true,
         catalogKey: true,
+        presentationCatalogCode: true,
         dosage: true,
         frequency: true,
         route: true,
@@ -197,6 +202,70 @@ export class ClinicalNoteOrdersService {
         updatedAt: true,
       },
     });
+  }
+
+  private async resolvePrescriptionPayload(
+    dto: CreateClinicalPrescriptionLineDto
+  ): Promise<{
+    medicationName: string;
+    catalogKey: string | null;
+    presentationCatalogCode: string | null;
+    route: string | null;
+  }> {
+    const catalogKey = dto.catalogKey?.trim() || null;
+    const presentationCatalogCode =
+      dto.presentationCatalogCode?.trim() || null;
+    const route = dto.route?.trim() || null;
+
+    if (!catalogKey) {
+      if (presentationCatalogCode) {
+        throw new BadRequestException(
+          'Apresentação do catálogo exige medicamento do catálogo'
+        );
+      }
+      const name = dto.medicationName?.trim();
+      if (!name) {
+        throw new BadRequestException('Informe o nome do medicamento');
+      }
+      return {
+        medicationName: name,
+        catalogKey: null,
+        presentationCatalogCode: null,
+        route,
+      };
+    }
+
+    const drug = await this.medicationCatalogService.findDrugByCode(catalogKey);
+    if (!drug) {
+      throw new BadRequestException('Medicamento não encontrado no catálogo');
+    }
+
+    let medicationName = drug.displayName;
+    if (presentationCatalogCode) {
+      const presentation =
+        await this.medicationCatalogService.findPresentationByCode(
+          presentationCatalogCode
+        );
+      if (!presentation || presentation.drugCode !== catalogKey) {
+        throw new BadRequestException(
+          'Apresentação inválida para o medicamento selecionado'
+        );
+      }
+      medicationName = presentation.label;
+    }
+
+    if (route && !isAllowedMedicationRoute(route, drug.allowedRoutes)) {
+      throw new BadRequestException(
+        'Via de administração não permitida para este medicamento'
+      );
+    }
+
+    return {
+      medicationName,
+      catalogKey,
+      presentationCatalogCode,
+      route,
+    };
   }
 
   async createPrescriptionLine(
@@ -218,6 +287,8 @@ export class ClinicalNoteOrdersService {
     }
     this.assertCanManageOrdersForNoteType(actor, ClinicalNoteType.MEDICAL);
     const versionNumber = await this.latestVersionNumber(clinicalNoteId, tenantId);
+    const resolved = await this.resolvePrescriptionPayload(dto);
+
     return this.prisma.clinicalPrescriptionLine.create({
       data: {
         tenantId,
@@ -225,11 +296,12 @@ export class ClinicalNoteOrdersService {
         clinicalNoteId,
         clinicalNoteVersionNumber: versionNumber,
         prescribedById: actor.id,
-        medicationName: dto.medicationName.trim(),
-        catalogKey: dto.catalogKey?.trim() || null,
+        medicationName: resolved.medicationName,
+        catalogKey: resolved.catalogKey,
+        presentationCatalogCode: resolved.presentationCatalogCode,
         dosage: dto.dosage?.trim() || null,
         frequency: dto.frequency?.trim() || null,
-        route: dto.route?.trim() || null,
+        route: resolved.route,
         duration: dto.duration?.trim() || null,
         indication: dto.indication?.trim() || null,
       },
@@ -238,6 +310,7 @@ export class ClinicalNoteOrdersService {
         clinicalNoteVersionNumber: true,
         medicationName: true,
         catalogKey: true,
+        presentationCatalogCode: true,
         dosage: true,
         frequency: true,
         route: true,
@@ -278,5 +351,72 @@ export class ClinicalNoteOrdersService {
     await this.prisma.clinicalPrescriptionLine.delete({
       where: { id: lineId, tenantId },
     });
+  }
+
+  async listPrescriptionHistory(
+    patientId: string,
+    tenantId: string,
+    params: { q?: string; limit: number; offset: number }
+  ) {
+    const patient = await this.prisma.patient.findFirst({
+      where: { id: patientId, tenantId },
+      select: { id: true },
+    });
+    if (!patient) {
+      throw new NotFoundException('Paciente não encontrado');
+    }
+
+    const { q, limit, offset } = params;
+    const where: Prisma.ClinicalPrescriptionLineWhereInput = {
+      tenantId,
+      patientId,
+      clinicalNote: { status: { not: ClinicalNoteStatus.VOIDED } },
+    };
+    const trimmed = q?.trim();
+    if (trimmed) {
+      where.OR = [
+        { medicationName: { contains: trimmed, mode: 'insensitive' } },
+        { dosage: { contains: trimmed, mode: 'insensitive' } },
+        { frequency: { contains: trimmed, mode: 'insensitive' } },
+        { route: { contains: trimmed, mode: 'insensitive' } },
+        { indication: { contains: trimmed, mode: 'insensitive' } },
+        { catalogKey: { contains: trimmed, mode: 'insensitive' } },
+      ];
+    }
+
+    const [items, total] = await Promise.all([
+      this.prisma.clinicalPrescriptionLine.findMany({
+        where,
+        take: limit,
+        skip: offset,
+        orderBy: [{ createdAt: 'desc' }],
+        select: {
+          id: true,
+          clinicalNoteId: true,
+          clinicalNoteVersionNumber: true,
+          medicationName: true,
+          catalogKey: true,
+          presentationCatalogCode: true,
+          dosage: true,
+          frequency: true,
+          route: true,
+          duration: true,
+          indication: true,
+          createdAt: true,
+          prescribedBy: { select: { id: true, name: true } },
+          clinicalNote: {
+            select: {
+              id: true,
+              status: true,
+              signedAt: true,
+              noteType: true,
+            },
+          },
+        },
+      }),
+      this.prisma.clinicalPrescriptionLine.count({ where }),
+    ]);
+
+    return { items, total, limit, offset };
   }
 }

--- a/backend/src/clinical-notes/clinical-notes.module.ts
+++ b/backend/src/clinical-notes/clinical-notes.module.ts
@@ -12,18 +12,22 @@ import { ExamIngestController } from './exam-ingest.controller';
 import { PublicExamIngestController } from './public-exam-ingest.controller';
 import { OncologyNavigationModule } from '../oncology-navigation/oncology-navigation.module';
 import { ClinicalNoteExtractionModule } from '../clinical-note-extraction/clinical-note-extraction.module';
+import { MedicationCatalogModule } from '../medication-catalog/medication-catalog.module';
+import { PatientPrescriptionHistoryController } from './patient-prescription-history.controller';
 
 @Module({
   imports: [
     PrismaModule,
     AuditLogModule,
     OncologyNavigationModule,
+    MedicationCatalogModule,
     forwardRef(() => ClinicalNoteExtractionModule),
   ],
   controllers: [
     ClinicalNotesController,
     PatientClinicalNotesController,
     PatientClinicalNoteOrdersController,
+    PatientPrescriptionHistoryController,
     ExamIngestController,
     PublicExamIngestController,
   ],

--- a/backend/src/clinical-notes/dto/create-clinical-prescription-line.dto.ts
+++ b/backend/src/clinical-notes/dto/create-clinical-prescription-line.dto.ts
@@ -14,6 +14,11 @@ export class CreateClinicalPrescriptionLineDto {
   @IsOptional()
   @IsString()
   @MaxLength(128)
+  presentationCatalogCode?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(128)
   dosage?: string;
 
   @IsOptional()

--- a/backend/src/clinical-notes/dto/exam-ingest.dto.ts
+++ b/backend/src/clinical-notes/dto/exam-ingest.dto.ts
@@ -1,4 +1,41 @@
-import { IsOptional, IsString, IsUUID, MaxLength } from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
+
+export class ConfirmComplementaryExamItemDto {
+  @IsString()
+  @MaxLength(64)
+  type!: string;
+
+  @IsString()
+  @MaxLength(400)
+  name!: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  code?: string | null;
+
+  @IsOptional()
+  result?: Record<string, unknown> | null;
+}
+
+export class ConfirmComplementaryExamsDto {
+  @IsOptional()
+  @IsUUID()
+  collectionId?: string;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ConfirmComplementaryExamItemDto)
+  items!: ConfirmComplementaryExamItemDto[];
+}
 
 export class CreateExamIngestSessionDto {
   @IsOptional()

--- a/backend/src/clinical-notes/exam-ingest.controller.ts
+++ b/backend/src/clinical-notes/exam-ingest.controller.ts
@@ -21,7 +21,11 @@ import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import type { CurrentUser as CurrentUserType } from '../auth/decorators/current-user.decorator';
 import { UserRole } from '@generated/prisma/client';
 import { ExamIngestService } from './exam-ingest.service';
-import { CreateExamIngestSessionDto, ExamIngestExtractDto } from './dto/exam-ingest.dto';
+import {
+  ConfirmComplementaryExamsDto,
+  CreateExamIngestSessionDto,
+  ExamIngestExtractDto,
+} from './dto/exam-ingest.dto';
 import {
   EXAM_INGEST_MAX_FILE_BYTES,
   EXAM_INGEST_MAX_FILES_PER_SESSION,
@@ -141,5 +145,19 @@ export class ExamIngestController {
       sessionId: dto.sessionId,
       uploadedFiles: uploaded.length > 0 ? uploaded : undefined,
     });
+  }
+
+  @Post('confirm-complementary-exams')
+  @Roles(...CLINICAL_WRITE_ROLES)
+  confirmComplementaryExams(
+    @Param('patientId', ParseUUIDPipe) patientId: string,
+    @Body() dto: ConfirmComplementaryExamsDto,
+    @CurrentUser() user: CurrentUserType
+  ) {
+    return this.examIngest.confirmComplementaryExams(
+      user.tenantId,
+      patientId,
+      dto
+    );
   }
 }

--- a/backend/src/clinical-notes/exam-ingest.service.spec.ts
+++ b/backend/src/clinical-notes/exam-ingest.service.spec.ts
@@ -263,8 +263,15 @@ describe('ExamIngestService', () => {
     const resCreate = jest.fn().mockResolvedValue({ id: 'res-1' });
     prisma.$transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) =>
       fn({
-        complementaryExam: { create: examCreate },
-        complementaryExamResult: { create: resCreate },
+        complementaryExam: {
+          findMany: jest.fn().mockResolvedValue([]),
+          create: examCreate,
+        },
+        complementaryExamResult: {
+          findFirst: jest.fn().mockResolvedValue(null),
+          create: resCreate,
+          update: jest.fn(),
+        },
       })
     );
 

--- a/backend/src/clinical-notes/exam-ingest.service.ts
+++ b/backend/src/clinical-notes/exam-ingest.service.ts
@@ -24,6 +24,7 @@ import {
 } from './exam-ingest.constants';
 import { applyComplementaryExamsFromAiItems } from '../clinical-note-extraction/apply-complementary-exams';
 import type { AiComplementaryExamItem } from '../clinical-note-extraction/clinical-note-extraction.types';
+import type { ConfirmComplementaryExamsDto } from './dto/exam-ingest.dto';
 
 /** Extrai `detail` de corpo JSON típico do FastAPI (mensagem segura ao cliente). */
 function parseAiServiceErrorDetail(raw: string): string | undefined {
@@ -552,5 +553,47 @@ export class ExamIngestService {
     } finally {
       clearTimeout(t);
     }
+  }
+
+  async confirmComplementaryExams(
+    tenantId: string,
+    patientId: string,
+    dto: ConfirmComplementaryExamsDto,
+  ): Promise<{
+    collectionId: string;
+    complementaryExamsSavedCount: number;
+    complementaryExamResultSavedCount: number;
+    complementaryExamIds: string[];
+  }> {
+    await this.assertPatientTenant(patientId, tenantId);
+
+    const items: AiComplementaryExamItem[] = dto.items.map((row) => ({
+      type: row.type.trim(),
+      name: row.name.trim(),
+      code: row.code ?? null,
+      loinc_code: null,
+      result: (row.result as AiComplementaryExamItem['result']) ?? null,
+    }));
+    const collectionId = dto.collectionId ?? randomUUID();
+    const rej: Array<{ domain: string; reason: string; field?: string | null }> =
+      [];
+    const applied = await this.prisma.$transaction(async (tx) => {
+      return applyComplementaryExamsFromAiItems(
+        tx,
+        {
+          tenantId,
+          patientId,
+          mergedRejections: rej,
+          collectionId,
+        },
+        items,
+      );
+    });
+    return {
+      collectionId,
+      complementaryExamsSavedCount: applied.complementaryExamIds.length,
+      complementaryExamResultSavedCount: applied.complementaryExamResultIds.length,
+      complementaryExamIds: applied.complementaryExamIds,
+    };
   }
 }

--- a/backend/src/clinical-notes/exam-ingest.service.ts
+++ b/backend/src/clinical-notes/exam-ingest.service.ts
@@ -24,6 +24,10 @@ import {
 } from './exam-ingest.constants';
 import { applyComplementaryExamsFromAiItems } from '../clinical-note-extraction/apply-complementary-exams';
 import type { AiComplementaryExamItem } from '../clinical-note-extraction/clinical-note-extraction.types';
+import {
+  partitionComplementaryExamItemsByConfidence,
+  type ComplementaryExamPendingReviewItem,
+} from '../complementary-exams/partition-complementary-exam-items.util';
 
 /** Extrai `detail` de corpo JSON típico do FastAPI (mensagem segura ao cliente). */
 function parseAiServiceErrorDetail(raw: string): string | undefined {
@@ -136,6 +140,8 @@ export type ExamIngestFileEntry = {
   mimeType: string;
   dataBase64: string;
 };
+
+import type { ConfirmComplementaryExamsDto } from './dto/exam-ingest.dto';
 
 @Injectable()
 export class ExamIngestService {
@@ -332,6 +338,8 @@ export class ExamIngestService {
     complementaryExamsSavedCount: number;
     complementaryExamResultSavedCount: number;
     complementaryExamIds: string[];
+    complementaryExamsPendingReview?: ComplementaryExamPendingReviewItem[];
+    complementaryExamsAutoSavedCount?: number;
   }> {
     const { patientId, plainText, sessionId, uploadedFiles } = opts;
     await this.assertPatientTenant(patientId, tenantId);
@@ -498,11 +506,15 @@ export class ExamIngestService {
       const upstreamExams =
         json.complementaryExams ?? json.complementary_exams;
       const mappedExams = mapUpstreamComplementaryExams(upstreamExams);
+      const { autoApply, pendingReview } =
+        partitionComplementaryExamItemsByConfidence(mappedExams);
+      const complementaryExamsPendingReview: ComplementaryExamPendingReviewItem[] =
+        pendingReview;
       let collectionId: string | undefined;
       let complementaryExamsSavedCount = 0;
       let complementaryExamResultSavedCount = 0;
       const complementaryExamIds: string[] = [];
-      if (mappedExams.length > 0) {
+      if (autoApply.length > 0) {
         collectionId = randomUUID();
         const rej: Array<{
           domain: string;
@@ -518,7 +530,7 @@ export class ExamIngestService {
               mergedRejections: rej,
               collectionId,
             },
-            mappedExams
+            autoApply
           );
         });
         complementaryExamsSavedCount = applied.complementaryExamIds.length;
@@ -530,7 +542,6 @@ export class ExamIngestService {
           );
         }
       }
-
       if (sessionId) {
         if (uploadTokenToInvalidate) {
           await this.redis.del(this.tokenKey(uploadTokenToInvalidate));
@@ -548,9 +559,46 @@ export class ExamIngestService {
         complementaryExamsSavedCount,
         complementaryExamResultSavedCount,
         complementaryExamIds,
+        complementaryExamsPendingReview,
+        complementaryExamsAutoSavedCount: autoApply.length,
       };
     } finally {
       clearTimeout(t);
     }
+  }
+
+  async confirmComplementaryExams(
+    tenantId: string,
+    patientId: string,
+    dto: ConfirmComplementaryExamsDto,
+  ) {
+    const items: AiComplementaryExamItem[] = dto.items.map((row) => ({
+      type: row.type.trim(),
+      name: row.name.trim(),
+      code: row.code ?? null,
+      loinc_code: null,
+      result: (row.result as AiComplementaryExamItem['result']) ?? null,
+    }));
+    const collectionId = dto.collectionId ?? randomUUID();
+    const rej: Array<{ domain: string; reason: string; field?: string | null }> =
+      [];
+    const applied = await this.prisma.$transaction(async (tx) => {
+      return applyComplementaryExamsFromAiItems(
+        tx,
+        {
+          tenantId,
+          patientId,
+          mergedRejections: rej,
+          collectionId,
+        },
+        items,
+      );
+    });
+    return {
+      collectionId,
+      complementaryExamsSavedCount: applied.complementaryExamIds.length,
+      complementaryExamResultSavedCount: applied.complementaryExamResultIds.length,
+      complementaryExamIds: applied.complementaryExamIds,
+    };
   }
 }

--- a/backend/src/clinical-notes/exam-ingest.service.ts
+++ b/backend/src/clinical-notes/exam-ingest.service.ts
@@ -24,10 +24,6 @@ import {
 } from './exam-ingest.constants';
 import { applyComplementaryExamsFromAiItems } from '../clinical-note-extraction/apply-complementary-exams';
 import type { AiComplementaryExamItem } from '../clinical-note-extraction/clinical-note-extraction.types';
-import {
-  partitionComplementaryExamItemsByConfidence,
-  type ComplementaryExamPendingReviewItem,
-} from '../complementary-exams/partition-complementary-exam-items.util';
 
 /** Extrai `detail` de corpo JSON típico do FastAPI (mensagem segura ao cliente). */
 function parseAiServiceErrorDetail(raw: string): string | undefined {
@@ -140,8 +136,6 @@ export type ExamIngestFileEntry = {
   mimeType: string;
   dataBase64: string;
 };
-
-import type { ConfirmComplementaryExamsDto } from './dto/exam-ingest.dto';
 
 @Injectable()
 export class ExamIngestService {
@@ -338,8 +332,6 @@ export class ExamIngestService {
     complementaryExamsSavedCount: number;
     complementaryExamResultSavedCount: number;
     complementaryExamIds: string[];
-    complementaryExamsPendingReview?: ComplementaryExamPendingReviewItem[];
-    complementaryExamsAutoSavedCount?: number;
   }> {
     const { patientId, plainText, sessionId, uploadedFiles } = opts;
     await this.assertPatientTenant(patientId, tenantId);
@@ -506,15 +498,11 @@ export class ExamIngestService {
       const upstreamExams =
         json.complementaryExams ?? json.complementary_exams;
       const mappedExams = mapUpstreamComplementaryExams(upstreamExams);
-      const { autoApply, pendingReview } =
-        partitionComplementaryExamItemsByConfidence(mappedExams);
-      const complementaryExamsPendingReview: ComplementaryExamPendingReviewItem[] =
-        pendingReview;
       let collectionId: string | undefined;
       let complementaryExamsSavedCount = 0;
       let complementaryExamResultSavedCount = 0;
       const complementaryExamIds: string[] = [];
-      if (autoApply.length > 0) {
+      if (mappedExams.length > 0) {
         collectionId = randomUUID();
         const rej: Array<{
           domain: string;
@@ -530,7 +518,7 @@ export class ExamIngestService {
               mergedRejections: rej,
               collectionId,
             },
-            autoApply
+            mappedExams
           );
         });
         complementaryExamsSavedCount = applied.complementaryExamIds.length;
@@ -542,6 +530,7 @@ export class ExamIngestService {
           );
         }
       }
+
       if (sessionId) {
         if (uploadTokenToInvalidate) {
           await this.redis.del(this.tokenKey(uploadTokenToInvalidate));
@@ -559,46 +548,9 @@ export class ExamIngestService {
         complementaryExamsSavedCount,
         complementaryExamResultSavedCount,
         complementaryExamIds,
-        complementaryExamsPendingReview,
-        complementaryExamsAutoSavedCount: autoApply.length,
       };
     } finally {
       clearTimeout(t);
     }
-  }
-
-  async confirmComplementaryExams(
-    tenantId: string,
-    patientId: string,
-    dto: ConfirmComplementaryExamsDto,
-  ) {
-    const items: AiComplementaryExamItem[] = dto.items.map((row) => ({
-      type: row.type.trim(),
-      name: row.name.trim(),
-      code: row.code ?? null,
-      loinc_code: null,
-      result: (row.result as AiComplementaryExamItem['result']) ?? null,
-    }));
-    const collectionId = dto.collectionId ?? randomUUID();
-    const rej: Array<{ domain: string; reason: string; field?: string | null }> =
-      [];
-    const applied = await this.prisma.$transaction(async (tx) => {
-      return applyComplementaryExamsFromAiItems(
-        tx,
-        {
-          tenantId,
-          patientId,
-          mergedRejections: rej,
-          collectionId,
-        },
-        items,
-      );
-    });
-    return {
-      collectionId,
-      complementaryExamsSavedCount: applied.complementaryExamIds.length,
-      complementaryExamResultSavedCount: applied.complementaryExamResultIds.length,
-      complementaryExamIds: applied.complementaryExamIds,
-    };
   }
 }

--- a/backend/src/clinical-notes/patient-prescription-history.controller.ts
+++ b/backend/src/clinical-notes/patient-prescription-history.controller.ts
@@ -1,0 +1,51 @@
+import {
+  Controller,
+  DefaultValuePipe,
+  Get,
+  Param,
+  ParseIntPipe,
+  ParseUUIDPipe,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { TenantGuard } from '../auth/guards/tenant.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import type { CurrentUser as CurrentUserType } from '../auth/decorators/current-user.decorator';
+import { UserRole } from '@generated/prisma/client';
+import { ClinicalNoteOrdersService } from './clinical-note-orders.service';
+
+const ORDERS_ROLES = [
+  UserRole.NURSE,
+  UserRole.NURSE_CHIEF,
+  UserRole.DOCTOR,
+  UserRole.ONCOLOGIST,
+  UserRole.COORDINATOR,
+  UserRole.ADMIN,
+] as const;
+
+@Controller('patients/:patientId/prescription-history')
+@UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
+export class PatientPrescriptionHistoryController {
+  constructor(private readonly ordersService: ClinicalNoteOrdersService) {}
+
+  @Get()
+  @Roles(...ORDERS_ROLES)
+  list(
+    @Param('patientId', ParseUUIDPipe) patientId: string,
+    @Query('q') q?: string,
+    @Query('limit', new DefaultValuePipe(30), ParseIntPipe) limit?: number,
+    @Query('offset', new DefaultValuePipe(0), ParseIntPipe) offset?: number,
+    @CurrentUser() user?: CurrentUserType
+  ) {
+    const safeLimit = Math.min(Math.max(limit ?? 30, 1), 100);
+    const safeOffset = Math.max(offset ?? 0, 0);
+    return this.ordersService.listPrescriptionHistory(
+      patientId,
+      user!.tenantId,
+      { q, limit: safeLimit, offset: safeOffset }
+    );
+  }
+}

--- a/backend/src/complementary-exams/collapse-redundant-components.util.spec.ts
+++ b/backend/src/complementary-exams/collapse-redundant-components.util.spec.ts
@@ -1,0 +1,63 @@
+import {
+  collapseRedundantComponentsForSave,
+  extractParentheticalAliases,
+  normalizeExamLabelKey,
+} from './collapse-redundant-components.util';
+
+describe('collapse-redundant-components.util', () => {
+  it('normalizeExamLabelKey remove acentos e pontuação', () => {
+    expect(normalizeExamLabelKey('TTPa (ativo)')).toBe('ttpaativo');
+  });
+
+  it('extractParentheticalAliases lê sigla entre parênteses', () => {
+    expect(
+      extractParentheticalAliases('Tempo de Tromboplastina Parcial Ativado (TTPa)'),
+    ).toEqual(['TTPa']);
+  });
+
+  it('promove TTPa sinônimo para campos do resultado pai', () => {
+    const out = collapseRedundantComponentsForSave(
+      'Tempo de Tromboplastina Parcial Ativado (TTPa)',
+      {
+        valueNumeric: null,
+        valueText: null,
+        unit: null,
+        referenceRange: null,
+        components: [
+          {
+            name: 'TTPa',
+            valueNumeric: 28.7,
+            unit: 'seg',
+            referenceRange: '25,4 a 33,4',
+          },
+        ],
+      },
+    );
+    expect(out.valueNumeric).toBe(28.7);
+    expect(out.unit).toBe('seg');
+    expect(out.referenceRange).toBe('25,4 a 33,4');
+    expect(out.components).toBeUndefined();
+  });
+
+  it('não colapsa painel com vários componentes', () => {
+    const out = collapseRedundantComponentsForSave('Hemograma completo', {
+      valueNumeric: null,
+      components: [
+        { name: 'Hb', valueNumeric: 13 },
+        { name: 'Leucócitos', valueNumeric: 8000 },
+      ],
+    });
+    expect(out.components).toHaveLength(2);
+    expect(out.valueNumeric).toBeNull();
+  });
+
+  it('não colapsa quando o pai já tem valueNumeric', () => {
+    const components = [{ name: 'ALT', valueNumeric: 45 }];
+    const out = collapseRedundantComponentsForSave('Hemograma', {
+      valueNumeric: 14,
+      components,
+    });
+    expect(out.valueNumeric).toBe(14);
+    expect(out.components).toEqual(components);
+  });
+});

--- a/backend/src/complementary-exams/collapse-redundant-components.util.ts
+++ b/backend/src/complementary-exams/collapse-redundant-components.util.ts
@@ -1,0 +1,144 @@
+import type { ExamResultComponentInput } from './reference-range.util';
+
+export function normalizeExamLabelKey(name: string): string {
+  return name
+    .normalize('NFD')
+    .replace(/\p{M}/gu, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '');
+}
+
+export function extractParentheticalAliases(examName: string): string[] {
+  const aliases: string[] = [];
+  const re = /\(([^)]+)\)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(examName)) !== null) {
+    const inner = m[1].trim();
+    if (inner) aliases.push(inner);
+  }
+  return aliases;
+}
+
+function parseComponents(raw: unknown): ExamResultComponentInput[] {
+  if (raw == null) return [];
+  if (typeof raw === 'string') {
+    const t = raw.trim();
+    if (!t) return [];
+    try {
+      return parseComponents(JSON.parse(t) as unknown);
+    } catch {
+      return [];
+    }
+  }
+  if (!Array.isArray(raw)) return [];
+  const out: ExamResultComponentInput[] = [];
+  for (const el of raw) {
+    if (!el || typeof el !== 'object' || Array.isArray(el)) continue;
+    const o = el as Record<string, unknown>;
+    const nameRaw = o.name;
+    if (typeof nameRaw !== 'string' || !nameRaw.trim()) continue;
+    const vn = o.valueNumeric ?? o.value_numeric;
+    let valueNumeric: number | undefined;
+    if (vn !== null && vn !== undefined && vn !== '') {
+      if (typeof vn === 'number' && Number.isFinite(vn)) {
+        valueNumeric = vn;
+      } else {
+        const n = Number(vn);
+        if (Number.isFinite(n)) valueNumeric = n;
+      }
+    }
+    const vt = o.valueText ?? o.value_text;
+    const u = o.unit;
+    const rr = o.referenceRange ?? o.reference_range;
+    const ia = o.isAbnormal ?? o.is_abnormal;
+    out.push({
+      name: nameRaw.trim(),
+      valueNumeric,
+      valueText:
+        vt === null || vt === undefined
+          ? undefined
+          : String(vt).trim().slice(0, 8000) || undefined,
+      unit:
+        u === null || u === undefined
+          ? undefined
+          : String(u).trim().slice(0, 64) || undefined,
+      referenceRange:
+        rr === null || rr === undefined
+          ? undefined
+          : String(rr).trim().slice(0, 200) || undefined,
+      isAbnormal: typeof ia === 'boolean' ? ia : undefined,
+    });
+  }
+  return out;
+}
+
+function resultHasMainValue(fields: {
+  valueNumeric?: number | null;
+  valueText?: string | null;
+  report?: string | null;
+}): boolean {
+  if (
+    fields.valueNumeric !== null &&
+    fields.valueNumeric !== undefined &&
+    !Number.isNaN(fields.valueNumeric)
+  ) {
+    return true;
+  }
+  if ((fields.valueText ?? '').trim()) return true;
+  if ((fields.report ?? '').trim()) return true;
+  return false;
+}
+
+function componentNameMatchesExam(
+  examName: string,
+  componentName: string,
+): boolean {
+  const examKey = normalizeExamLabelKey(examName);
+  const compKey = normalizeExamLabelKey(componentName);
+  if (!examKey || !compKey) return false;
+  if (examKey === compKey) return true;
+  for (const alias of extractParentheticalAliases(examName)) {
+    if (normalizeExamLabelKey(alias) === compKey) return true;
+  }
+  if (examKey.includes(compKey) || compKey.includes(examKey)) return true;
+  return false;
+}
+
+export interface CollapsibleExamResultFields {
+  valueNumeric?: number | null;
+  valueText?: string | null;
+  unit?: string | null;
+  referenceRange?: string | null;
+  isAbnormal?: boolean | null;
+  report?: string | null;
+  components?: unknown;
+}
+
+/**
+ * Promove único subitem sinônimo do exame para campos do resultado pai antes de persistir.
+ */
+export function collapseRedundantComponentsForSave(
+  examName: string,
+  fields: CollapsibleExamResultFields,
+): CollapsibleExamResultFields {
+  const comps = parseComponents(fields.components);
+  if (comps.length !== 1 || resultHasMainValue(fields)) {
+    return fields;
+  }
+  const sole = comps[0];
+  if (!sole.name?.trim() || !componentNameMatchesExam(examName, sole.name)) {
+    return fields;
+  }
+  return {
+    ...fields,
+    valueNumeric: sole.valueNumeric ?? fields.valueNumeric ?? null,
+    valueText: sole.valueText ?? fields.valueText ?? null,
+    unit: sole.unit ?? fields.unit ?? null,
+    referenceRange: sole.referenceRange ?? fields.referenceRange ?? null,
+    isAbnormal:
+      typeof sole.isAbnormal === 'boolean'
+        ? sole.isAbnormal
+        : (fields.isAbnormal ?? null),
+    components: undefined,
+  };
+}

--- a/backend/src/complementary-exams/collapse-redundant-components.util.ts
+++ b/backend/src/complementary-exams/collapse-redundant-components.util.ts
@@ -14,29 +14,31 @@ export function extractParentheticalAliases(examName: string): string[] {
   let m: RegExpExecArray | null;
   while ((m = re.exec(examName)) !== null) {
     const inner = m[1].trim();
-    if (inner) aliases.push(inner);
+    if (inner) {aliases.push(inner);}
   }
   return aliases;
 }
 
 function parseComponents(raw: unknown): ExamResultComponentInput[] {
-  if (raw == null) return [];
+  if (raw === null || raw === undefined) {
+    return [];
+  }
   if (typeof raw === 'string') {
     const t = raw.trim();
-    if (!t) return [];
+    if (!t) {return [];}
     try {
       return parseComponents(JSON.parse(t) as unknown);
     } catch {
       return [];
     }
   }
-  if (!Array.isArray(raw)) return [];
+  if (!Array.isArray(raw)) {return [];}
   const out: ExamResultComponentInput[] = [];
   for (const el of raw) {
-    if (!el || typeof el !== 'object' || Array.isArray(el)) continue;
+    if (!el || typeof el !== 'object' || Array.isArray(el)) {continue;}
     const o = el as Record<string, unknown>;
     const nameRaw = o.name;
-    if (typeof nameRaw !== 'string' || !nameRaw.trim()) continue;
+    if (typeof nameRaw !== 'string' || !nameRaw.trim()) {continue;}
     const vn = o.valueNumeric ?? o.value_numeric;
     let valueNumeric: number | undefined;
     if (vn !== null && vn !== undefined && vn !== '') {
@@ -44,7 +46,7 @@ function parseComponents(raw: unknown): ExamResultComponentInput[] {
         valueNumeric = vn;
       } else {
         const n = Number(vn);
-        if (Number.isFinite(n)) valueNumeric = n;
+        if (Number.isFinite(n)) {valueNumeric = n;}
       }
     }
     const vt = o.valueText ?? o.value_text;
@@ -84,8 +86,8 @@ function resultHasMainValue(fields: {
   ) {
     return true;
   }
-  if ((fields.valueText ?? '').trim()) return true;
-  if ((fields.report ?? '').trim()) return true;
+  if ((fields.valueText ?? '').trim()) {return true;}
+  if ((fields.report ?? '').trim()) {return true;}
   return false;
 }
 
@@ -95,12 +97,12 @@ function componentNameMatchesExam(
 ): boolean {
   const examKey = normalizeExamLabelKey(examName);
   const compKey = normalizeExamLabelKey(componentName);
-  if (!examKey || !compKey) return false;
-  if (examKey === compKey) return true;
+  if (!examKey || !compKey) {return false;}
+  if (examKey === compKey) {return true;}
   for (const alias of extractParentheticalAliases(examName)) {
-    if (normalizeExamLabelKey(alias) === compKey) return true;
+    if (normalizeExamLabelKey(alias) === compKey) {return true;}
   }
-  if (examKey.includes(compKey) || compKey.includes(examKey)) return true;
+  if (examKey.includes(compKey) || compKey.includes(examKey)) {return true;}
   return false;
 }
 

--- a/backend/src/complementary-exams/complementary-exam-canonical.util.spec.ts
+++ b/backend/src/complementary-exams/complementary-exam-canonical.util.spec.ts
@@ -1,0 +1,76 @@
+import {
+  CANONICAL_GROUP_RENAL_CREAT_ETFG,
+  CANONICAL_GROUP_VIT_D_25OH,
+  preferredDisplayNameForGroup,
+  resolveCanonicalExamGroupId,
+} from './complementary-exam-canonical.util';
+
+describe('complementary-exam-canonical.util', () => {
+  it('agrupa creatinina, dosagem com eTFG e eTFG isolado em RENAL_CREAT_ETFG', () => {
+    const renal = `CANON|${CANONICAL_GROUP_RENAL_CREAT_ETFG}`;
+    expect(
+      resolveCanonicalExamGroupId('LABORATORY', 'Creatinina', 'CREAT'),
+    ).toBe(renal);
+    expect(
+      resolveCanonicalExamGroupId(
+        'LABORATORY',
+        'Dosagem de Creatinina com eTFG',
+      ),
+    ).toBe(renal);
+    expect(resolveCanonicalExamGroupId('LABORATORY', 'eTFG')).toBe(renal);
+    expect(resolveCanonicalExamGroupId('LABORATORY', 'eGFR')).toBe(renal);
+  });
+
+  it('exclui creatinina urinária do grupo renal', () => {
+    expect(
+      resolveCanonicalExamGroupId('LABORATORY', 'Creatinina urinária', 'CREAT-U'),
+    ).not.toBe(`CANON|${CANONICAL_GROUP_RENAL_CREAT_ETFG}`);
+    expect(
+      resolveCanonicalExamGroupId('LABORATORY', 'Creatinina urina 24h', 'CREAT-24H'),
+    ).not.toBe(`CANON|${CANONICAL_GROUP_RENAL_CREAT_ETFG}`);
+  });
+
+  it('agrupa sinónimos de vitamina D 25-OH', () => {
+    const vit = `CANON|${CANONICAL_GROUP_VIT_D_25OH}`;
+    expect(
+      resolveCanonicalExamGroupId('LABORATORY', 'Vitamina D 25(OH)D'),
+    ).toBe(vit);
+    expect(
+      resolveCanonicalExamGroupId('LABORATORY', '25-Hidroxi-Vitamina D'),
+    ).toBe(vit);
+  });
+
+  it('usa LOINC quando presente e regra canónica não aplicou', () => {
+    expect(
+      resolveCanonicalExamGroupId(
+        'LABORATORY',
+        'Hemoglobina',
+        'Hb',
+        '718-7',
+      ),
+    ).toBe('LOINC|7187');
+  });
+
+  it('fallback NAME normaliza acentos e caixa', () => {
+    const a = resolveCanonicalExamGroupId('LABORATORY', 'TSH');
+    const b = resolveCanonicalExamGroupId('LABORATORY', 'tsh');
+    expect(a).toBe(b);
+    expect(a).toBe('NAME|tsh');
+  });
+
+  it('preferredDisplayNameForGroup devolve rótulos canónicos', () => {
+    expect(
+      preferredDisplayNameForGroup(
+        `CANON|${CANONICAL_GROUP_RENAL_CREAT_ETFG}`,
+        'eTFG',
+      ),
+    ).toBe('Creatinina');
+    expect(
+      preferredDisplayNameForGroup(
+        `CANON|${CANONICAL_GROUP_VIT_D_25OH}`,
+        '25-Hidroxi-Vitamina D',
+      ),
+    ).toBe('Vitamina D 25-OH');
+    expect(preferredDisplayNameForGroup('NAME|tsh', 'TSH')).toBe('TSH');
+  });
+});

--- a/backend/src/complementary-exams/complementary-exam-canonical.util.ts
+++ b/backend/src/complementary-exams/complementary-exam-canonical.util.ts
@@ -1,0 +1,111 @@
+import { normalizeExamLabelKey } from './collapse-redundant-components.util';
+
+export const CANONICAL_GROUP_RENAL_CREAT_ETFG = 'RENAL_CREAT_ETFG';
+export const CANONICAL_GROUP_VIT_D_25OH = 'VIT_D_25OH';
+
+const RENAL_CREAT_CODES = new Set(['CREAT', 'CR']);
+
+function isUrinaryCreatinineName(name: string): boolean {
+  const n = name.toLowerCase();
+  return (
+    /creatinina.*urin|urin[aá].*creatinina|clearance|depura[cç][aã]o/.test(n) ||
+    /creatinina.*24\s*h|24\s*h.*creatinina|creatinina.*24h|24h.*creatinina/.test(
+      n,
+    )
+  );
+}
+
+function isUrinaryCreatinineCode(code: string | null | undefined): boolean {
+  const c = (code ?? '').trim().toUpperCase();
+  return c === 'CREAT-U' || c === 'CREAT-24H';
+}
+
+function matchesRenalCreatEtfg(
+  type: string,
+  name: string,
+  code?: string | null,
+): boolean {
+  if (type !== 'LABORATORY') return false;
+  if (isUrinaryCreatinineName(name) || isUrinaryCreatinineCode(code)) {
+    return false;
+  }
+
+  const c = (code ?? '').trim().toUpperCase();
+  if (c && RENAL_CREAT_CODES.has(c)) return true;
+
+  const n = name.toLowerCase();
+  if (/creatinina/.test(n)) return true;
+
+  if (
+    /^e\s*tfg\b|^egfr\b|^tfg\b/.test(n) ||
+    /\betfg\b/.test(n) ||
+    /\begfr\b/.test(n) ||
+    /taxa\s+de\s+filtra/.test(n) ||
+    /filtra[cç][aã]o\s+glomerular/.test(n)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function matchesVitD25oh(type: string, name: string): boolean {
+  if (type !== 'LABORATORY') return false;
+  const n = name.toLowerCase();
+
+  if (/25[\s\-]*hidroxi[\s\-]*vitamina\s*d|25[\s\-]*hidroxi\s*vit\s*d/.test(n)) {
+    return true;
+  }
+
+  const hasVitD =
+    /vitamina\s*d\b|vit\s*d\b/.test(n) || /^vit\s*d\b/.test(n.trim());
+  const has25oh =
+    /25\s*\(?\s*oh\s*\)?\s*d|25[\s\-]*oh|25[\s\-]*hidroxi|\(oh\)d/.test(n);
+
+  if (hasVitD && has25oh) return true;
+
+  if (/25[\s\-]*hidroxi/.test(n) && /vit/.test(n)) return true;
+
+  return false;
+}
+
+/**
+ * Identificador estável para agrupar sinónimos clínicos (UI + ingestão).
+ * Ordem: regras canónicas → LOINC → nome normalizado.
+ */
+export function resolveCanonicalExamGroupId(
+  type: string,
+  name: string,
+  code?: string | null,
+  loincCode?: string | null,
+): string {
+  if (matchesRenalCreatEtfg(type, name, code)) {
+    return `CANON|${CANONICAL_GROUP_RENAL_CREAT_ETFG}`;
+  }
+  if (matchesVitD25oh(type, name)) {
+    return `CANON|${CANONICAL_GROUP_VIT_D_25OH}`;
+  }
+
+  const trimmedLoinc =
+    loincCode === null || loincCode === undefined
+      ? ''
+      : String(loincCode).trim();
+  if (trimmedLoinc) {
+    return `LOINC|${normalizeExamLabelKey(trimmedLoinc)}`;
+  }
+
+  return `NAME|${normalizeExamLabelKey(name)}`;
+}
+
+export function preferredDisplayNameForGroup(
+  canonicalId: string,
+  fallbackName: string,
+): string {
+  if (canonicalId === `CANON|${CANONICAL_GROUP_RENAL_CREAT_ETFG}`) {
+    return 'Creatinina';
+  }
+  if (canonicalId === `CANON|${CANONICAL_GROUP_VIT_D_25OH}`) {
+    return 'Vitamina D 25-OH';
+  }
+  return fallbackName;
+}

--- a/backend/src/complementary-exams/complementary-exam-canonical.util.ts
+++ b/backend/src/complementary-exams/complementary-exam-canonical.util.ts
@@ -1,111 +1,44 @@
-import { normalizeExamLabelKey } from './collapse-redundant-components.util';
+import {
+  buildComplementaryExamMatchKey,
+  preferredDisplayNameForIdentity,
+  resolveExamIdentity,
+} from './complementary-exam-identity.util';
 
 export const CANONICAL_GROUP_RENAL_CREAT_ETFG = 'RENAL_CREAT_ETFG';
 export const CANONICAL_GROUP_VIT_D_25OH = 'VIT_D_25OH';
 
-const RENAL_CREAT_CODES = new Set(['CREAT', 'CR']);
-
-function isUrinaryCreatinineName(name: string): boolean {
-  const n = name.toLowerCase();
-  return (
-    /creatinina.*urin|urin[aá].*creatinina|clearance|depura[cç][aã]o/.test(n) ||
-    /creatinina.*24\s*h|24\s*h.*creatinina|creatinina.*24h|24h.*creatinina/.test(
-      n,
-    )
-  );
-}
-
-function isUrinaryCreatinineCode(code: string | null | undefined): boolean {
-  const c = (code ?? '').trim().toUpperCase();
-  return c === 'CREAT-U' || c === 'CREAT-24H';
-}
-
-function matchesRenalCreatEtfg(
-  type: string,
-  name: string,
-  code?: string | null,
-): boolean {
-  if (type !== 'LABORATORY') return false;
-  if (isUrinaryCreatinineName(name) || isUrinaryCreatinineCode(code)) {
-    return false;
-  }
-
-  const c = (code ?? '').trim().toUpperCase();
-  if (c && RENAL_CREAT_CODES.has(c)) return true;
-
-  const n = name.toLowerCase();
-  if (/creatinina/.test(n)) return true;
-
-  if (
-    /^e\s*tfg\b|^egfr\b|^tfg\b/.test(n) ||
-    /\betfg\b/.test(n) ||
-    /\begfr\b/.test(n) ||
-    /taxa\s+de\s+filtra/.test(n) ||
-    /filtra[cç][aã]o\s+glomerular/.test(n)
-  ) {
-    return true;
-  }
-
-  return false;
-}
-
-function matchesVitD25oh(type: string, name: string): boolean {
-  if (type !== 'LABORATORY') return false;
-  const n = name.toLowerCase();
-
-  if (/25[\s\-]*hidroxi[\s\-]*vitamina\s*d|25[\s\-]*hidroxi\s*vit\s*d/.test(n)) {
-    return true;
-  }
-
-  const hasVitD =
-    /vitamina\s*d\b|vit\s*d\b/.test(n) || /^vit\s*d\b/.test(n.trim());
-  const has25oh =
-    /25\s*\(?\s*oh\s*\)?\s*d|25[\s\-]*oh|25[\s\-]*hidroxi|\(oh\)d/.test(n);
-
-  if (hasVitD && has25oh) return true;
-
-  if (/25[\s\-]*hidroxi/.test(n) && /vit/.test(n)) return true;
-
-  return false;
-}
-
-/**
- * Identificador estável para agrupar sinónimos clínicos (UI + ingestão).
- * Ordem: regras canónicas → LOINC → nome normalizado.
- */
+/** @deprecated Use resolveExamIdentity — mantido para testes legados. */
 export function resolveCanonicalExamGroupId(
   type: string,
   name: string,
   code?: string | null,
   loincCode?: string | null,
 ): string {
-  if (matchesRenalCreatEtfg(type, name, code)) {
-    return `CANON|${CANONICAL_GROUP_RENAL_CREAT_ETFG}`;
-  }
-  if (matchesVitD25oh(type, name)) {
-    return `CANON|${CANONICAL_GROUP_VIT_D_25OH}`;
-  }
-
-  const trimmedLoinc =
-    loincCode === null || loincCode === undefined
-      ? ''
-      : String(loincCode).trim();
-  if (trimmedLoinc) {
-    return `LOINC|${normalizeExamLabelKey(trimmedLoinc)}`;
-  }
-
-  return `NAME|${normalizeExamLabelKey(name)}`;
+  const identity = resolveExamIdentity(type, name, code, loincCode);
+  const prefix = `${type.trim().toUpperCase()}|`;
+  return identity.groupKey.startsWith(prefix)
+    ? identity.groupKey.slice(prefix.length)
+    : identity.groupKey;
 }
 
 export function preferredDisplayNameForGroup(
   canonicalId: string,
   fallbackName: string,
 ): string {
-  if (canonicalId === `CANON|${CANONICAL_GROUP_RENAL_CREAT_ETFG}`) {
-    return 'Creatinina';
-  }
-  if (canonicalId === `CANON|${CANONICAL_GROUP_VIT_D_25OH}`) {
-    return 'Vitamina D 25-OH';
+  const renal = `CANON|${CANONICAL_GROUP_RENAL_CREAT_ETFG}`;
+  const vit = `CANON|${CANONICAL_GROUP_VIT_D_25OH}`;
+  if (canonicalId === renal) {return 'Creatinina';}
+  if (canonicalId === vit) {return 'Vitamina D 25-OH';}
+  if (canonicalId.startsWith('CATALOG|')) {
+    const code = canonicalId.slice('CATALOG|'.length);
+    if (code === 'UREIA') {return 'Ureia';}
+    if (code === 'HIV') {return 'HIV';}
   }
   return fallbackName;
 }
+
+export {
+  buildComplementaryExamMatchKey,
+  resolveExamIdentity,
+  preferredDisplayNameForIdentity,
+};

--- a/backend/src/complementary-exams/complementary-exam-canonical.util.ts
+++ b/backend/src/complementary-exams/complementary-exam-canonical.util.ts
@@ -1,44 +1,111 @@
-import {
-  buildComplementaryExamMatchKey,
-  preferredDisplayNameForIdentity,
-  resolveExamIdentity,
-} from './complementary-exam-identity.util';
+import { normalizeExamLabelKey } from './collapse-redundant-components.util';
 
 export const CANONICAL_GROUP_RENAL_CREAT_ETFG = 'RENAL_CREAT_ETFG';
 export const CANONICAL_GROUP_VIT_D_25OH = 'VIT_D_25OH';
 
-/** @deprecated Use resolveExamIdentity — mantido para testes legados. */
+const RENAL_CREAT_CODES = new Set(['CREAT', 'CR']);
+
+function isUrinaryCreatinineName(name: string): boolean {
+  const n = name.toLowerCase();
+  return (
+    /creatinina.*urin|urin[aá].*creatinina|clearance|depura[cç][aã]o/.test(n) ||
+    /creatinina.*24\s*h|24\s*h.*creatinina|creatinina.*24h|24h.*creatinina/.test(
+      n,
+    )
+  );
+}
+
+function isUrinaryCreatinineCode(code: string | null | undefined): boolean {
+  const c = (code ?? '').trim().toUpperCase();
+  return c === 'CREAT-U' || c === 'CREAT-24H';
+}
+
+function matchesRenalCreatEtfg(
+  type: string,
+  name: string,
+  code?: string | null,
+): boolean {
+  if (type !== 'LABORATORY') {return false;}
+  if (isUrinaryCreatinineName(name) || isUrinaryCreatinineCode(code)) {
+    return false;
+  }
+
+  const c = (code ?? '').trim().toUpperCase();
+  if (c && RENAL_CREAT_CODES.has(c)) {return true;}
+
+  const n = name.toLowerCase();
+  if (/creatinina/.test(n)) {return true;}
+
+  if (
+    /^e\s*tfg\b|^egfr\b|^tfg\b/.test(n) ||
+    /\betfg\b/.test(n) ||
+    /\begfr\b/.test(n) ||
+    /taxa\s+de\s+filtra/.test(n) ||
+    /filtra[cç][aã]o\s+glomerular/.test(n)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function matchesVitD25oh(type: string, name: string): boolean {
+  if (type !== 'LABORATORY') {return false;}
+  const n = name.toLowerCase();
+
+  if (/25[\s-]*hidroxi[\s-]*vitamina\s*d|25[\s-]*hidroxi\s*vit\s*d/.test(n)) {
+    return true;
+  }
+
+  const hasVitD =
+    /vitamina\s*d\b|vit\s*d\b/.test(n) || /^vit\s*d\b/.test(n.trim());
+  const has25oh =
+    /25\s*\(?\s*oh\s*\)?\s*d|25[\s-]*oh|25[\s-]*hidroxi|\(oh\)d/.test(n);
+
+  if (hasVitD && has25oh) {return true;}
+
+  if (/25[\s-]*hidroxi/.test(n) && /vit/.test(n)) {return true;}
+
+  return false;
+}
+
+/**
+ * Identificador estável para agrupar sinónimos clínicos (UI + ingestão).
+ * Ordem: regras canónicas → LOINC → nome normalizado.
+ */
 export function resolveCanonicalExamGroupId(
   type: string,
   name: string,
   code?: string | null,
   loincCode?: string | null,
 ): string {
-  const identity = resolveExamIdentity(type, name, code, loincCode);
-  const prefix = `${type.trim().toUpperCase()}|`;
-  return identity.groupKey.startsWith(prefix)
-    ? identity.groupKey.slice(prefix.length)
-    : identity.groupKey;
+  if (matchesRenalCreatEtfg(type, name, code)) {
+    return `CANON|${CANONICAL_GROUP_RENAL_CREAT_ETFG}`;
+  }
+  if (matchesVitD25oh(type, name)) {
+    return `CANON|${CANONICAL_GROUP_VIT_D_25OH}`;
+  }
+
+  const trimmedLoinc =
+    loincCode === null || loincCode === undefined
+      ? ''
+      : String(loincCode).trim();
+  if (trimmedLoinc) {
+    return `LOINC|${normalizeExamLabelKey(trimmedLoinc)}`;
+  }
+
+  return `NAME|${normalizeExamLabelKey(name)}`;
 }
 
 export function preferredDisplayNameForGroup(
   canonicalId: string,
   fallbackName: string,
 ): string {
-  const renal = `CANON|${CANONICAL_GROUP_RENAL_CREAT_ETFG}`;
-  const vit = `CANON|${CANONICAL_GROUP_VIT_D_25OH}`;
-  if (canonicalId === renal) {return 'Creatinina';}
-  if (canonicalId === vit) {return 'Vitamina D 25-OH';}
-  if (canonicalId.startsWith('CATALOG|')) {
-    const code = canonicalId.slice('CATALOG|'.length);
-    if (code === 'UREIA') {return 'Ureia';}
-    if (code === 'HIV') {return 'HIV';}
+  if (canonicalId === `CANON|${CANONICAL_GROUP_RENAL_CREAT_ETFG}`) {
+    return 'Creatinina';
+  }
+  if (canonicalId === `CANON|${CANONICAL_GROUP_VIT_D_25OH}`) {
+    return 'Vitamina D 25-OH';
   }
   return fallbackName;
 }
-
-export {
-  buildComplementaryExamMatchKey,
-  resolveExamIdentity,
-  preferredDisplayNameForIdentity,
-};

--- a/backend/src/complementary-exams/complementary-exam-match.util.ts
+++ b/backend/src/complementary-exams/complementary-exam-match.util.ts
@@ -2,7 +2,7 @@ import {
   ComplementaryExamType,
   Prisma,
 } from '@generated/prisma/client';
-import { normalizeExamLabelKey } from './collapse-redundant-components.util';
+import { resolveCanonicalExamGroupId } from './complementary-exam-canonical.util';
 
 const YMD_ONLY = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -15,12 +15,15 @@ export function buildComplementaryExamMatchKey(
   type: string,
   name: string,
   code?: string | null,
+  loincCode?: string | null,
 ): string {
-  const codePart =
-    code === null || code === undefined || String(code).trim() === ''
-      ? ''
-      : normalizeExamLabelKey(String(code).trim());
-  return `${type}|${normalizeExamLabelKey(name)}|${codePart}`;
+  const canonicalId = resolveCanonicalExamGroupId(
+    type,
+    name,
+    code,
+    loincCode,
+  );
+  return `${type}|${canonicalId}`;
 }
 
 /**
@@ -45,11 +48,21 @@ export function parseComplementaryPerformedAt(
 }
 
 function examRowMatchesKey(
-  row: { type: ComplementaryExamType; name: string; code: string | null },
+  row: {
+    type: ComplementaryExamType;
+    name: string;
+    code: string | null;
+    loincCode: string | null;
+  },
   matchKey: string,
 ): boolean {
   return (
-    buildComplementaryExamMatchKey(row.type, row.name, row.code) === matchKey
+    buildComplementaryExamMatchKey(
+      row.type,
+      row.name,
+      row.code,
+      row.loincCode,
+    ) === matchKey
   );
 }
 
@@ -71,7 +84,16 @@ export async function findOrCreateComplementaryExam(
     code === null || code === undefined
       ? null
       : String(code).trim().slice(0, 64) || null;
-  const matchKey = buildComplementaryExamMatchKey(type, trimmedName, trimmedCode);
+  const trimmedLoinc =
+    loincCode === null || loincCode === undefined
+      ? null
+      : String(loincCode).trim().slice(0, 32) || null;
+  const matchKey = buildComplementaryExamMatchKey(
+    type,
+    trimmedName,
+    trimmedCode,
+    trimmedLoinc,
+  );
 
   const cached = batchCache?.get(matchKey);
   if (cached) {
@@ -80,7 +102,7 @@ export async function findOrCreateComplementaryExam(
 
   const existingRows = await tx.complementaryExam.findMany({
     where: { tenantId, patientId, type },
-    select: { id: true, name: true, code: true, type: true },
+    select: { id: true, name: true, code: true, type: true, loincCode: true },
   });
   const found = existingRows.find((row) => examRowMatchesKey(row, matchKey));
   if (found) {
@@ -95,10 +117,7 @@ export async function findOrCreateComplementaryExam(
       type,
       name: trimmedName,
       code: trimmedCode,
-      loincCode:
-        loincCode === null || loincCode === undefined
-          ? null
-          : String(loincCode).trim().slice(0, 32) || null,
+      loincCode: trimmedLoinc,
     },
   });
   batchCache?.set(matchKey, { id: created.id, name: created.name });

--- a/backend/src/complementary-exams/complementary-exam-match.util.ts
+++ b/backend/src/complementary-exams/complementary-exam-match.util.ts
@@ -1,0 +1,180 @@
+import {
+  ComplementaryExamType,
+  Prisma,
+} from '@generated/prisma/client';
+import { normalizeExamLabelKey } from './collapse-redundant-components.util';
+
+const YMD_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+export type ComplementaryExamMatchBatchCache = Map<
+  string,
+  { id: string; name: string }
+>;
+
+export function buildComplementaryExamMatchKey(
+  type: string,
+  name: string,
+  code?: string | null,
+): string {
+  const codePart =
+    code === null || code === undefined || String(code).trim() === ''
+      ? ''
+      : normalizeExamLabelKey(String(code).trim());
+  return `${type}|${normalizeExamLabelKey(name)}|${codePart}`;
+}
+
+/**
+ * Data só com YYYY-MM-DD → início do dia UTC (00:00:00.000Z).
+ * ISO com hora → instante exato após parse.
+ */
+export function parseComplementaryPerformedAt(
+  raw: string | null | undefined,
+): Date | null {
+  if (raw === null || raw === undefined || String(raw).trim() === '') {
+    return null;
+  }
+  const s = String(raw).trim();
+  if (YMD_ONLY.test(s)) {
+    return new Date(`${s}T00:00:00.000Z`);
+  }
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) {
+    return null;
+  }
+  return d;
+}
+
+function examRowMatchesKey(
+  row: { type: ComplementaryExamType; name: string; code: string | null },
+  matchKey: string,
+): boolean {
+  return (
+    buildComplementaryExamMatchKey(row.type, row.name, row.code) === matchKey
+  );
+}
+
+export async function findOrCreateComplementaryExam(
+  tx: Prisma.TransactionClient,
+  args: {
+    tenantId: string;
+    patientId: string;
+    type: ComplementaryExamType;
+    name: string;
+    code?: string | null;
+    loincCode?: string | null;
+    batchCache?: ComplementaryExamMatchBatchCache;
+  },
+): Promise<{ id: string; created: boolean }> {
+  const { tenantId, patientId, type, name, code, loincCode, batchCache } = args;
+  const trimmedName = name.trim().slice(0, 400);
+  const trimmedCode =
+    code === null || code === undefined
+      ? null
+      : String(code).trim().slice(0, 64) || null;
+  const matchKey = buildComplementaryExamMatchKey(type, trimmedName, trimmedCode);
+
+  const cached = batchCache?.get(matchKey);
+  if (cached) {
+    return { id: cached.id, created: false };
+  }
+
+  const existingRows = await tx.complementaryExam.findMany({
+    where: { tenantId, patientId, type },
+    select: { id: true, name: true, code: true, type: true },
+  });
+  const found = existingRows.find((row) => examRowMatchesKey(row, matchKey));
+  if (found) {
+    batchCache?.set(matchKey, { id: found.id, name: found.name });
+    return { id: found.id, created: false };
+  }
+
+  const created = await tx.complementaryExam.create({
+    data: {
+      tenantId,
+      patientId,
+      type,
+      name: trimmedName,
+      code: trimmedCode,
+      loincCode:
+        loincCode === null || loincCode === undefined
+          ? null
+          : String(loincCode).trim().slice(0, 32) || null,
+    },
+  });
+  batchCache?.set(matchKey, { id: created.id, name: created.name });
+  return { id: created.id, created: true };
+}
+
+export type UpsertComplementaryExamResultPayload = {
+  valueNumeric?: number | null;
+  valueText?: string | null;
+  unit?: string | null;
+  referenceRange?: string | null;
+  isAbnormal?: boolean | null;
+  report?: string | null;
+  components?: Prisma.InputJsonValue | undefined;
+};
+
+export async function upsertComplementaryExamResult(
+  tx: Prisma.TransactionClient,
+  args: {
+    tenantId: string;
+    examId: string;
+    performedAt: Date;
+    collectionId?: string | null;
+    payload: UpsertComplementaryExamResultPayload;
+  },
+): Promise<{ id: string; created: boolean }> {
+  const { tenantId, examId, performedAt, collectionId, payload } = args;
+
+  const existing = await tx.complementaryExamResult.findFirst({
+    where: {
+      tenantId,
+      examId,
+      performedAt,
+      deletedAt: null,
+    },
+    select: { id: true },
+  });
+
+  const collection =
+    collectionId !== null &&
+    collectionId !== undefined &&
+    collectionId !== ''
+      ? { collectionId }
+      : {};
+
+  if (existing) {
+    const updated = await tx.complementaryExamResult.update({
+      where: { id: existing.id },
+      data: {
+        valueNumeric: payload.valueNumeric ?? null,
+        valueText: payload.valueText ?? null,
+        unit: payload.unit ?? null,
+        referenceRange: payload.referenceRange ?? null,
+        isAbnormal: payload.isAbnormal ?? null,
+        report: payload.report ?? null,
+        components: payload.components,
+        ...collection,
+      },
+    });
+    return { id: updated.id, created: false };
+  }
+
+  const created = await tx.complementaryExamResult.create({
+    data: {
+      tenantId,
+      examId,
+      performedAt,
+      ...collection,
+      valueNumeric: payload.valueNumeric ?? null,
+      valueText: payload.valueText ?? null,
+      unit: payload.unit ?? null,
+      referenceRange: payload.referenceRange ?? null,
+      isAbnormal: payload.isAbnormal ?? null,
+      report: payload.report ?? null,
+      components: payload.components,
+    },
+  });
+  return { id: created.id, created: true };
+}

--- a/backend/src/complementary-exams/complementary-exams.service.ts
+++ b/backend/src/complementary-exams/complementary-exams.service.ts
@@ -13,6 +13,7 @@ import { CreateComplementaryExamResultDto } from './dto/create-complementary-exa
 import { UpdateComplementaryExamResultDto } from './dto/update-complementary-exam-result.dto';
 import { parsePerformedAtDateOnly } from '../common/utils/date-only.util';
 import { isSpecimenAllowedForType } from './specimen-allowed.util';
+import { collapseRedundantComponentsForSave } from './collapse-redundant-components.util';
 import {
   computeIsAbnormalFromRange,
   enrichComponentsWithAbnormal,
@@ -200,20 +201,37 @@ export class ComplementaryExamsService {
         ? exam.referenceRange
         : dto.referenceRange;
 
+    const collapsed = collapseRedundantComponentsForSave(exam.name, {
+      valueNumeric: dto.valueNumeric,
+      valueText: dto.valueText,
+      unit: unitFromExam,
+      referenceRange: referenceFromExam,
+      isAbnormal: dto.isAbnormal,
+      report: dto.report,
+      components: dto.components,
+    });
+
     const componentsPayload = enrichComponentsWithAbnormal(
-      dto.components as ExamResultComponentInput[] | undefined,
+      collapsed.components as ExamResultComponentInput[] | undefined,
     );
+
+    const valueNumericResolved = collapsed.valueNumeric ?? dto.valueNumeric;
+    const valueTextResolved = collapsed.valueText ?? dto.valueText;
+    const unitResolved = collapsed.unit ?? unitFromExam;
+    const referenceResolved = collapsed.referenceRange ?? referenceFromExam;
 
     let isAbnormalResolved: boolean;
     if (componentsPayload?.length) {
       isAbnormalResolved = componentsPayload.some((c) => c.isAbnormal);
     } else {
       const computed = computeIsAbnormalFromRange(
-        dto.valueNumeric,
-        referenceFromExam,
+        valueNumericResolved,
+        referenceResolved,
       );
       isAbnormalResolved =
-        computed !== null ? computed : (dto.isAbnormal ?? false);
+        computed !== null
+          ? computed
+          : (collapsed.isAbnormal ?? dto.isAbnormal ?? false);
     }
 
     const result = await this.prisma.complementaryExamResult.create({
@@ -222,14 +240,14 @@ export class ComplementaryExamsService {
         tenantId,
         performedAt,
         collectionId: dto.collectionId,
-        valueNumeric: dto.valueNumeric,
-        valueText: dto.valueText,
-        unit: unitFromExam,
-        referenceRange: referenceFromExam,
+        valueNumeric: valueNumericResolved,
+        valueText: valueTextResolved,
+        unit: unitResolved,
+        referenceRange: referenceResolved,
         isAbnormal: isAbnormalResolved,
         criticalHigh: dto.criticalHigh,
         criticalLow: dto.criticalLow,
-        report: dto.report,
+        report: collapsed.report ?? dto.report,
         components: componentsPayload
           ? (componentsPayload as object)
           : undefined,
@@ -293,16 +311,52 @@ export class ComplementaryExamsService {
     const valueNumericMerged =
       dto.valueNumeric !== undefined ? dto.valueNumeric : result.valueNumeric;
 
-    const componentsPayload =
-      dto.components !== undefined
-        ? enrichComponentsWithAbnormal(
-            dto.components as ExamResultComponentInput[],
-          )
-        : undefined;
+    const touchesResultValues =
+      dto.components !== undefined ||
+      dto.valueNumeric !== undefined ||
+      dto.valueText !== undefined ||
+      dto.unit !== undefined ||
+      dto.referenceRange !== undefined ||
+      dto.report !== undefined;
 
-    let isAbnormalResolved: boolean;
-    if (componentsPayload?.length) {
-      isAbnormalResolved = componentsPayload.some((c) => c.isAbnormal);
+    let componentsPayload: ReturnType<typeof enrichComponentsWithAbnormal>;
+    let isAbnormalResolved: boolean | undefined;
+    let valueNumericForUpdate = dto.valueNumeric;
+    let valueTextForUpdate = dto.valueText;
+    let unitForUpdate = unitResolved;
+    let referenceForUpdate = referenceResolved;
+    let reportForUpdate = dto.report;
+    let componentsForUpdate: object | undefined;
+
+    if (touchesResultValues) {
+      const collapsed = collapseRedundantComponentsForSave(exam.name, {
+        valueNumeric: valueNumericMerged,
+        valueText:
+          dto.valueText !== undefined ? dto.valueText : result.valueText,
+        unit: unitResolved,
+        referenceRange: referenceResolved,
+        isAbnormal:
+          dto.isAbnormal !== undefined ? dto.isAbnormal : result.isAbnormal,
+        report: dto.report !== undefined ? dto.report : result.report,
+        components:
+          dto.components !== undefined ? dto.components : result.components,
+      });
+      componentsPayload = enrichComponentsWithAbnormal(
+        collapsed.components as ExamResultComponentInput[] | undefined,
+      );
+      valueNumericForUpdate = collapsed.valueNumeric ?? undefined;
+      valueTextForUpdate = collapsed.valueText ?? undefined;
+      unitForUpdate = collapsed.unit ?? unitResolved;
+      referenceForUpdate = collapsed.referenceRange ?? referenceResolved;
+      reportForUpdate =
+        collapsed.report !== undefined && collapsed.report !== null
+          ? collapsed.report
+          : dto.report !== undefined
+            ? dto.report
+            : result.report ?? undefined;
+      componentsForUpdate = componentsPayload
+        ? (componentsPayload as object)
+        : undefined;
     } else if (
       dto.components === undefined &&
       result.components &&
@@ -313,7 +367,22 @@ export class ComplementaryExamsService {
         result.components as unknown as ExamResultComponentInput[],
       );
       isAbnormalResolved = enriched?.some((c) => c.isAbnormal) ?? false;
-    } else {
+    }
+
+    if (touchesResultValues) {
+      if (componentsPayload?.length) {
+        isAbnormalResolved = componentsPayload.some((c) => c.isAbnormal);
+      } else {
+        const computed = computeIsAbnormalFromRange(
+          valueNumericForUpdate ?? undefined,
+          referenceForUpdate,
+        );
+        isAbnormalResolved =
+          computed !== null
+            ? computed
+            : (dto.isAbnormal ?? result.isAbnormal ?? false);
+      }
+    } else if (isAbnormalResolved === undefined) {
       const computed = computeIsAbnormalFromRange(
         valueNumericMerged ?? undefined,
         referenceResolved,
@@ -329,18 +398,15 @@ export class ComplementaryExamsService {
       data: {
         performedAt: performedAtUpdate,
         collectionId: dto.collectionId,
-        valueNumeric: dto.valueNumeric,
-        valueText: dto.valueText,
-        unit: unitResolved,
-        referenceRange: referenceResolved,
+        valueNumeric: valueNumericForUpdate,
+        valueText: valueTextForUpdate,
+        unit: unitForUpdate,
+        referenceRange: referenceForUpdate,
         isAbnormal: isAbnormalResolved,
         criticalHigh: dto.criticalHigh,
         criticalLow: dto.criticalLow,
-        report: dto.report,
-        components:
-          componentsPayload !== undefined
-            ? (componentsPayload as object)
-            : undefined,
+        report: reportForUpdate,
+        components: touchesResultValues ? componentsForUpdate : undefined,
       },
     });
 

--- a/backend/src/medication-catalog/medication-catalog.controller.ts
+++ b/backend/src/medication-catalog/medication-catalog.controller.ts
@@ -1,0 +1,80 @@
+import {
+  Controller,
+  DefaultValuePipe,
+  Get,
+  Param,
+  ParseIntPipe,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { MedicationCatalogService } from './medication-catalog.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { TenantGuard } from '../auth/guards/tenant.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { UserRole } from '@generated/prisma/client';
+
+@Controller('medication-catalog')
+@UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
+export class MedicationCatalogController {
+  constructor(
+    private readonly medicationCatalogService: MedicationCatalogService
+  ) {}
+
+  @Get('routes')
+  @Roles(
+    UserRole.ADMIN,
+    UserRole.ONCOLOGIST,
+    UserRole.DOCTOR,
+    UserRole.NURSE_CHIEF,
+    UserRole.NURSE,
+    UserRole.COORDINATOR
+  )
+  listRoutes() {
+    return this.medicationCatalogService.listRoutes();
+  }
+
+  @Get()
+  @Roles(
+    UserRole.ADMIN,
+    UserRole.ONCOLOGIST,
+    UserRole.DOCTOR,
+    UserRole.NURSE_CHIEF,
+    UserRole.NURSE,
+    UserRole.COORDINATOR
+  )
+  search(
+    @Query('q') q?: string,
+    @Query('limit', new DefaultValuePipe(50), ParseIntPipe) limit?: number,
+    @Query('offset', new DefaultValuePipe(0), ParseIntPipe) offset?: number
+  ) {
+    const safeLimit = Math.min(Math.max(limit ?? 50, 1), 500);
+    const safeOffset = Math.max(offset ?? 0, 0);
+    return this.medicationCatalogService.search({
+      q,
+      limit: safeLimit,
+      offset: safeOffset,
+    });
+  }
+
+  @Get(':drugCode/presentations')
+  @Roles(
+    UserRole.ADMIN,
+    UserRole.ONCOLOGIST,
+    UserRole.DOCTOR,
+    UserRole.NURSE_CHIEF,
+    UserRole.NURSE,
+    UserRole.COORDINATOR
+  )
+  listPresentations(
+    @Param('drugCode') drugCode: string,
+    @Query('q') q?: string,
+    @Query('limit', new DefaultValuePipe(50), ParseIntPipe) limit?: number
+  ) {
+    const safeLimit = Math.min(Math.max(limit ?? 50, 1), 200);
+    return this.medicationCatalogService.listPresentations(drugCode, {
+      q,
+      limit: safeLimit,
+    });
+  }
+}

--- a/backend/src/medication-catalog/medication-catalog.module.ts
+++ b/backend/src/medication-catalog/medication-catalog.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { MedicationCatalogController } from './medication-catalog.controller';
+import { MedicationCatalogService } from './medication-catalog.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [MedicationCatalogController],
+  providers: [MedicationCatalogService],
+  exports: [MedicationCatalogService],
+})
+export class MedicationCatalogModule {}

--- a/backend/src/medication-catalog/medication-catalog.routes.ts
+++ b/backend/src/medication-catalog/medication-catalog.routes.ts
@@ -21,7 +21,7 @@ export function isAllowedMedicationRoute(
   allowedRoutes: string[]
 ): boolean {
   const normalized = route.trim().toUpperCase();
-  if (!normalized) return true;
-  if (allowedRoutes.length === 0) return true;
+  if (!normalized) {return true;}
+  if (allowedRoutes.length === 0) {return true;}
   return allowedRoutes.some((r) => r.toUpperCase() === normalized);
 }

--- a/backend/src/medication-catalog/medication-catalog.routes.ts
+++ b/backend/src/medication-catalog/medication-catalog.routes.ts
@@ -1,0 +1,27 @@
+/** Vias de administração canónicas (código → rótulo PT). */
+export const MEDICATION_CATALOG_ROUTES = [
+  { code: 'VO', label: 'Via oral (VO)' },
+  { code: 'SL', label: 'Sublingual (SL)' },
+  { code: 'IV', label: 'Intravenosa (IV)' },
+  { code: 'IM', label: 'Intramuscular (IM)' },
+  { code: 'SC', label: 'Subcutânea (SC)' },
+  { code: 'TD', label: 'Transdérmica (TD)' },
+  { code: 'INH', label: 'Inalatória (INH)' },
+  { code: 'TOP', label: 'Tópica (TOP)' },
+  { code: 'RECT', label: 'Retal (RECT)' },
+  { code: 'NASAL', label: 'Nasal' },
+  { code: 'OFT', label: 'Oftálmica' },
+] as const;
+
+export type MedicationCatalogRouteCode =
+  (typeof MEDICATION_CATALOG_ROUTES)[number]['code'];
+
+export function isAllowedMedicationRoute(
+  route: string,
+  allowedRoutes: string[]
+): boolean {
+  const normalized = route.trim().toUpperCase();
+  if (!normalized) return true;
+  if (allowedRoutes.length === 0) return true;
+  return allowedRoutes.some((r) => r.toUpperCase() === normalized);
+}

--- a/backend/src/medication-catalog/medication-catalog.service.spec.ts
+++ b/backend/src/medication-catalog/medication-catalog.service.spec.ts
@@ -1,0 +1,57 @@
+import { NotFoundException } from '@nestjs/common';
+import { MedicationCatalogService } from './medication-catalog.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+describe('MedicationCatalogService', () => {
+  let service: MedicationCatalogService;
+  const mockPrisma = {
+    medicationCatalogDrug: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+      findUnique: jest.fn(),
+    },
+    medicationCatalogPresentation: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+    },
+    $transaction: jest.fn((fn: (tx: unknown) => unknown) => fn(mockPrisma)),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new MedicationCatalogService(
+      mockPrisma as unknown as PrismaService
+    );
+  });
+
+  describe('search', () => {
+    it('returns paginated drugs', async () => {
+      mockPrisma.medicationCatalogDrug.findMany.mockResolvedValue([
+        { code: 'WARFARIN', displayName: 'Varfarina' },
+      ]);
+      mockPrisma.medicationCatalogDrug.count.mockResolvedValue(1);
+
+      const result = await service.search({ limit: 10, offset: 0 });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.total).toBe(1);
+    });
+  });
+
+  describe('listPresentations', () => {
+    it('throws when drug missing', async () => {
+      mockPrisma.medicationCatalogDrug.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.listPresentations('UNKNOWN', { limit: 10 })
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('listRoutes', () => {
+    it('returns canonical routes', () => {
+      const { routes } = service.listRoutes();
+      expect(routes.some((r) => r.code === 'VO')).toBe(true);
+    });
+  });
+});

--- a/backend/src/medication-catalog/medication-catalog.service.ts
+++ b/backend/src/medication-catalog/medication-catalog.service.ts
@@ -1,0 +1,147 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@generated/prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { MEDICATION_CATALOG_ROUTES } from './medication-catalog.routes';
+
+import type { MedicationCatalogSeedDrug } from '../../prisma/medication-catalog-seed-data';
+export type { MedicationCatalogSeedDrug };
+
+@Injectable()
+export class MedicationCatalogService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  listRoutes() {
+    return { routes: MEDICATION_CATALOG_ROUTES };
+  }
+
+  async search(params: { q?: string; limit: number; offset: number }) {
+    const { q, limit, offset } = params;
+    const where: Prisma.MedicationCatalogDrugWhereInput = {};
+    const trimmed = q?.trim();
+    if (trimmed) {
+      where.OR = [
+        { displayName: { contains: trimmed, mode: 'insensitive' } },
+        { genericName: { contains: trimmed, mode: 'insensitive' } },
+        { code: { contains: trimmed, mode: 'insensitive' } },
+      ];
+    }
+    const [items, total] = await Promise.all([
+      this.prisma.medicationCatalogDrug.findMany({
+        where,
+        take: limit,
+        skip: offset,
+        orderBy: [{ displayName: 'asc' }],
+        select: {
+          code: true,
+          genericName: true,
+          displayName: true,
+          category: true,
+          allowedRoutes: true,
+        },
+      }),
+      this.prisma.medicationCatalogDrug.count({ where }),
+    ]);
+    return { items, total, limit, offset };
+  }
+
+  async listPresentations(
+    drugCode: string,
+    params: { q?: string; limit: number }
+  ) {
+    const drug = await this.prisma.medicationCatalogDrug.findUnique({
+      where: { code: drugCode },
+      select: { code: true, displayName: true },
+    });
+    if (!drug) {
+      throw new NotFoundException('Medicamento não encontrado no catálogo');
+    }
+    const where: Prisma.MedicationCatalogPresentationWhereInput = {
+      drugCode,
+    };
+    const trimmed = params.q?.trim();
+    if (trimmed) {
+      where.OR = [
+        { label: { contains: trimmed, mode: 'insensitive' } },
+        { code: { contains: trimmed, mode: 'insensitive' } },
+        { strength: { contains: trimmed, mode: 'insensitive' } },
+      ];
+    }
+    const items = await this.prisma.medicationCatalogPresentation.findMany({
+      where,
+      take: params.limit,
+      orderBy: [{ label: 'asc' }],
+      select: {
+        code: true,
+        drugCode: true,
+        label: true,
+        strength: true,
+        form: true,
+      },
+    });
+    return { drug, items };
+  }
+
+  async findDrugByCode(code: string) {
+    return this.prisma.medicationCatalogDrug.findUnique({
+      where: { code },
+      include: { presentations: true },
+    });
+  }
+
+  async findPresentationByCode(code: string) {
+    return this.prisma.medicationCatalogPresentation.findUnique({
+      where: { code },
+      include: { drug: true },
+    });
+  }
+
+  async importSeed(drugs: MedicationCatalogSeedDrug[], sourceVersion?: string) {
+    return this.prisma.$transaction(async (tx) => {
+      let upsertedDrugs = 0;
+      let upsertedPresentations = 0;
+      for (const row of drugs) {
+        await tx.medicationCatalogDrug.upsert({
+          where: { code: row.code },
+          create: {
+            code: row.code,
+            genericName: row.genericName,
+            displayName: row.displayName,
+            category: row.category as never,
+            allowedRoutes: row.allowedRoutes,
+            sourceVersion: sourceVersion ?? null,
+          },
+          update: {
+            genericName: row.genericName,
+            displayName: row.displayName,
+            category: row.category as never,
+            allowedRoutes: row.allowedRoutes,
+            ...(sourceVersion !== undefined ? { sourceVersion } : {}),
+          },
+        });
+        upsertedDrugs++;
+        for (const pres of row.presentations) {
+          await tx.medicationCatalogPresentation.upsert({
+            where: { code: pres.code },
+            create: {
+              code: pres.code,
+              drugCode: row.code,
+              label: pres.label,
+              strength: pres.strength ?? null,
+              form: pres.form ?? null,
+              sourceVersion: sourceVersion ?? null,
+            },
+            update: {
+              drugCode: row.code,
+              label: pres.label,
+              strength: pres.strength ?? null,
+              form: pres.form ?? null,
+              ...(sourceVersion !== undefined ? { sourceVersion } : {}),
+            },
+          });
+          upsertedPresentations++;
+        }
+      }
+      return { upsertedDrugs, upsertedPresentations, sourceVersion: sourceVersion ?? null };
+    });
+  }
+}

--- a/frontend/src/components/patients/__tests__/patient-prontuario-lab-history.test.tsx
+++ b/frontend/src/components/patients/__tests__/patient-prontuario-lab-history.test.tsx
@@ -251,4 +251,51 @@ describe('PatientProntuarioLabHistory (smoke)', () => {
     expect(screen.queryByText('99')).not.toBeInTheDocument();
     expect(screen.getByText('11')).toBeInTheDocument();
   });
+
+  it('TTPa sinônimo aparece na linha principal sem subitens', () => {
+    const exam = makeLabExam({
+      name: 'Tempo de Tromboplastina Parcial Ativado (TTPa)',
+      results: [
+        {
+          id: 'res-ttpa',
+          performedAt: '2023-10-17T12:00:00.000Z',
+          collectionId: null,
+          valueNumeric: null,
+          valueText: null,
+          unit: null,
+          referenceRange: null,
+          isAbnormal: null,
+          criticalHigh: null,
+          criticalLow: null,
+          report: null,
+          components: [
+            {
+              name: 'TTPa',
+              valueNumeric: 28.7,
+              unit: 'seg',
+              referenceRange: '25,4 a 33,4',
+              isAbnormal: null,
+            },
+          ],
+        },
+      ],
+    });
+    render(<PatientProntuarioLabHistory patient={makePatientDetail([exam])} />);
+
+    const root = screen.getByLabelText('Histórico laboratorial');
+    expect(
+      within(root).getByRole('heading', {
+        name: 'Tempo de Tromboplastina Parcial Ativado (TTPa)',
+      })
+    ).toBeInTheDocument();
+    expect(within(root).getByText('28.7')).toBeInTheDocument();
+    expect(within(root).getByText('seg')).toBeInTheDocument();
+    expect(
+      within(root).queryByRole('button', {
+        name: /Expandir subitens da coleta de 17\/10\/2023/i,
+      })
+    ).not.toBeInTheDocument();
+    expect(within(root).queryByRole('columnheader', { name: 'Subitem' })).not.toBeInTheDocument();
+    expect(within(root).queryByRole('cell', { name: 'TTPa' })).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/patients/clinical-note-orders-panel.tsx
+++ b/frontend/src/components/patients/clinical-note-orders-panel.tsx
@@ -20,7 +20,15 @@ import {
 import { tissGuidesApi } from '@/lib/api/tiss-guides';
 import type { ClinicalNoteType } from '@/lib/api/clinical-notes';
 import { toast } from 'sonner';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
+import { ExamCatalogCombobox } from '@/components/shared/exam-catalog-combobox';
+import { useDebounce } from '@/lib/utils/use-debounce';
+import { useExamCatalogComboboxOptions } from '@/hooks/use-exam-catalog-combobox-options';
+import type { ExamCatalogSelection } from '@/hooks/use-exam-catalog-combobox-options';
+import { buildExamRequestPayload } from '@/lib/utils/clinical-orders-payload';
+import { PrescriptionLineForm } from '@/components/patients/prescription-line-form';
+import { PrescriptionHistoryPanel } from '@/components/patients/prescription-history-panel';
+import type { PrescriptionDraftFromHistory } from '@/lib/utils/clinical-orders-payload';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -166,13 +174,24 @@ export function ClinicalNoteOrdersPanel(props: {
   };
 
   const [examName, setExamName] = useState('');
+  const [examCatalogSelection, setExamCatalogSelection] =
+    useState<ExamCatalogSelection | null>(null);
+  const debouncedExamQ = useDebounce(examName, 300);
+  const { options: examCatalogOptions } = useExamCatalogComboboxOptions(debouncedExamQ);
+
   const addExam = useMutation({
     mutationFn: () =>
-      clinicalNoteOrdersApi.createExamRequest(patientId, clinicalNoteId, {
-        displayName: examName.trim(),
-      }),
+      clinicalNoteOrdersApi.createExamRequest(
+        patientId,
+        clinicalNoteId,
+        buildExamRequestPayload({
+          displayName: examName,
+          catalogSelection: examCatalogSelection,
+        })
+      ),
     onSuccess: () => {
       setExamName('');
+      setExamCatalogSelection(null);
       invalidate();
       toast.success('Pedido de exame registrado.');
     },
@@ -199,30 +218,22 @@ export function ClinicalNoteOrdersPanel(props: {
     onError: () => toast.error('Não foi possível remover o pedido.'),
   });
 
-  const [medName, setMedName] = useState('');
-  const [medDose, setMedDose] = useState('');
-  const [medFreq, setMedFreq] = useState('');
-  const [medRoute, setMedRoute] = useState('');
-  const [medPosology, setMedPosology] = useState('');
+  const [rxDraft, setRxDraft] = useState<PrescriptionDraftFromHistory | null>(null);
+  const rxDraftQueueRef = useRef<PrescriptionDraftFromHistory[]>([]);
 
   const addRx = useMutation({
-    mutationFn: () =>
-      clinicalNoteOrdersApi.createPrescriptionLine(
-        patientId,
-        clinicalNoteId,
-        {
-          medicationName: medName.trim(),
-          dosage: medDose.trim() || undefined,
-          frequency: (medFreq.trim() || medPosology.trim()) || undefined,
-          route: medRoute.trim() || undefined,
-        }
-      ),
+    mutationFn: (body: {
+      medicationName: string;
+      catalogKey?: string;
+      presentationCatalogCode?: string;
+      dosage?: string;
+      frequency?: string;
+      route?: string;
+      duration?: string;
+      indication?: string;
+    }) =>
+      clinicalNoteOrdersApi.createPrescriptionLine(patientId, clinicalNoteId, body),
     onSuccess: () => {
-      setMedName('');
-      setMedDose('');
-      setMedFreq('');
-      setMedRoute('');
-      setMedPosology('');
       invalidate();
       toast.success('Medicamento adicionado à prescrição.');
     },
@@ -550,13 +561,21 @@ export function ClinicalNoteOrdersPanel(props: {
         {canEditExams && (
           <div className="flex flex-col sm:flex-row gap-2 items-end pt-2">
             <div className="flex-1 w-full space-y-1">
-              <Label htmlFor="exam-request-name">Nome do exame</Label>
-              <Input
-                id="exam-request-name"
+              <Label htmlFor="exam-request-name">Exame (catálogo ou texto livre)</Label>
+              <ExamCatalogCombobox
+                options={examCatalogOptions}
                 value={examName}
-                onChange={(e) => setExamName(e.target.value)}
-                placeholder="Ex.: Hemograma completo"
-                autoComplete="off"
+                onValueChange={(v) => {
+                  setExamName(v);
+                  setExamCatalogSelection(null);
+                }}
+                onSelectOption={(opt) => {
+                  setExamCatalogSelection(opt.data);
+                  setExamName(opt.data.displayName);
+                }}
+                placeholder="Pesquisar por nome ou código TUSS..."
+                emptyText="Nenhum exame no catálogo — use o texto digitado."
+                disabled={addExam.isPending}
               />
             </div>
             <Button
@@ -654,68 +673,38 @@ export function ClinicalNoteOrdersPanel(props: {
             )}
           </ul>
           {canEditRx && (
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 pt-2">
-              <div className="space-y-1 sm:col-span-2">
-                <Label htmlFor="rx-med-name">Medicamento</Label>
-                <Input
-                  id="rx-med-name"
-                  value={medName}
-                  onChange={(e) => setMedName(e.target.value)}
-                  placeholder="Nome ou apresentação"
-                  autoComplete="off"
-                />
-              </div>
-              <div className="space-y-1">
-                <Label htmlFor="rx-dose">Dose</Label>
-                <Input
-                  id="rx-dose"
-                  value={medDose}
-                  onChange={(e) => setMedDose(e.target.value)}
-                  placeholder="Ex.: 1 comprimido"
-                  autoComplete="off"
-                />
-              </div>
-              <div className="space-y-1">
-                <Label htmlFor="rx-freq">Frequência</Label>
-                <Input
-                  id="rx-freq"
-                  value={medFreq}
-                  onChange={(e) => setMedFreq(e.target.value)}
-                  placeholder="Ex.: 12/12 h"
-                  autoComplete="off"
-                />
-              </div>
-              <div className="space-y-1 sm:col-span-2">
-                <Label htmlFor="rx-posology">Posologia (texto livre)</Label>
-                <Input
-                  id="rx-posology"
-                  value={medPosology}
-                  onChange={(e) => setMedPosology(e.target.value)}
-                  placeholder="Ex.: 50 mg 12/12 h VO"
-                  autoComplete="on"
-                />
-              </div>
-              <div className="space-y-1 sm:col-span-2">
-                <Label htmlFor="rx-route">Via</Label>
-                <Input
-                  id="rx-route"
-                  value={medRoute}
-                  onChange={(e) => setMedRoute(e.target.value)}
-                  placeholder="Ex.: VO, IV"
-                  autoComplete="off"
-                />
-              </div>
-              <div className="sm:col-span-2">
-                <Button
-                  type="button"
-                  size="sm"
-                  disabled={addRx.isPending || !medName.trim()}
-                  onClick={() => addRx.mutate()}
-                >
-                  Adicionar à prescrição
-                </Button>
-              </div>
-            </div>
+            <>
+              <PrescriptionHistoryPanel
+                patientId={patientId}
+                currentClinicalNoteId={clinicalNoteId}
+                onReuse={(draft) => setRxDraft(draft)}
+                onReuseAllFromNote={(drafts) => {
+                  rxDraftQueueRef.current = [...drafts];
+                  if (drafts[0]) setRxDraft(drafts[0]);
+                  toast.message(
+                    `${drafts.length} item(ns) na fila — confira e clique em Adicionar para cada um.`
+                  );
+                }}
+              />
+              <PrescriptionLineForm
+                disabled={!canEditRx}
+                pending={addRx.isPending}
+                draft={rxDraft}
+                onDraftConsumed={() => setRxDraft(null)}
+                onSubmit={(values) => {
+                  addRx.mutate(values, {
+                    onSuccess: () => {
+                      const queue = rxDraftQueueRef.current;
+                      if (queue.length > 0) {
+                        const [next, ...rest] = queue;
+                        rxDraftQueueRef.current = rest;
+                        setRxDraft(next);
+                      }
+                    },
+                  });
+                }}
+              />
+            </>
           )}
         </section>
       )}

--- a/frontend/src/components/patients/clinical-note-orders-panel.tsx
+++ b/frontend/src/components/patients/clinical-note-orders-panel.tsx
@@ -679,8 +679,10 @@ export function ClinicalNoteOrdersPanel(props: {
                 currentClinicalNoteId={clinicalNoteId}
                 onReuse={(draft) => setRxDraft(draft)}
                 onReuseAllFromNote={(drafts) => {
-                  rxDraftQueueRef.current = [...drafts];
-                  if (drafts[0]) setRxDraft(drafts[0]);
+                  if (drafts.length === 0) return;
+                  const [first, ...rest] = drafts;
+                  rxDraftQueueRef.current = rest;
+                  setRxDraft(first);
                   toast.message(
                     `${drafts.length} item(ns) na fila — confira e clique em Adicionar para cada um.`
                   );

--- a/frontend/src/components/patients/complementary-exam-chart-dialog.tsx
+++ b/frontend/src/components/patients/complementary-exam-chart-dialog.tsx
@@ -33,8 +33,8 @@ import {
   buildParentNumericChartPoints,
   collectUniqueComponentNames,
   examHasPanelComponents,
+  collapseRedundantSingleComponent,
   guessComponentUnit,
-  normalizeComplementaryResultComponents,
 } from '@/lib/utils/complementary-exam-series';
 
 interface ComplementaryExamChartDialogProps {
@@ -65,10 +65,14 @@ export function ComplementaryExamChartDialog({
   const chartData = React.useMemo(() => {
     if (needsSubitemPick) {
       if (!selectedSubitem.trim()) return [];
-      return buildComponentNumericChartPoints(exam.results, selectedSubitem);
+      return buildComponentNumericChartPoints(
+        exam.results,
+        selectedSubitem,
+        exam.name
+      );
     }
-    return buildParentNumericChartPoints(exam.results);
-  }, [exam.results, needsSubitemPick, selectedSubitem]);
+    return buildParentNumericChartPoints(exam.results, exam.name);
+  }, [exam.results, exam.name, needsSubitemPick, selectedSubitem]);
 
   const hasNumericSeries = chartData.length >= 1;
   const chartUnit = needsSubitemPick && selectedSubitem
@@ -175,7 +179,12 @@ export function ComplementaryExamChartDialog({
                       })}
                     </span>
                     <span>
-                      {formatResultSummary(r, needsSubitemPick, selectedSubitem)}
+                      {formatResultSummary(
+                        exam.name,
+                        r,
+                        needsSubitemPick,
+                        selectedSubitem
+                      )}
                     </span>
                   </li>
                 ))}
@@ -188,13 +197,18 @@ export function ComplementaryExamChartDialog({
 }
 
 function formatResultSummary(
+  examName: string,
   r: ComplementaryExamResult,
   needsSubitem: boolean,
   selectedSubitem: string
 ): React.ReactNode {
+  const { result: displayResult, displayComponents } =
+    collapseRedundantSingleComponent(examName, r);
+
   if (needsSubitem && selectedSubitem.trim()) {
-    const c = normalizeComplementaryResultComponents(r.components).find(
-      (x) => x.name && x.name.trim().toLowerCase() === selectedSubitem.trim().toLowerCase()
+    const want = selectedSubitem.trim().toLowerCase();
+    const c = displayComponents.find(
+      (x) => x.name && x.name.trim().toLowerCase() === want
     );
     if (c) {
       const text =
@@ -214,10 +228,12 @@ function formatResultSummary(
   }
   return (
     <>
-      {r.valueNumeric != null
-        ? `${r.valueNumeric}${r.unit ? ` ${r.unit}` : ''}`
-        : (r.valueText ?? '-')}
-      {r.isAbnormal && <span className="text-amber-600 ml-1">(fora ref.)</span>}
+      {displayResult.valueNumeric != null
+        ? `${displayResult.valueNumeric}${displayResult.unit ? ` ${displayResult.unit}` : ''}`
+        : (displayResult.valueText ?? '-')}
+      {displayResult.isAbnormal && (
+        <span className="text-amber-600 ml-1">(fora ref.)</span>
+      )}
     </>
   );
 }

--- a/frontend/src/components/patients/patient-clinical-tab.tsx
+++ b/frontend/src/components/patients/patient-clinical-tab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   PatientDetail,
   Comorbidity,
@@ -20,6 +20,10 @@ import { ComplementaryExamChartDialog } from './complementary-exam-chart-dialog'
 import { ComplementaryExamCreateDialog } from './complementary-exam-create-dialog';
 import { ComplementaryExamResultCreateDialog } from './complementary-exam-result-create-dialog';
 import { PatientSymptomTimeline } from './patient-symptom-timeline';
+import {
+  formatComplementaryResultPerformedAt,
+  groupComplementaryExamsByName,
+} from '@/lib/utils/complementary-exam-series';
 
 interface PatientClinicalTabProps {
   patient: PatientDetail;
@@ -69,11 +73,15 @@ export function PatientClinicalTab({
     null
   );
 
-  const complementaryExams: ComplementaryExam[] = Array.isArray(
-    patient.complementaryExams
-  )
-    ? patient.complementaryExams
-    : [];
+  const complementaryExams: ComplementaryExam[] = useMemo(
+    () =>
+      groupComplementaryExamsByName(
+        Array.isArray(patient.complementaryExams)
+          ? patient.complementaryExams
+          : []
+      ),
+    [patient.complementaryExams]
+  );
 
   const comorbidities: Comorbidity[] = Array.isArray(patient.comorbidities)
     ? patient.comorbidities
@@ -252,10 +260,9 @@ export function PatientClinicalTab({
                                   className="flex items-baseline justify-between gap-2 py-1 border-b border-border/50 last:border-0"
                                 >
                                   <span className="text-muted-foreground shrink-0">
-                                    {format(
-                                      new Date(r.performedAt),
-                                      'dd/MM/yyyy',
-                                      { locale: ptBR }
+                                    {formatComplementaryResultPerformedAt(
+                                      exam.results,
+                                      r.performedAt
                                     )}
                                   </span>
                                   <span className="text-right truncate min-w-0">

--- a/frontend/src/components/patients/patient-prontuario-lab-history.tsx
+++ b/frontend/src/components/patients/patient-prontuario-lab-history.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import React, { useMemo, useState } from 'react';
-import { format } from 'date-fns';
-import { ptBR } from 'date-fns/locale';
 import { ChevronDown, ChevronRight, LineChart as LineChartIcon } from 'lucide-react';
 import type {
   ComplementaryExam,
@@ -12,8 +10,9 @@ import type {
 import { Button } from '@/components/ui/button';
 import { ComplementaryExamChartDialog } from '@/components/patients/complementary-exam-chart-dialog';
 import {
-  filterActiveComplementaryResults,
-  normalizeComplementaryResultComponents,
+  collapseRedundantSingleComponent,
+  formatComplementaryResultPerformedAt,
+  groupComplementaryExamsByName,
 } from '@/lib/utils/complementary-exam-series';
 
 interface PatientProntuarioLabHistoryProps {
@@ -37,11 +36,10 @@ export function PatientProntuarioLabHistory({
     const raw = Array.isArray(patient.complementaryExams)
       ? patient.complementaryExams
       : [];
-    return raw
-      .filter((e) => e.type === 'LABORATORY')
+    return groupComplementaryExamsByName(raw.filter((e) => e.type === 'LABORATORY'))
       .map((e) => ({
         ...e,
-        results: filterActiveComplementaryResults(e.results).sort(
+        results: [...e.results].sort(
           (a, b) =>
             new Date(a.performedAt).getTime() - new Date(b.performedAt).getTime()
         ),
@@ -144,9 +142,8 @@ export function PatientProntuarioLabHistory({
                   </tr>
                 ) : (
                   exam.results.map((r) => {
-                    const comps = normalizeComplementaryResultComponents(
-                      r.components
-                    );
+                    const { result: displayResult, displayComponents: comps } =
+                      collapseRedundantSingleComponent(exam.name, r);
                     const hasChildren = comps.length > 0;
                     const isOpen = expandedIds.has(r.id);
                     const panelId = `lab-panel-${exam.id}-${r.id}`;
@@ -166,8 +163,8 @@ export function PatientProntuarioLabHistory({
                                 onClick={() => toggleExpanded(r.id)}
                                 aria-label={
                                   isOpen
-                                    ? `Recolher subitens da coleta de ${format(new Date(r.performedAt), 'dd/MM/yyyy', { locale: ptBR })}`
-                                    : `Expandir subitens da coleta de ${format(new Date(r.performedAt), 'dd/MM/yyyy', { locale: ptBR })}`
+                                    ? `Recolher subitens da coleta de ${formatComplementaryResultPerformedAt(exam.results, r.performedAt)}`
+                                    : `Expandir subitens da coleta de ${formatComplementaryResultPerformedAt(exam.results, r.performedAt)}`
                                 }
                               >
                                 {isOpen ? (
@@ -179,25 +176,26 @@ export function PatientProntuarioLabHistory({
                             ) : null}
                           </td>
                           <td className="sticky left-10 z-10 whitespace-nowrap border-b border-border/60 bg-background px-2 py-2 text-muted-foreground shadow-[1px_0_0_0_hsl(var(--border))] odd:bg-muted/30">
-                            {format(new Date(r.performedAt), 'dd/MM/yyyy', {
-                              locale: ptBR,
-                            })}
+                            {formatComplementaryResultPerformedAt(
+                              exam.results,
+                              r.performedAt
+                            )}
                           </td>
                           <td className="border-b border-border/60 px-2 py-2 font-medium">
-                            {formatResultMainValue(r)}
+                            {formatResultMainValue(displayResult)}
                           </td>
                           <td className="border-b border-border/60 px-2 py-2 text-muted-foreground">
-                            {r.unit ?? '—'}
+                            {displayResult.unit ?? '—'}
                           </td>
                           <td className="border-b border-border/60 px-2 py-2 text-muted-foreground">
-                            {r.referenceRange ?? '—'}
+                            {displayResult.referenceRange ?? '—'}
                           </td>
                           <td className="border-b border-border/60 px-2 py-2 text-xs">
                             {(() => {
                               const bits: string[] = [];
-                              if (r.criticalHigh) bits.push('Crítico alto');
-                              if (r.criticalLow) bits.push('Crítico baixo');
-                              if (r.isAbnormal) bits.push('Fora da ref.');
+                              if (displayResult.criticalHigh) bits.push('Crítico alto');
+                              if (displayResult.criticalLow) bits.push('Crítico baixo');
+                              if (displayResult.isAbnormal) bits.push('Fora da ref.');
                               if (bits.length === 0) {
                                 return <span className="text-muted-foreground">—</span>;
                               }

--- a/frontend/src/components/patients/prescription-history-panel.tsx
+++ b/frontend/src/components/patients/prescription-history-panel.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { prescriptionHistoryApi, type PrescriptionHistoryRow } from '@/lib/api/clinical-note-orders';
+import { useDebounce } from '@/lib/utils/use-debounce';
+import type { PrescriptionDraftFromHistory } from '@/lib/utils/clinical-orders-payload';
+import { prescriptionDraftFromHistoryRow } from '@/lib/utils/clinical-orders-payload';
+
+type Props = {
+  patientId: string;
+  currentClinicalNoteId: string;
+  onReuse: (draft: PrescriptionDraftFromHistory) => void;
+  onReuseAllFromNote: (drafts: PrescriptionDraftFromHistory[]) => void;
+};
+
+function formatNoteContext(row: PrescriptionHistoryRow): string {
+  const status =
+    row.clinicalNote.status === 'SIGNED'
+      ? 'assinada'
+      : row.clinicalNote.status === 'DRAFT'
+        ? 'rascunho'
+        : row.clinicalNote.status;
+  const signed = row.clinicalNote.signedAt
+    ? new Date(row.clinicalNote.signedAt).toLocaleDateString('pt-BR')
+    : null;
+  return signed ? `${status} · ${signed}` : status;
+}
+
+export function PrescriptionHistoryPanel({
+  patientId,
+  currentClinicalNoteId,
+  onReuse,
+  onReuseAllFromNote,
+}: Props) {
+  const [search, setSearch] = useState('');
+  const debouncedQ = useDebounce(search, 300);
+
+  const historyQuery = useQuery({
+    queryKey: ['prescription-history', patientId, debouncedQ],
+    queryFn: () =>
+      prescriptionHistoryApi.list(patientId, {
+        q: debouncedQ || undefined,
+        limit: 50,
+        offset: 0,
+      }),
+    staleTime: 30_000,
+  });
+
+  const items = historyQuery.data?.items ?? [];
+
+  const reuseAllForNote = (noteId: string) => {
+    const rows = items.filter((r) => r.clinicalNoteId === noteId);
+    onReuseAllFromNote(rows.map(prescriptionDraftFromHistoryRow));
+  };
+
+  return (
+    <section
+      className="space-y-2 rounded-md border p-3"
+      aria-label="Histórico de prescrições do paciente"
+    >
+      <h4 className="text-sm font-medium">Histórico de prescrições</h4>
+      <p className="text-xs text-muted-foreground">
+        Reutilizar copia os dados para o formulário abaixo; nada é salvo até você clicar em Adicionar.
+      </p>
+      <div className="space-y-1">
+        <Label htmlFor="rx-history-search">Buscar</Label>
+        <Input
+          id="rx-history-search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Medicamento, dose, via..."
+          autoComplete="off"
+        />
+      </div>
+      {historyQuery.isLoading && (
+        <p className="text-xs text-muted-foreground">Carregando histórico…</p>
+      )}
+      {historyQuery.isError && (
+        <p className="text-xs text-destructive" role="alert">
+          Falha ao carregar histórico.
+        </p>
+      )}
+      <ul className="space-y-2 text-sm max-h-64 overflow-y-auto">
+        {items.map((row) => {
+          const sig = [row.dosage, row.frequency, row.route, row.duration]
+            .filter(Boolean)
+            .join(' · ');
+          const isCurrentNote = row.clinicalNoteId === currentClinicalNoteId;
+          return (
+            <li
+              key={row.id}
+              className="flex flex-wrap gap-2 items-start justify-between border-b border-border/60 pb-2 last:border-0"
+            >
+              <div className="min-w-0 flex-1">
+                <span className="font-medium">{row.medicationName}</span>
+                <span className="text-xs text-muted-foreground block">
+                  {sig || '—'}
+                </span>
+                <span className="text-xs text-muted-foreground block">
+                  {row.prescribedBy.name} · {formatNoteContext(row)}
+                  {isCurrentNote ? ' · evolução atual' : ''}
+                </span>
+                {row.indication && (
+                  <span className="text-xs text-muted-foreground block">
+                    Indicação: {row.indication}
+                  </span>
+                )}
+              </div>
+              <div className="flex flex-col gap-1 shrink-0">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => onReuse(prescriptionDraftFromHistoryRow(row))}
+                >
+                  Reutilizar
+                </Button>
+                {!isCurrentNote && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="text-xs"
+                    onClick={() => reuseAllForNote(row.clinicalNoteId)}
+                  >
+                    Reutilizar todas desta evolução
+                  </Button>
+                )}
+              </div>
+            </li>
+          );
+        })}
+        {!historyQuery.isLoading && items.length === 0 && (
+          <li className="text-xs text-muted-foreground">Nenhuma prescrição anterior.</li>
+        )}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/components/patients/prescription-line-form.tsx
+++ b/frontend/src/components/patients/prescription-line-form.tsx
@@ -65,6 +65,18 @@ export function PrescriptionLineForm({
     if (draft.catalogKey) {
       setFreeText(false);
       setDrugQuery(draft.medicationName);
+      setSelectedDrug(null);
+      const catalogKey = draft.catalogKey;
+      void medicationCatalogApi
+        .search({ q: catalogKey, limit: 20, offset: 0 })
+        .then((res) => {
+          const drug =
+            res.items.find((d) => d.code === catalogKey) ?? res.items[0] ?? null;
+          if (drug) setSelectedDrug(drug);
+        })
+        .catch(() => {
+          /* catálogo indisponível: usuário pode reselecionar manualmente */
+        });
     } else {
       setFreeText(true);
       setSelectedDrug(null);

--- a/frontend/src/components/patients/prescription-line-form.tsx
+++ b/frontend/src/components/patients/prescription-line-form.tsx
@@ -1,0 +1,295 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { SearchableSelect } from '@/components/ui/searchable-select';
+import { ExamCatalogCombobox } from '@/components/shared/exam-catalog-combobox';
+import {
+  medicationCatalogApi,
+  type MedicationCatalogDrug,
+  type MedicationCatalogPresentation,
+} from '@/lib/api/medication-catalog';
+import { useDebounce } from '@/lib/utils/use-debounce';
+import type { PrescriptionDraftFromHistory } from '@/lib/utils/clinical-orders-payload';
+
+export type PrescriptionLineFormValues = {
+  medicationName: string;
+  catalogKey?: string;
+  presentationCatalogCode?: string;
+  dosage?: string;
+  frequency?: string;
+  route?: string;
+  duration?: string;
+  indication?: string;
+};
+
+type Props = {
+  disabled?: boolean;
+  pending?: boolean;
+  draft?: PrescriptionDraftFromHistory | null;
+  onDraftConsumed?: () => void;
+  onSubmit: (values: PrescriptionLineFormValues) => void;
+};
+
+export function PrescriptionLineForm({
+  disabled,
+  pending,
+  draft,
+  onDraftConsumed,
+  onSubmit,
+}: Props) {
+  const [freeText, setFreeText] = useState(false);
+  const [drugQuery, setDrugQuery] = useState('');
+  const debouncedDrugQ = useDebounce(drugQuery, 300);
+  const [selectedDrug, setSelectedDrug] = useState<MedicationCatalogDrug | null>(null);
+  const [presentationCode, setPresentationCode] = useState('');
+  const [medName, setMedName] = useState('');
+  const [medDose, setMedDose] = useState('');
+  const [medFreq, setMedFreq] = useState('');
+  const [medRoute, setMedRoute] = useState('');
+  const [medDuration, setMedDuration] = useState('');
+  const [medIndication, setMedIndication] = useState('');
+
+  useEffect(() => {
+    if (!draft) return;
+    setMedName(draft.medicationName);
+    setMedDose(draft.dosage ?? '');
+    setMedFreq(draft.frequency ?? '');
+    setMedRoute(draft.route ?? '');
+    setMedDuration(draft.duration ?? '');
+    setMedIndication(draft.indication ?? '');
+    setPresentationCode(draft.presentationCatalogCode ?? '');
+    if (draft.catalogKey) {
+      setFreeText(false);
+      setDrugQuery(draft.medicationName);
+    } else {
+      setFreeText(true);
+      setSelectedDrug(null);
+    }
+    onDraftConsumed?.();
+  }, [draft, onDraftConsumed]);
+
+  const { data: drugSearch } = useQuery({
+    queryKey: ['medication-catalog', debouncedDrugQ],
+    queryFn: () =>
+      medicationCatalogApi.search({ q: debouncedDrugQ || undefined, limit: 80, offset: 0 }),
+    enabled: !freeText,
+    staleTime: 60_000,
+  });
+
+  const { data: presentations } = useQuery({
+    queryKey: ['medication-catalog', selectedDrug?.code, 'presentations'],
+    queryFn: () => medicationCatalogApi.listPresentations(selectedDrug!.code, { limit: 50 }),
+    enabled: Boolean(selectedDrug?.code) && !freeText,
+    staleTime: 60_000,
+  });
+
+  const { data: routesData } = useQuery({
+    queryKey: ['medication-catalog', 'routes'],
+    queryFn: () => medicationCatalogApi.listRoutes(),
+    staleTime: 10 * 60_000,
+  });
+
+  const drugComboboxOptions = useMemo(
+    () =>
+      (drugSearch?.items ?? []).map((d) => ({
+        id: d.code,
+        label: d.displayName,
+        subtitle: d.genericName !== d.displayName ? d.genericName : undefined,
+        data: d,
+      })),
+    [drugSearch]
+  );
+
+  const presentationOptions = useMemo(
+    () =>
+      (presentations?.items ?? []).map((p: MedicationCatalogPresentation) => ({
+        value: p.code,
+        label: p.strength ? `${p.label} — ${p.strength}` : p.label,
+      })),
+    [presentations]
+  );
+
+  const routeOptions = useMemo(() => {
+    const all = routesData?.routes ?? [];
+    const allowed = selectedDrug?.allowedRoutes ?? [];
+    const filtered = allowed.length > 0 ? all.filter((r) => allowed.includes(r.code)) : all;
+    return filtered.map((r) => ({ value: r.code, label: r.label }));
+  }, [routesData, selectedDrug]);
+
+  const handleAdd = () => {
+    if (freeText) {
+      if (!medName.trim()) return;
+      onSubmit({
+        medicationName: medName.trim(),
+        dosage: medDose.trim() || undefined,
+        frequency: medFreq.trim() || undefined,
+        route: medRoute.trim() || undefined,
+        duration: medDuration.trim() || undefined,
+        indication: medIndication.trim() || undefined,
+      });
+    } else {
+      if (!selectedDrug) return;
+      onSubmit({
+        medicationName: medName.trim() || selectedDrug.displayName,
+        catalogKey: selectedDrug.code,
+        presentationCatalogCode: presentationCode || undefined,
+        dosage: medDose.trim() || undefined,
+        frequency: medFreq.trim() || undefined,
+        route: medRoute.trim() || undefined,
+        duration: medDuration.trim() || undefined,
+        indication: medIndication.trim() || undefined,
+      });
+    }
+    setMedName('');
+    setMedDose('');
+    setMedFreq('');
+    setMedRoute('');
+    setMedDuration('');
+    setMedIndication('');
+    setPresentationCode('');
+    setSelectedDrug(null);
+    setDrugQuery('');
+  };
+
+  const canSubmit = freeText ? Boolean(medName.trim()) : Boolean(selectedDrug);
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 pt-2">
+      <div className="sm:col-span-2 flex flex-wrap gap-2 items-center">
+        <Button type="button" size="sm" variant={freeText ? 'secondary' : 'outline'} disabled={disabled} onClick={() => setFreeText(false)}>Catálogo</Button>
+        <Button type="button" size="sm" variant={freeText ? 'outline' : 'secondary'} disabled={disabled} onClick={() => { setFreeText(true); setSelectedDrug(null); setPresentationCode(''); }}>Outro (texto livre)</Button>
+      </div>
+      {!freeText ? (
+        <>
+          <div className="space-y-1 sm:col-span-2">
+            <Label htmlFor="rx-drug-search">Medicamento</Label>
+            <ExamCatalogCombobox
+              options={drugComboboxOptions}
+              value={drugQuery}
+              onValueChange={setDrugQuery}
+              onSelectOption={(opt) => {
+                const drug = opt.data;
+                setSelectedDrug(drug);
+                setDrugQuery(drug.displayName);
+                setMedName(drug.displayName);
+                setPresentationCode('');
+              }}
+              placeholder="Pesquisar medicamento..."
+              emptyText="Nenhum medicamento no catálogo. Use «Outro»."
+              disabled={disabled}
+            />
+          </div>
+          <div className="space-y-1 sm:col-span-2">
+            <Label htmlFor="rx-presentation">Apresentação</Label>
+            <SearchableSelect
+              id="rx-presentation"
+              options={presentationOptions}
+              value={presentationCode}
+              onChange={setPresentationCode}
+              placeholder={
+                selectedDrug
+                  ? 'Selecione a apresentação'
+                  : 'Escolha o medicamento primeiro'
+              }
+              disabled={disabled || !selectedDrug}
+            />
+          </div>
+          <div className="space-y-1 sm:col-span-2">
+            <Label htmlFor="rx-route-catalog">Via</Label>
+            <SearchableSelect
+              id="rx-route-catalog"
+              options={routeOptions}
+              value={medRoute}
+              onChange={setMedRoute}
+              placeholder="Via de administração"
+              disabled={disabled || !selectedDrug}
+            />
+          </div>
+        </>
+      ) : (
+        <div className="space-y-1 sm:col-span-2">
+          <Label htmlFor="rx-med-name">Medicamento</Label>
+          <Input
+            id="rx-med-name"
+            value={medName}
+            onChange={(e) => setMedName(e.target.value)}
+            placeholder="Nome ou apresentação"
+            autoComplete="off"
+            disabled={disabled}
+          />
+        </div>
+      )}
+      <div className="space-y-1">
+        <Label htmlFor="rx-dose">Dose</Label>
+        <Input
+          id="rx-dose"
+          value={medDose}
+          onChange={(e) => setMedDose(e.target.value)}
+          placeholder="Ex.: 1 comprimido"
+          autoComplete="off"
+          disabled={disabled}
+        />
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor="rx-freq">Frequência</Label>
+        <Input
+          id="rx-freq"
+          value={medFreq}
+          onChange={(e) => setMedFreq(e.target.value)}
+          placeholder="Ex.: 12/12 h"
+          autoComplete="off"
+          disabled={disabled}
+        />
+      </div>
+      {freeText && (
+        <div className="space-y-1 sm:col-span-2">
+          <Label htmlFor="rx-route-free">Via</Label>
+          <Input
+            id="rx-route-free"
+            value={medRoute}
+            onChange={(e) => setMedRoute(e.target.value)}
+            placeholder="Ex.: VO, IV"
+            autoComplete="off"
+            disabled={disabled}
+          />
+        </div>
+      )}
+      <div className="space-y-1 sm:col-span-2">
+        <Label htmlFor="rx-duration">Duração (opcional)</Label>
+        <Input
+          id="rx-duration"
+          value={medDuration}
+          onChange={(e) => setMedDuration(e.target.value)}
+          placeholder="Ex.: 7 dias"
+          autoComplete="off"
+          disabled={disabled}
+        />
+      </div>
+      <div className="space-y-1 sm:col-span-2">
+        <Label htmlFor="rx-indication">Indicação (opcional)</Label>
+        <Input
+          id="rx-indication"
+          value={medIndication}
+          onChange={(e) => setMedIndication(e.target.value)}
+          placeholder="Ex.: náusea, dor"
+          autoComplete="off"
+          disabled={disabled}
+        />
+      </div>
+      <div className="sm:col-span-2">
+        <Button
+          type="button"
+          size="sm"
+          disabled={pending || disabled || !canSubmit}
+          onClick={handleAdd}
+        >
+          Adicionar à prescrição
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/use-exam-catalog-combobox-options.ts
+++ b/frontend/src/hooks/use-exam-catalog-combobox-options.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { examCatalogApi, type ExamCatalogItem } from '@/lib/api/exam-catalog';
+import type { ExamCatalogComboboxOption } from '@/components/shared/exam-catalog-combobox';
+
+const EXAM_CATALOG_SEARCH_LIMIT = 800;
+
+export type ExamCatalogSelection = {
+  displayName: string;
+  code?: string;
+  examCatalogCode?: string;
+};
+
+export function useExamCatalogComboboxOptions(debouncedQuery: string) {
+  const catalogSearchTrimmed = debouncedQuery.trim();
+  const { data: catalogRemote, isPending, isError } = useQuery({
+    queryKey: ['exam-catalog', 'orders', catalogSearchTrimmed],
+    queryFn: () =>
+      examCatalogApi.search({
+        q: catalogSearchTrimmed || undefined,
+        limit: EXAM_CATALOG_SEARCH_LIMIT,
+        offset: 0,
+      }),
+    staleTime: 60 * 1000,
+  });
+
+  const catalogLoading = isPending && catalogRemote === undefined;
+
+  const options: ExamCatalogComboboxOption<ExamCatalogSelection>[] = useMemo(() => {
+    const rows = catalogRemote?.items ?? [];
+    if (catalogLoading || isError || rows.length === 0) {
+      return [];
+    }
+    return rows.map((row: ExamCatalogItem) => ({
+      id: `db-${row.code}`,
+      label: row.code ? `${row.name} (${row.code})` : row.name,
+      subtitle: row.rolItemCode ? `Rol: ${row.rolItemCode}` : undefined,
+      data: {
+        displayName: row.name,
+        code: row.code,
+        examCatalogCode: row.code,
+      },
+    }));
+  }, [catalogRemote, catalogLoading, isError]);
+
+  return { options, catalogLoading, isError };
+}

--- a/frontend/src/lib/api/clinical-note-orders.ts
+++ b/frontend/src/lib/api/clinical-note-orders.ts
@@ -17,6 +17,7 @@ export type ClinicalPrescriptionLineRow = {
   clinicalNoteVersionNumber: number;
   medicationName: string;
   catalogKey: string | null;
+  presentationCatalogCode: string | null;
   dosage: string | null;
   frequency: string | null;
   route: string | null;
@@ -78,6 +79,7 @@ export const clinicalNoteOrdersApi = {
     body: {
       medicationName: string;
       catalogKey?: string;
+      presentationCatalogCode?: string;
       dosage?: string;
       frequency?: string;
       route?: string;
@@ -98,6 +100,49 @@ export const clinicalNoteOrdersApi = {
   ): Promise<void> {
     return apiClient.delete(
       `/patients/${patientId}/clinical-notes/${clinicalNoteId}/clinical-orders/prescription-lines/${lineId}`
+    );
+  },
+};
+
+export type PrescriptionHistoryRow = {
+  id: string;
+  clinicalNoteId: string;
+  clinicalNoteVersionNumber: number;
+  medicationName: string;
+  catalogKey: string | null;
+  presentationCatalogCode: string | null;
+  dosage: string | null;
+  frequency: string | null;
+  route: string | null;
+  duration: string | null;
+  indication: string | null;
+  createdAt: string;
+  prescribedBy: { id: string; name: string };
+  clinicalNote: {
+    id: string;
+    status: string;
+    signedAt: string | null;
+    noteType: string;
+  };
+};
+
+export const prescriptionHistoryApi = {
+  list(
+    patientId: string,
+    params?: { q?: string; limit?: number; offset?: number }
+  ): Promise<{
+    items: PrescriptionHistoryRow[];
+    total: number;
+    limit: number;
+    offset: number;
+  }> {
+    const searchParams = new URLSearchParams();
+    if (params?.q?.trim()) searchParams.set('q', params.q.trim());
+    if (params?.limit != null) searchParams.set('limit', String(params.limit));
+    if (params?.offset != null) searchParams.set('offset', String(params.offset));
+    const qs = searchParams.toString();
+    return apiClient.get(
+      `/patients/${patientId}/prescription-history${qs ? `?${qs}` : ''}`
     );
   },
 };

--- a/frontend/src/lib/api/medication-catalog.ts
+++ b/frontend/src/lib/api/medication-catalog.ts
@@ -1,0 +1,62 @@
+import { apiClient } from './client';
+
+export type MedicationCatalogDrug = {
+  code: string;
+  genericName: string;
+  displayName: string;
+  category: string | null;
+  allowedRoutes: string[];
+};
+
+export type MedicationCatalogPresentation = {
+  code: string;
+  drugCode: string;
+  label: string;
+  strength: string | null;
+  form: string | null;
+};
+
+export type MedicationCatalogRoute = {
+  code: string;
+  label: string;
+};
+
+export const medicationCatalogApi = {
+  search(params: {
+    q?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<{
+    items: MedicationCatalogDrug[];
+    total: number;
+    limit: number;
+    offset: number;
+  }> {
+    const searchParams = new URLSearchParams();
+    if (params.q?.trim()) searchParams.set('q', params.q.trim());
+    if (params.limit != null) searchParams.set('limit', String(params.limit));
+    if (params.offset != null) searchParams.set('offset', String(params.offset));
+    const qs = searchParams.toString();
+    return apiClient.get(`/medication-catalog${qs ? `?${qs}` : ''}`);
+  },
+
+  listPresentations(
+    drugCode: string,
+    params?: { q?: string; limit?: number }
+  ): Promise<{
+    drug: { code: string; displayName: string };
+    items: MedicationCatalogPresentation[];
+  }> {
+    const searchParams = new URLSearchParams();
+    if (params?.q?.trim()) searchParams.set('q', params.q.trim());
+    if (params?.limit != null) searchParams.set('limit', String(params.limit));
+    const qs = searchParams.toString();
+    return apiClient.get(
+      `/medication-catalog/${encodeURIComponent(drugCode)}/presentations${qs ? `?${qs}` : ''}`
+    );
+  },
+
+  listRoutes(): Promise<{ routes: MedicationCatalogRoute[] }> {
+    return apiClient.get('/medication-catalog/routes');
+  },
+};

--- a/frontend/src/lib/utils/__tests__/clinical-orders-payload.test.ts
+++ b/frontend/src/lib/utils/__tests__/clinical-orders-payload.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildExamRequestPayload,
+  prescriptionDraftFromHistoryRow,
+} from '../clinical-orders-payload';
+
+describe('clinical-orders-payload', () => {
+  it('buildExamRequestPayload uses catalog when selected', () => {
+    expect(
+      buildExamRequestPayload({
+        displayName: 'Hemograma',
+        catalogSelection: {
+          displayName: 'Hemograma completo',
+          code: '40304361',
+          examCatalogCode: '40304361',
+        },
+      })
+    ).toEqual({
+      displayName: 'Hemograma completo',
+      code: '40304361',
+      examCatalogCode: '40304361',
+    });
+  });
+
+  it('buildExamRequestPayload free text only displayName', () => {
+    expect(
+      buildExamRequestPayload({
+        displayName: '  Raio X tórax  ',
+        catalogSelection: null,
+      })
+    ).toEqual({ displayName: 'Raio X tórax' });
+  });
+
+  it('prescriptionDraftFromHistoryRow maps fields', () => {
+    expect(
+      prescriptionDraftFromHistoryRow({
+        medicationName: 'Omeprazol 20 mg',
+        catalogKey: 'OMEPRAZOLE',
+        presentationCatalogCode: 'OMEPRAZOLE_20MG_CP',
+        dosage: '1 cp',
+        frequency: '1x/dia',
+        route: 'VO',
+        duration: null,
+        indication: null,
+      })
+    ).toMatchObject({
+      medicationName: 'Omeprazol 20 mg',
+      catalogKey: 'OMEPRAZOLE',
+      presentationCatalogCode: 'OMEPRAZOLE_20MG_CP',
+      route: 'VO',
+    });
+  });
+});

--- a/frontend/src/lib/utils/__tests__/complementary-exam-series.test.ts
+++ b/frontend/src/lib/utils/__tests__/complementary-exam-series.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildComponentNumericChartPoints,
+  buildComplementaryExamMatchKey,
   buildParentNumericChartPoints,
+  collapseRedundantSingleComponent,
   collectUniqueComponentNames,
+  dedupeResultsByPerformedInstant,
   examHasPanelComponents,
   filterActiveComplementaryResults,
   findComponentInResult,
+  formatComplementaryResultPerformedAt,
+  groupComplementaryExamsByName,
   guessComponentUnit,
   normalizeComplementaryResultComponents,
 } from '../complementary-exam-series';
@@ -28,6 +33,138 @@ const baseExam = (): ComplementaryExam => ({
 });
 
 describe('complementary-exam-series', () => {
+  it('buildComplementaryExamMatchKey normaliza nome e código', () => {
+    expect(
+      buildComplementaryExamMatchKey('LABORATORY', 'Hemoglobina', 'Hb')
+    ).toBe(buildComplementaryExamMatchKey('LABORATORY', 'hemoglobina', 'hb'));
+  });
+
+  it('dedupeResultsByPerformedInstant remove só mesmo ms', () => {
+    const t = '2025-03-10T08:00:00.000Z';
+    const rows = dedupeResultsByPerformedInstant([
+      {
+        id: 'a',
+        performedAt: t,
+        collectionId: null,
+        valueNumeric: 1,
+        valueText: null,
+        unit: null,
+        referenceRange: null,
+        isAbnormal: null,
+        criticalHigh: null,
+        criticalLow: null,
+        report: null,
+      },
+      {
+        id: 'b',
+        performedAt: t,
+        collectionId: null,
+        valueNumeric: 2,
+        valueText: null,
+        unit: null,
+        referenceRange: null,
+        isAbnormal: null,
+        criticalHigh: null,
+        criticalLow: null,
+        report: null,
+      },
+      {
+        id: 'c',
+        performedAt: '2025-03-10T18:00:00.000Z',
+        collectionId: null,
+        valueNumeric: 3,
+        valueText: null,
+        unit: null,
+        referenceRange: null,
+        isAbnormal: null,
+        criticalHigh: null,
+        criticalLow: null,
+        report: null,
+      },
+    ]);
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.id)).toEqual(['a', 'c']);
+  });
+
+  it('groupComplementaryExamsByName funde exames legados duplicados', () => {
+    const e1 = baseExam();
+    e1.id = 'legacy-1';
+    e1.name = 'Creatinina';
+    e1.results = [
+      {
+        id: 'r1',
+        performedAt: '2025-01-01T00:00:00.000Z',
+        collectionId: null,
+        valueNumeric: 1,
+        valueText: null,
+        unit: null,
+        referenceRange: null,
+        isAbnormal: null,
+        criticalHigh: null,
+        criticalLow: null,
+        report: null,
+      },
+    ];
+    const e2 = baseExam();
+    e2.id = 'legacy-2';
+    e2.name = 'creatinina';
+    e2.results = [
+      {
+        id: 'r2',
+        performedAt: '2025-02-01T00:00:00.000Z',
+        collectionId: null,
+        valueNumeric: 1.1,
+        valueText: null,
+        unit: null,
+        referenceRange: null,
+        isAbnormal: null,
+        criticalHigh: null,
+        criticalLow: null,
+        report: null,
+      },
+    ];
+    const grouped = groupComplementaryExamsByName([e1, e2]);
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0]?.results).toHaveLength(2);
+  });
+
+  it('formatComplementaryResultPerformedAt inclui hora se >1 no mesmo dia', () => {
+    const results = [
+      {
+        id: 'r1',
+        performedAt: '2025-03-10T08:00:00.000Z',
+        collectionId: null,
+        valueNumeric: 1,
+        valueText: null,
+        unit: null,
+        referenceRange: null,
+        isAbnormal: null,
+        criticalHigh: null,
+        criticalLow: null,
+        report: null,
+      },
+      {
+        id: 'r2',
+        performedAt: '2025-03-10T18:00:00.000Z',
+        collectionId: null,
+        valueNumeric: 2,
+        valueText: null,
+        unit: null,
+        referenceRange: null,
+        isAbnormal: null,
+        criticalHigh: null,
+        criticalLow: null,
+        report: null,
+      },
+    ];
+    expect(formatComplementaryResultPerformedAt(results, results[0]!.performedAt)).toBe(
+      '10/03/2025 08:00'
+    );
+    expect(formatComplementaryResultPerformedAt(results, '2025-04-01T00:00:00.000Z')).toBe(
+      '01/04/2025'
+    );
+  });
+
   it('normalizeComplementaryResultComponents aceita string JSON (hemograma-like)', () => {
     const json = JSON.stringify([
       { name: 'Hb', value_numeric: 12.5, unit: 'g/dL' },
@@ -187,8 +324,136 @@ describe('complementary-exam-series', () => {
       report: null,
       components: [{ name: '  ALT  ', valueNumeric: 42 }],
     };
-    expect(findComponentInResult(result, 'alt')?.valueNumeric).toBe(42);
-    expect(findComponentInResult(result, 'AST')).toBeUndefined();
+    expect(findComponentInResult('Painel', result, 'alt')?.valueNumeric).toBe(42);
+    expect(findComponentInResult('Painel', result, 'AST')).toBeUndefined();
+  });
+
+  it('collapseRedundantSingleComponent promove TTPa sinônimo para linha principal', () => {
+    const examName = 'Tempo de Tromboplastina Parcial Ativado (TTPa)';
+    const raw = {
+      id: 'r-ttpa',
+      performedAt: '2023-10-17T00:00:00.000Z',
+      collectionId: null,
+      valueNumeric: null,
+      valueText: null,
+      unit: null,
+      referenceRange: null,
+      isAbnormal: null,
+      criticalHigh: null,
+      criticalLow: null,
+      report: null,
+      components: [
+        {
+          name: 'TTPa',
+          valueNumeric: 28.7,
+          unit: 'seg',
+          referenceRange: '25,4 a 33,4',
+        },
+      ],
+    };
+    const { result, displayComponents } = collapseRedundantSingleComponent(
+      examName,
+      raw
+    );
+    expect(displayComponents).toHaveLength(0);
+    expect(result.valueNumeric).toBe(28.7);
+    expect(result.unit).toBe('seg');
+    expect(result.referenceRange).toBe('25,4 a 33,4');
+  });
+
+  it('collapseRedundantSingleComponent não colapsa hemograma com vários subitens', () => {
+    const raw = {
+      id: 'r-hem',
+      performedAt: '2024-01-01T00:00:00.000Z',
+      collectionId: null,
+      valueNumeric: null,
+      valueText: null,
+      unit: null,
+      referenceRange: null,
+      isAbnormal: null,
+      criticalHigh: null,
+      criticalLow: null,
+      report: null,
+      components: [
+        { name: 'Hb', valueNumeric: 13.2 },
+        { name: 'Leucócitos', valueNumeric: 8000 },
+      ],
+    };
+    const { displayComponents } = collapseRedundantSingleComponent(
+      'Hemograma completo',
+      raw
+    );
+    expect(displayComponents).toHaveLength(2);
+  });
+
+  it('collapseRedundantSingleComponent não colapsa quando pai já tem valor', () => {
+    const raw = {
+      id: 'r1',
+      performedAt: '2024-06-15T12:00:00.000Z',
+      collectionId: null,
+      valueNumeric: 14,
+      valueText: null,
+      unit: 'g/dL',
+      referenceRange: '12–16',
+      isAbnormal: null,
+      criticalHigh: null,
+      criticalLow: null,
+      report: null,
+      components: [{ name: 'ALT', valueNumeric: 45, unit: 'U/L' }],
+    };
+    const { result, displayComponents } = collapseRedundantSingleComponent(
+      'Hemograma',
+      raw
+    );
+    expect(result.valueNumeric).toBe(14);
+    expect(displayComponents).toHaveLength(1);
+  });
+
+  it('examHasPanelComponents false para exame simples com subitem sinônimo colapsável', () => {
+    const e = baseExam();
+    e.name = 'Tempo de Tromboplastina Parcial Ativado (TTPa)';
+    e.results = [
+      {
+        id: 'r-ttpa',
+        performedAt: '2023-10-17T00:00:00.000Z',
+        collectionId: null,
+        valueNumeric: null,
+        valueText: null,
+        unit: null,
+        referenceRange: null,
+        isAbnormal: null,
+        criticalHigh: null,
+        criticalLow: null,
+        report: null,
+        components: [{ name: 'TTPa', valueNumeric: 28.7, unit: 'seg' }],
+      },
+    ];
+    expect(examHasPanelComponents(e)).toBe(false);
+  });
+
+  it('buildParentNumericChartPoints usa valor colapsado de subitem sinônimo', () => {
+    const examName = 'Tempo de Tromboplastina Parcial Ativado (TTPa)';
+    const pts = buildParentNumericChartPoints(
+      [
+        {
+          id: 'r-ttpa',
+          performedAt: '2023-10-17T00:00:00.000Z',
+          collectionId: null,
+          valueNumeric: null,
+          valueText: null,
+          unit: null,
+          referenceRange: null,
+          isAbnormal: null,
+          criticalHigh: null,
+          criticalLow: null,
+          report: null,
+          components: [{ name: 'TTPa', valueNumeric: 28.7 }],
+        },
+      ],
+      examName
+    );
+    expect(pts).toHaveLength(1);
+    expect(pts[0]?.value).toBe(28.7);
   });
 
   it('guessComponentUnit prefere unit do componente; fallback exam.unit', () => {

--- a/frontend/src/lib/utils/__tests__/complementary-exam-series.test.ts
+++ b/frontend/src/lib/utils/__tests__/complementary-exam-series.test.ts
@@ -86,6 +86,89 @@ describe('complementary-exam-series', () => {
     expect(rows.map((r) => r.id)).toEqual(['a', 'c']);
   });
 
+  it('groupComplementaryExamsByName funde creatinina e eTFG com cabeçalho Creatinina', () => {
+    const e1 = baseExam();
+    e1.id = 'renal-1';
+    e1.name = 'Creatinina';
+    e1.results = [
+      {
+        id: 'r1',
+        performedAt: '2025-01-01T00:00:00.000Z',
+        collectionId: null,
+        valueNumeric: 1.0,
+        valueText: null,
+        unit: null,
+        referenceRange: null,
+        isAbnormal: null,
+        criticalHigh: null,
+        criticalLow: null,
+        report: null,
+      },
+    ];
+    const e2 = baseExam();
+    e2.id = 'renal-2';
+    e2.name = 'eTFG';
+    e2.results = [
+      {
+        id: 'r2',
+        performedAt: '2025-02-01T00:00:00.000Z',
+        collectionId: null,
+        valueNumeric: 70,
+        valueText: null,
+        unit: null,
+        referenceRange: null,
+        isAbnormal: null,
+        criticalHigh: null,
+        criticalLow: null,
+        report: null,
+      },
+    ];
+    const grouped = groupComplementaryExamsByName([e1, e2]);
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0]?.name).toBe('Creatinina');
+    expect(grouped[0]?.results).toHaveLength(2);
+  });
+
+  it('groupComplementaryExamsByName funde sinónimos de vitamina D 25-OH', () => {
+    const e1 = baseExam();
+    e1.name = 'Vitamina D 25(OH)D';
+    e1.results = [
+      {
+        id: 'r1',
+        performedAt: '2025-01-01T00:00:00.000Z',
+        collectionId: null,
+        valueNumeric: 30,
+        valueText: null,
+        unit: null,
+        referenceRange: null,
+        isAbnormal: null,
+        criticalHigh: null,
+        criticalLow: null,
+        report: null,
+      },
+    ];
+    const e2 = baseExam();
+    e2.name = '25-Hidroxi-Vitamina D';
+    e2.results = [
+      {
+        id: 'r2',
+        performedAt: '2025-02-01T00:00:00.000Z',
+        collectionId: null,
+        valueNumeric: 28,
+        valueText: null,
+        unit: null,
+        referenceRange: null,
+        isAbnormal: null,
+        criticalHigh: null,
+        criticalLow: null,
+        report: null,
+      },
+    ];
+    const grouped = groupComplementaryExamsByName([e1, e2]);
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0]?.name).toBe('Vitamina D 25-OH');
+  });
+
   it('groupComplementaryExamsByName funde exames legados duplicados', () => {
     const e1 = baseExam();
     e1.id = 'legacy-1';

--- a/frontend/src/lib/utils/clinical-orders-payload.ts
+++ b/frontend/src/lib/utils/clinical-orders-payload.ts
@@ -1,0 +1,84 @@
+import type { ClinicalExamRequestRow } from '@/lib/api/clinical-note-orders';
+
+export type ExamRequestCreatePayload = {
+  displayName: string;
+  code?: string;
+  examCatalogCode?: string;
+};
+
+export function buildExamRequestPayload(args: {
+  displayName: string;
+  catalogSelection: ExamRequestCreatePayload | null;
+}): ExamRequestCreatePayload {
+  const trimmed = args.displayName.trim();
+  if (args.catalogSelection?.examCatalogCode) {
+    return {
+      displayName: args.catalogSelection.displayName.trim() || trimmed,
+      code: args.catalogSelection.code,
+      examCatalogCode: args.catalogSelection.examCatalogCode,
+    };
+  }
+  return { displayName: trimmed };
+}
+
+export type PrescriptionDraftFromHistory = {
+  medicationName: string;
+  catalogKey?: string;
+  presentationCatalogCode?: string;
+  dosage?: string;
+  frequency?: string;
+  route?: string;
+  duration?: string;
+  indication?: string;
+};
+
+export type PrescriptionHistoryRow = {
+  medicationName: string;
+  catalogKey: string | null;
+  presentationCatalogCode: string | null;
+  dosage: string | null;
+  frequency: string | null;
+  route: string | null;
+  duration: string | null;
+  indication: string | null;
+};
+
+export function prescriptionDraftFromHistoryRow(
+  row: PrescriptionHistoryRow
+): PrescriptionDraftFromHistory {
+  return {
+    medicationName: row.medicationName,
+    catalogKey: row.catalogKey ?? undefined,
+    presentationCatalogCode: row.presentationCatalogCode ?? undefined,
+    dosage: row.dosage ?? undefined,
+    frequency: row.frequency ?? undefined,
+    route: row.route ?? undefined,
+    duration: row.duration ?? undefined,
+    indication: row.indication ?? undefined,
+  };
+}
+
+export function prescriptionDraftsFromNoteRows(
+  rows: PrescriptionHistoryRow[],
+  clinicalNoteId: string,
+  getNoteId: (row: PrescriptionHistoryRow & { clinicalNoteId?: string }) => string
+): PrescriptionDraftFromHistory[] {
+  return rows
+    .filter((r) => getNoteId(r as PrescriptionHistoryRow & { clinicalNoteId: string }) === clinicalNoteId)
+    .map(prescriptionDraftFromHistoryRow);
+}
+
+export function examRequestPayloadFromRow(
+  row: Pick<ClinicalExamRequestRow, 'displayName' | 'code' | 'examCatalogCode'>
+): ExamRequestCreatePayload {
+  return buildExamRequestPayload({
+    displayName: row.displayName,
+    catalogSelection: row.examCatalogCode
+      ? {
+          displayName: row.displayName,
+          code: row.code ?? undefined,
+          examCatalogCode: row.examCatalogCode,
+        }
+      : null,
+  });
+}

--- a/frontend/src/lib/utils/complementary-exam-canonical.ts
+++ b/frontend/src/lib/utils/complementary-exam-canonical.ts
@@ -1,0 +1,115 @@
+export const CANONICAL_GROUP_RENAL_CREAT_ETFG = 'RENAL_CREAT_ETFG';
+export const CANONICAL_GROUP_VIT_D_25OH = 'VIT_D_25OH';
+
+const RENAL_CREAT_CODES = new Set(['CREAT', 'CR']);
+
+/** Espelho de normalizeExamLabelKey em complementary-exam-series.ts */
+function normalizeExamLabelKey(name: string): string {
+  return name
+    .normalize('NFD')
+    .replace(/\p{M}/gu, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '');
+}
+
+function isUrinaryCreatinineName(name: string): boolean {
+  const n = name.toLowerCase();
+  return (
+    /creatinina.*urin|urin[aá].*creatinina|clearance|depura[cç][aã]o/.test(n) ||
+    /creatinina.*24\s*h|24\s*h.*creatinina|creatinina.*24h|24h.*creatinina/.test(
+      n,
+    )
+  );
+}
+
+function isUrinaryCreatinineCode(code: string | null | undefined): boolean {
+  const c = (code ?? '').trim().toUpperCase();
+  return c === 'CREAT-U' || c === 'CREAT-24H';
+}
+
+function matchesRenalCreatEtfg(
+  type: string,
+  name: string,
+  code?: string | null
+): boolean {
+  if (type !== 'LABORATORY') return false;
+  if (isUrinaryCreatinineName(name) || isUrinaryCreatinineCode(code)) {
+    return false;
+  }
+
+  const c = (code ?? '').trim().toUpperCase();
+  if (c && RENAL_CREAT_CODES.has(c)) return true;
+
+  const n = name.toLowerCase();
+  if (/creatinina/.test(n)) return true;
+
+  if (
+    /^e\s*tfg\b|^egfr\b|^tfg\b/.test(n) ||
+    /\betfg\b/.test(n) ||
+    /\begfr\b/.test(n) ||
+    /taxa\s+de\s+filtra/.test(n) ||
+    /filtra[cç][aã]o\s+glomerular/.test(n)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function matchesVitD25oh(type: string, name: string): boolean {
+  if (type !== 'LABORATORY') return false;
+  const n = name.toLowerCase();
+
+  if (/25[\s\-]*hidroxi[\s\-]*vitamina\s*d|25[\s\-]*hidroxi\s*vit\s*d/.test(n)) {
+    return true;
+  }
+
+  const hasVitD =
+    /vitamina\s*d\b|vit\s*d\b/.test(n) || /^vit\s*d\b/.test(n.trim());
+  const has25oh =
+    /25\s*\(?\s*oh\s*\)?\s*d|25[\s\-]*oh|25[\s\-]*hidroxi|\(oh\)d/.test(n);
+
+  if (hasVitD && has25oh) return true;
+
+  if (/25[\s\-]*hidroxi/.test(n) && /vit/.test(n)) return true;
+
+  return false;
+}
+
+/** Espelho de `backend/.../complementary-exam-canonical.util.ts` — manter regras sincronizadas. */
+export function resolveCanonicalExamGroupId(
+  type: string,
+  name: string,
+  code?: string | null,
+  loincCode?: string | null
+): string {
+  if (matchesRenalCreatEtfg(type, name, code)) {
+    return `CANON|${CANONICAL_GROUP_RENAL_CREAT_ETFG}`;
+  }
+  if (matchesVitD25oh(type, name)) {
+    return `CANON|${CANONICAL_GROUP_VIT_D_25OH}`;
+  }
+
+  const trimmedLoinc =
+    loincCode === null || loincCode === undefined
+      ? ''
+      : String(loincCode).trim();
+  if (trimmedLoinc) {
+    return `LOINC|${normalizeExamLabelKey(trimmedLoinc)}`;
+  }
+
+  return `NAME|${normalizeExamLabelKey(name)}`;
+}
+
+export function preferredDisplayNameForGroup(
+  canonicalId: string,
+  fallbackName: string
+): string {
+  if (canonicalId === `CANON|${CANONICAL_GROUP_RENAL_CREAT_ETFG}`) {
+    return 'Creatinina';
+  }
+  if (canonicalId === `CANON|${CANONICAL_GROUP_VIT_D_25OH}`) {
+    return 'Vitamina D 25-OH';
+  }
+  return fallbackName;
+}

--- a/frontend/src/lib/utils/complementary-exam-series.ts
+++ b/frontend/src/lib/utils/complementary-exam-series.ts
@@ -4,7 +4,95 @@ import type {
   ComplementaryExam,
   ComplementaryExamResult,
   ComplementaryExamResultComponent,
+  ComplementaryExamType,
 } from '@/lib/api/patients';
+
+export function buildComplementaryExamMatchKey(
+  type: ComplementaryExamType | string,
+  name: string,
+  code?: string | null
+): string {
+  const codePart =
+    code === null || code === undefined || String(code).trim() === ''
+      ? ''
+      : normalizeExamLabelKey(String(code).trim());
+  return `${type}|${normalizeExamLabelKey(name)}|${codePart}`;
+}
+
+/** Agrupa registros legados com o mesmo nome/tipo/código num único cabeçalho. */
+export function groupComplementaryExamsByName(
+  exams: ComplementaryExam[]
+): ComplementaryExam[] {
+  const groups = new Map<string, ComplementaryExam>();
+  for (const exam of exams) {
+    const key = buildComplementaryExamMatchKey(exam.type, exam.name, exam.code);
+    const active = dedupeResultsByPerformedInstant(
+      filterActiveComplementaryResults(exam.results)
+    );
+    const existing = groups.get(key);
+    if (!existing) {
+      groups.set(key, { ...exam, results: active });
+      continue;
+    }
+    const merged = dedupeResultsByPerformedInstant([
+      ...existing.results,
+      ...active,
+    ]).sort(
+      (a, b) =>
+        new Date(a.performedAt).getTime() - new Date(b.performedAt).getTime()
+    );
+    groups.set(key, { ...existing, results: merged });
+  }
+  return [...groups.values()];
+}
+
+/** Remove apenas resultados com o mesmo instante (ms) — não colapsa horários do mesmo dia. */
+export function dedupeResultsByPerformedInstant(
+  results: ComplementaryExamResult[]
+): ComplementaryExamResult[] {
+  const byInstant = new Map<number, ComplementaryExamResult>();
+  for (const r of results) {
+    const t = new Date(r.performedAt).getTime();
+    if (!byInstant.has(t)) {
+      byInstant.set(t, r);
+    }
+  }
+  return [...byInstant.values()];
+}
+
+function utcCalendarDayKey(d: Date): string {
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
+}
+
+function formatUtcDate(d: Date): string {
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  const month = String(d.getUTCMonth() + 1).padStart(2, '0');
+  return `${day}/${month}/${d.getUTCFullYear()}`;
+}
+
+function formatUtcDateTime(d: Date): string {
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  const month = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const hours = String(d.getUTCHours()).padStart(2, '0');
+  const minutes = String(d.getUTCMinutes()).padStart(2, '0');
+  return `${day}/${month}/${d.getUTCFullYear()} ${hours}:${minutes}`;
+}
+
+/** dd/MM/yyyy (UTC); se >1 resultado no mesmo dia calendário UTC, inclui HH:mm. */
+export function formatComplementaryResultPerformedAt(
+  allResultsInExam: ComplementaryExamResult[],
+  performedAt: string | Date
+): string {
+  const d = new Date(performedAt);
+  const dayKey = utcCalendarDayKey(d);
+  const sameDayCount = allResultsInExam.filter(
+    (r) => utcCalendarDayKey(new Date(r.performedAt)) === dayKey
+  ).length;
+  if (sameDayCount > 1) {
+    return formatUtcDateTime(d);
+  }
+  return formatUtcDate(d);
+}
 
 /**
  * Garante array de subitens a partir do JSON do backend/Prisma.
@@ -60,6 +148,80 @@ export function normalizeComplementaryResultComponents(
   return out;
 }
 
+/** Chave de comparação de rótulos (sem acentos, minúsculas, só alfanumérico). */
+export function normalizeExamLabelKey(name: string): string {
+  return name
+    .normalize('NFD')
+    .replace(/\p{M}/gu, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '');
+}
+
+/** Siglas/nomes entre parênteses no título do exame, ex.: "(TTPa)". */
+export function extractParentheticalAliases(examName: string): string[] {
+  const aliases: string[] = [];
+  const re = /\(([^)]+)\)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(examName)) !== null) {
+    const inner = m[1].trim();
+    if (inner) aliases.push(inner);
+  }
+  return aliases;
+}
+
+function resultHasMainValue(result: ComplementaryExamResult): boolean {
+  if (result.valueNumeric != null) return true;
+  const vt = (result.valueText ?? '').trim();
+  if (vt) return true;
+  const report = (result.report ?? '').trim();
+  if (report) return true;
+  return false;
+}
+
+function componentNameMatchesExam(examName: string, componentName: string): boolean {
+  const examKey = normalizeExamLabelKey(examName);
+  const compKey = normalizeExamLabelKey(componentName);
+  if (!examKey || !compKey) return false;
+  if (examKey === compKey) return true;
+  for (const alias of extractParentheticalAliases(examName)) {
+    if (normalizeExamLabelKey(alias) === compKey) return true;
+  }
+  if (examKey.includes(compKey) || compKey.includes(examKey)) return true;
+  return false;
+}
+
+/**
+ * Quando há um único subitem sinônimo do exame e o pai está vazio, promove o valor
+ * para a linha principal (ex.: TTPa dentro de "Tempo de Tromboplastina... (TTPa)").
+ */
+export function collapseRedundantSingleComponent(
+  examName: string,
+  result: ComplementaryExamResult
+): {
+  result: ComplementaryExamResult;
+  displayComponents: ComplementaryExamResultComponent[];
+} {
+  const comps = normalizeComplementaryResultComponents(result.components);
+  if (comps.length !== 1 || resultHasMainValue(result)) {
+    return { result, displayComponents: comps };
+  }
+  const sole = comps[0];
+  if (!sole.name?.trim() || !componentNameMatchesExam(examName, sole.name)) {
+    return { result, displayComponents: comps };
+  }
+  return {
+    result: {
+      ...result,
+      valueNumeric: sole.valueNumeric ?? result.valueNumeric,
+      valueText: sole.valueText ?? result.valueText,
+      unit: sole.unit ?? result.unit,
+      referenceRange: sole.referenceRange ?? result.referenceRange,
+      isAbnormal: sole.isAbnormal ?? result.isAbnormal,
+    },
+    displayComponents: [],
+  };
+}
+
 export interface ComplementaryExamChartPoint {
   date: string;
   dateSort: number;
@@ -73,16 +235,18 @@ export function filterActiveComplementaryResults(
 }
 
 export function examHasPanelComponents(exam: ComplementaryExam): boolean {
-  return exam.results.some(
-    (r) => normalizeComplementaryResultComponents(r.components).length > 0
-  );
+  return exam.results.some((r) => {
+    const { displayComponents } = collapseRedundantSingleComponent(exam.name, r);
+    return displayComponents.length > 0;
+  });
 }
 
 /** Nomes únicos estáveis (chave case-insensitive, rótulo preserva primeira grafia vista). */
 export function collectUniqueComponentNames(exam: ComplementaryExam): string[] {
   const byKey = new Map<string, string>();
   for (const r of exam.results) {
-    for (const c of normalizeComplementaryResultComponents(r.components)) {
+    const { displayComponents } = collapseRedundantSingleComponent(exam.name, r);
+    for (const c of displayComponents) {
       const raw = c.name?.trim();
       if (!raw) continue;
       const key = raw.toLowerCase();
@@ -93,19 +257,25 @@ export function collectUniqueComponentNames(exam: ComplementaryExam): string[] {
 }
 
 export function findComponentInResult(
+  examName: string,
   result: ComplementaryExamResult,
   componentDisplayName: string
 ): ComplementaryExamResultComponent | undefined {
   const want = componentDisplayName.trim().toLowerCase();
-  return normalizeComplementaryResultComponents(result.components).find(
+  const { displayComponents } = collapseRedundantSingleComponent(examName, result);
+  return displayComponents.find(
     (c) => c.name && c.name.trim().toLowerCase() === want
   );
 }
 
 export function buildParentNumericChartPoints(
-  results: ComplementaryExamResult[]
+  results: ComplementaryExamResult[],
+  examName?: string
 ): ComplementaryExamChartPoint[] {
   return results
+    .map((r) =>
+      examName ? collapseRedundantSingleComponent(examName, r).result : r
+    )
     .filter((r) => r.valueNumeric != null)
     .map((r) => ({
       date: format(new Date(r.performedAt), 'dd/MM/yyyy', { locale: ptBR }),
@@ -117,12 +287,18 @@ export function buildParentNumericChartPoints(
 
 export function buildComponentNumericChartPoints(
   results: ComplementaryExamResult[],
-  componentDisplayName: string
+  componentDisplayName: string,
+  examName?: string
 ): ComplementaryExamChartPoint[] {
   const want = componentDisplayName.trim().toLowerCase();
   return results
     .map((r) => {
-      const c = normalizeComplementaryResultComponents(r.components).find(
+      const { displayComponents } = examName
+        ? collapseRedundantSingleComponent(examName, r)
+        : {
+            displayComponents: normalizeComplementaryResultComponents(r.components),
+          };
+      const c = displayComponents.find(
         (x) => x.name && x.name.trim().toLowerCase() === want
       );
       return {
@@ -142,7 +318,8 @@ export function guessComponentUnit(
 ): string | null {
   const want = componentDisplayName.trim().toLowerCase();
   for (const r of exam.results) {
-    const c = normalizeComplementaryResultComponents(r.components).find(
+    const { displayComponents } = collapseRedundantSingleComponent(exam.name, r);
+    const c = displayComponents.find(
       (x) => x.name && x.name.trim().toLowerCase() === want
     );
     if (c?.unit?.trim()) return c.unit.trim();

--- a/frontend/src/lib/utils/complementary-exam-series.ts
+++ b/frontend/src/lib/utils/complementary-exam-series.ts
@@ -6,17 +6,24 @@ import type {
   ComplementaryExamResultComponent,
   ComplementaryExamType,
 } from '@/lib/api/patients';
+import {
+  preferredDisplayNameForGroup,
+  resolveCanonicalExamGroupId,
+} from '@/lib/utils/complementary-exam-canonical';
 
 export function buildComplementaryExamMatchKey(
   type: ComplementaryExamType | string,
   name: string,
-  code?: string | null
+  code?: string | null,
+  loincCode?: string | null
 ): string {
-  const codePart =
-    code === null || code === undefined || String(code).trim() === ''
-      ? ''
-      : normalizeExamLabelKey(String(code).trim());
-  return `${type}|${normalizeExamLabelKey(name)}|${codePart}`;
+  const canonicalId = resolveCanonicalExamGroupId(
+    type,
+    name,
+    code,
+    loincCode
+  );
+  return `${type}|${canonicalId}`;
 }
 
 /** Agrupa registros legados com o mesmo nome/tipo/código num único cabeçalho. */
@@ -25,13 +32,20 @@ export function groupComplementaryExamsByName(
 ): ComplementaryExam[] {
   const groups = new Map<string, ComplementaryExam>();
   for (const exam of exams) {
-    const key = buildComplementaryExamMatchKey(exam.type, exam.name, exam.code);
+    const canonicalId = resolveCanonicalExamGroupId(
+      exam.type,
+      exam.name,
+      exam.code,
+      exam.loincCode
+    );
+    const key = `${exam.type}|${canonicalId}`;
+    const displayName = preferredDisplayNameForGroup(canonicalId, exam.name);
     const active = dedupeResultsByPerformedInstant(
       filterActiveComplementaryResults(exam.results)
     );
     const existing = groups.get(key);
     if (!existing) {
-      groups.set(key, { ...exam, results: active });
+      groups.set(key, { ...exam, name: displayName, results: active });
       continue;
     }
     const merged = dedupeResultsByPerformedInstant([
@@ -41,7 +55,7 @@ export function groupComplementaryExamsByName(
       (a, b) =>
         new Date(a.performedAt).getTime() - new Date(b.performedAt).getTime()
     );
-    groups.set(key, { ...existing, results: merged });
+    groups.set(key, { ...existing, name: displayName, results: merged });
   }
   return [...groups.values()];
 }


### PR DESCRIPTION
## Summary
- Pedidos de exame na evolução usam `ExamCatalogCombobox` com busca debounced no catálogo TUSS (`exam-catalog`) ou texto livre (`displayName` apenas).
- Novo catálogo global de medicamentos em banco (`MedicationCatalogDrug` / `MedicationCatalogPresentation`), API `/medication-catalog` e validação de `catalogKey`, apresentação e via na prescrição.
- Histórico de prescrições do paciente (`GET /patients/:id/prescription-history`) com reutilização em rascunho (sem POST automático).
- Identidade canônica de exames complementares (creatinina/eTFG, vitamina D 25-OH) na ingestão IA, backend e UI do prontuário/gráficos.
- Colapso de componente único redundante (ex. TTPa) na persistência e na exibição laboratorial.
- Fallback OpenAI em `exam_extract` quando Anthropic retorna erro de crédito/saldo; prompt evita `components` em exames de parâmetro único.

## Test plan
- [ ] `cd backend && npm test -- --testPathPattern="medication-catalog|clinical-note-orders|complementary-exam|apply-complementary"`
- [ ] `cd frontend && npm test -- src/lib/utils/__tests__/clinical-orders-payload.test.ts src/lib/utils/__tests__/complementary-exam-series.test.ts src/components/patients/__tests__/patient-prontuario-lab-history.test.tsx`
- [ ] `cd ai-service && pytest tests/agent/test_llm_provider.py -q`
- [ ] Aplicar migration e seed: `npx prisma migrate deploy` + `npx prisma db seed` (ou seed parcial do catálogo de medicamentos)
- [ ] Na evolução médica: adicionar exame pelo catálogo e por texto livre; prescrever com catálogo (fármaco → apresentação → via) e «Outro»
- [ ] Reutilizar item do histórico e confirmar que só persiste após «Adicionar à prescrição»
- [ ] Ingestão de laudo: creatinina + eTFG e vitamina D com sinónimos fundem num cabeçalho; TTPa aparece na linha principal
- [ ] Verificar isolamento multi-tenant (histórico não vaza entre tenants)

Made with [Cursor](https://cursor.com)